### PR TITLE
Handle unauthorized responses by auto logout

### DIFF
--- a/frontend/src/components/Header/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu.tsx
@@ -2,6 +2,7 @@ import { HeaderGlobalAction, HeaderPanel, Switcher, SwitcherItem, SwitcherDivide
 import { UserAvatar, Logout, User as UserIcon } from '@carbon/icons-react';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { clearAuthStorage } from '../../services/auth';
 
 interface User {
   username: string;
@@ -34,8 +35,7 @@ const UserMenu = () => {
   }, []);
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
+    clearAuthStorage();
     setUser(null);
     setIsUserMenuOpen(false);
     navigate('/');

--- a/frontend/src/components/ProblemSolver.tsx
+++ b/frontend/src/components/ProblemSolver.tsx
@@ -11,13 +11,13 @@ import {
   TabList,
   TabPanels,
   TabPanel,
-  Loading
 } from '@carbon/react';
 import { Send, Play } from '@carbon/icons-react';
 import Editor from '@monaco-editor/react';
 import ProblemPreview from './ProblemPreview';
 import ProblemSubmissionList from './ProblemSubmissionList';
 import TestSubmissionResultModal from './TestSubmissionResultModal';
+import { authFetch } from '../services/auth';
 
 export interface LanguageConfig {
   language: string;
@@ -106,18 +106,15 @@ const ProblemSolver: React.FC<ProblemSolverProps> = ({
     setIsPollingResult(true);
     if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
 
-    pollIntervalRef.current = setInterval(async () => {
-      try {
-        const token = localStorage.getItem('token');
-        const url = isContestMode 
-            ? `/api/v1/contests/${contestId}/submissions/${submissionId}/` // Assuming this endpoint exists or similar
-            : `/api/v1/submissions/${submissionId}/`;
-            
-        // Fallback to standard endpoint if contest specific one isn't distinct for polling details
-        // Actually usually submission ID is unique globally so /api/v1/submissions/:id works
-        const res = await fetch(`/api/v1/submissions/${submissionId}/`, {
-          headers: { 'Authorization': `Bearer ${token}` }
-        });
+      pollIntervalRef.current = setInterval(async () => {
+        try {
+          const url = isContestMode
+              ? `/api/v1/contests/${contestId}/submissions/${submissionId}/` // Assuming this endpoint exists or similar
+              : `/api/v1/submissions/${submissionId}/`;
+
+          // Fallback to standard endpoint if contest specific one isn't distinct for polling details
+          // Actually usually submission ID is unique globally so /api/v1/submissions/:id works
+          const res = await authFetch(url);
         const data = await res.json();
         setTestSubmission(data);
         

--- a/frontend/src/components/ProblemSubmissionList.tsx
+++ b/frontend/src/components/ProblemSubmissionList.tsx
@@ -17,6 +17,7 @@ import {
 } from '@carbon/react';
 import { View } from '@carbon/icons-react';
 import { useNavigate } from 'react-router-dom';
+import { authFetch } from '../services/auth';
 
 interface Submission {
   id: number;
@@ -55,14 +56,11 @@ const ProblemSubmissionList: React.FC<ProblemSubmissionListProps> = ({ problemId
   const fetchSubmissions = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem('token');
       // Note: Backend should handle this logic:
       // - Show all public submissions (is_test=false) for problem
       // - Show user's test submissions (is_test=true) for problem
       // For now, we just fetch all submissions for this problem
-      const res = await fetch(`/api/v1/submissions/?problem=${problemId}&ordering=-created_at&page=${page}&page_size=${pageSize}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await authFetch(`/api/v1/submissions/?problem=${problemId}&ordering=-created_at&page=${page}&page_size=${pageSize}`);
       const data = await res.json();
       setSubmissions(data.results || []);
       setTotal(data.count || 0);

--- a/frontend/src/components/TestSubmissionResultModal.tsx
+++ b/frontend/src/components/TestSubmissionResultModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Modal, Tag, InlineLoading } from '@carbon/react';
-import { CheckmarkFilled, WarningFilled, ErrorFilled, Time } from '@carbon/icons-react';
 
 interface Submission {
   id: number;
@@ -35,17 +34,6 @@ const TestSubmissionResultModal: React.FC<TestSubmissionResultModalProps> = ({
       case 'RE': return 'red';
       case 'CE': return 'gray';
       default: return 'gray';
-    }
-  };
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'AC': return <CheckmarkFilled />;
-      case 'WA': return <WarningFilled />;
-      case 'TLE': return <Time />;
-      case 'RE': return <ErrorFilled />;
-      default: return null;
     }
   };
 

--- a/frontend/src/pages/ContestDashboardPage.tsx
+++ b/frontend/src/pages/ContestDashboardPage.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
-  Grid,
-  Column,
   Tile,
   DataTable,
   Table,
@@ -21,7 +19,7 @@ import {
   Loading,
   ProgressBar
 } from '@carbon/react';
-import { CheckmarkFilled, CloseFilled, Time } from '@carbon/icons-react';
+import { Time } from '@carbon/icons-react';
 import { api } from '../services/api';
 import type { Contest } from '../services/api';
 

--- a/frontend/src/pages/ContestProblemPage.tsx
+++ b/frontend/src/pages/ContestProblemPage.tsx
@@ -5,7 +5,6 @@ import { ArrowLeft } from '@carbon/icons-react';
 import ProblemSolver from '../components/ProblemSolver';
 import type { Problem, Submission } from '../components/ProblemSolver';
 import { api } from '../services/api';
-import type { Contest } from '../services/api';
 
 const ContestProblemPage = () => {
   const { contestId, problemId } = useParams<{ contestId: string; problemId: string }>();
@@ -13,7 +12,6 @@ const ContestProblemPage = () => {
   const [problem, setProblem] = useState<Problem | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [contest, setContest] = useState<Contest | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -22,7 +20,6 @@ const ContestProblemPage = () => {
         // Fetch contest details which includes problems
         const contestData = await api.getContest(contestId);
         if (!contestData) throw new Error('Contest not found');
-        setContest(contestData);
 
         // Find the specific problem in the contest
         // The contestData.problems is a list of ContestProblem objects

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Loading } from '@carbon/react';
 import ProblemSolver from '../components/ProblemSolver';
 import type { Problem, Submission } from '../components/ProblemSolver';
+import { authFetch } from '../services/auth';
 
 const ProblemDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -14,11 +15,8 @@ const ProblemDetailPage: React.FC = () => {
   useEffect(() => {
     const fetchProblem = async () => {
       if (!id) return;
-      try {
-        const token = localStorage.getItem('token');
-        const res = await fetch(`/api/v1/problems/${id}/`, {
-          headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-        });
+        try {
+          const res = await authFetch(`/api/v1/problems/${id}/`);
         
         if (!res.ok) throw new Error('Failed to fetch problem');
         
@@ -38,13 +36,11 @@ const ProblemDetailPage: React.FC = () => {
   const handleSubmit = async (code: string, language: string, isTest: boolean): Promise<Submission | void> => {
     if (!problem) return;
 
-    const token = localStorage.getItem('token');
-    const res = await fetch('/api/v1/submissions/', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
-      },
+      const res = await authFetch('/api/v1/submissions/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
       body: JSON.stringify({
         problem: problem.id,
         language: language,

--- a/frontend/src/pages/ProblemFormPage.tsx
+++ b/frontend/src/pages/ProblemFormPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ProblemForm from '../components/ProblemForm';
 import type { ProblemFormData } from '../components/ProblemForm';
+import { authFetch } from '../services/auth';
 const ProblemFormPage = () => {
   const navigate = useNavigate();
   const { id } = useParams();
@@ -20,10 +21,7 @@ const ProblemFormPage = () => {
 
   const loadProblem = async () => {
     try {
-      const token = localStorage.getItem('token');
-      const res = await fetch(`/api/v1/problems/${id}/`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await authFetch(`/api/v1/problems/${id}/`);
       
       if (res.ok) {
         const data = await res.json();
@@ -40,15 +38,13 @@ const ProblemFormPage = () => {
     setSuccess('');
 
     try {
-      const token = localStorage.getItem('token');
       const url = isEditMode ? `/api/v1/problems/${id}/` : '/api/v1/problems/';
       const method = isEditMode ? 'PUT' : 'POST';
 
-      const res = await fetch(url, {
+      const res = await authFetch(url, {
         method,
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify(data)
       });

--- a/frontend/src/pages/ProblemListPage.tsx
+++ b/frontend/src/pages/ProblemListPage.tsx
@@ -16,7 +16,6 @@ import {
   Loading
 } from '@carbon/react';
 import { Link, useNavigate } from 'react-router-dom';
-import { CheckmarkFilled, View } from '@carbon/icons-react';
 import { api } from '../services/api';
 import type { Problem } from '../services/api';
 

--- a/frontend/src/pages/ProblemManagementPage.tsx
+++ b/frontend/src/pages/ProblemManagementPage.tsx
@@ -6,8 +6,8 @@ import {
   View,
   TrashCan 
 } from '@carbon/icons-react';
-import { 
-  Button, 
+import {
+  Button,
   DataTable,
   Table,
   TableHead,
@@ -22,6 +22,7 @@ import {
   Tag,
   InlineLoading
 } from '@carbon/react';
+import { authFetch } from '../services/auth';
 
 interface Problem {
   id: number;
@@ -59,12 +60,7 @@ const ProblemManagementPage = () => {
     setError('');
     
     try {
-      const token = localStorage.getItem('token');
-      const res = await fetch('/api/v1/problems/?scope=manage', {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
+      const res = await authFetch('/api/v1/problems/?scope=manage');
       
       if (res.ok) {
         const data = await res.json();
@@ -219,16 +215,12 @@ const ProblemManagementPage = () => {
                                 renderIcon={TrashCan}
                                 iconDescription="刪除"
                                 hasIconOnly
-                                onClick={async () => {
-                                  if (confirm(`確定要刪除題目「${problem.title}」嗎？`)) {
-                                    try {
-                                      const token = localStorage.getItem('token');
-                                      const res = await fetch(`/api/v1/problems/${problem.id}/`, {
-                                        method: 'DELETE',
-                                        headers: {
-                                          'Authorization': `Bearer ${token}`
-                                        }
-                                      });
+                                  onClick={async () => {
+                                    if (confirm(`確定要刪除題目「${problem.title}」嗎？`)) {
+                                      try {
+                                        const res = await authFetch(`/api/v1/problems/${problem.id}/`, {
+                                          method: 'DELETE'
+                                        });
                                       
                                       if (res.ok) {
                                         // Refresh the list

--- a/frontend/src/pages/SubmissionDetailPage.tsx
+++ b/frontend/src/pages/SubmissionDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '@carbon/react';
 import { ArrowLeft } from '@carbon/icons-react';
 import Editor from '@monaco-editor/react';
+import { authFetch } from '../services/auth';
 
 interface SubmissionDetail {
   id: number;
@@ -65,10 +66,7 @@ const SubmissionDetailPage = () => {
 
   const fetchSubmission = async () => {
     try {
-      const token = localStorage.getItem('token');
-      const res = await fetch(`/api/v1/submissions/${id}/`, {
-        headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-      });
+      const res = await authFetch(`/api/v1/submissions/${id}/`);
 
       if (res.ok) {
         const data = await res.json();
@@ -88,13 +86,10 @@ const SubmissionDetailPage = () => {
     }
   };
 
-  const startPolling = () => {
-    const pollInterval = setInterval(async () => {
-      try {
-        const token = localStorage.getItem('token');
-        const res = await fetch(`/api/v1/submissions/${id}/`, {
-          headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-        });
+    const startPolling = () => {
+      const pollInterval = setInterval(async () => {
+        try {
+          const res = await authFetch(`/api/v1/submissions/${id}/`);
 
         if (res.ok) {
           const data = await res.json();
@@ -179,7 +174,7 @@ const SubmissionDetailPage = () => {
   ];
 
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  const resultRows = (submission.results || []).map((result, index) => ({
+  const resultRows = (submission.results || []).map((result) => ({
     id: result.id.toString(),
     test_case: result.test_case.is_sample 
       ? `範例 ${result.test_case.order + 1}` 

--- a/frontend/src/pages/SubmissionsPage.tsx
+++ b/frontend/src/pages/SubmissionsPage.tsx
@@ -20,6 +20,7 @@ import {
   InlineLoading
 } from '@carbon/react';
 import { View, Renew } from '@carbon/icons-react';
+import { authFetch } from '../services/auth';
 
 interface Submission {
   id: number;
@@ -46,8 +47,7 @@ const SubmissionsPage = () => {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
   const [totalItems, setTotalItems] = useState(0);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [searchQuery, setSearchQuery] = useState('');
+  const [, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
 
   const statusOptions = [
@@ -69,15 +69,12 @@ const SubmissionsPage = () => {
   const fetchSubmissions = async () => {
     if (!refreshing) setLoading(true);
     try {
-      const token = localStorage.getItem('token');
       let url = `/api/v1/submissions/?page=${page}&page_size=${pageSize}&is_test=false`;
       if (statusFilter !== 'all') {
         url += `&status=${statusFilter}`;
       }
 
-      const res = await fetch(url, {
-        headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-      });
+      const res = await authFetch(url);
 
       if (res.ok) {
         const data = await res.json();
@@ -210,8 +207,7 @@ const SubmissionsPage = () => {
           headers,
           getTableProps,
           getHeaderProps,
-          getRowProps,
-          getTableContainerProps
+          getRowProps
         }: any) => (
           <TableContainer 
             title="" 

--- a/frontend/src/pages/TeacherContestEditPage.tsx
+++ b/frontend/src/pages/TeacherContestEditPage.tsx
@@ -36,7 +36,7 @@ import {
 } from '@carbon/react';
 import { Save, ArrowLeft, Add, TrashCan, ChevronUp, ChevronDown } from '@carbon/icons-react';
 import { api } from '../services/api';
-import type { Contest, Problem } from '../services/api';
+import type { Problem } from '../services/api';
 
 const TeacherContestEditPage = () => {
   const { id } = useParams<{ id: string }>();

--- a/frontend/src/pages/TeacherContestListPage.tsx
+++ b/frontend/src/pages/TeacherContestListPage.tsx
@@ -9,8 +9,6 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableToolbar,
-  TableToolbarContent,
   Button,
   Tag,
   Loading,

--- a/frontend/src/pages/TeacherContestProblemEditPage.tsx
+++ b/frontend/src/pages/TeacherContestProblemEditPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ProblemForm from '../components/ProblemForm';
 import type { ProblemFormData } from '../components/ProblemForm';
+import { authFetch } from '../services/auth';
 
 const TeacherContestProblemEditPage = () => {
   const navigate = useNavigate();
@@ -21,12 +22,9 @@ const TeacherContestProblemEditPage = () => {
 
   const loadProblem = async () => {
     try {
-      const token = localStorage.getItem('token');
       // Note: We might need a specific endpoint for contest problem details if permissions differ
       // But usually the problem ID is globally unique or we use the same endpoint
-      const res = await fetch(`/api/v1/problems/${problemId}/`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await authFetch(`/api/v1/problems/${problemId}/`);
       
       if (res.ok) {
         const data = await res.json();
@@ -43,15 +41,13 @@ const TeacherContestProblemEditPage = () => {
     setSuccess('');
 
     try {
-      const token = localStorage.getItem('token');
       const url = `/api/v1/problems/${problemId}/`; // Always edit for now
       const method = 'PUT';
 
-      const res = await fetch(url, {
+      const res = await authFetch(url, {
         method,
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify(data)
       });

--- a/frontend/src/pages/UserManagementPage.tsx
+++ b/frontend/src/pages/UserManagementPage.tsx
@@ -6,8 +6,8 @@ import {
   WarningFilled,
   TrashCan
 } from '@carbon/icons-react';
-import { 
-  TextInput, 
+import {
+  TextInput,
   Button, 
   Table,
   TableHead,
@@ -19,7 +19,8 @@ import {
   SelectItem,
   Modal,
   TableContainer
-} from '@carbon/react';
+  } from '@carbon/react';
+import { authFetch } from '../services/auth';
 import { api } from '../services/api';
 
 interface User {
@@ -151,14 +152,10 @@ const UserManagementPage = () => {
   const handleDeleteConfirm = async () => {
     if (!userToDelete) return;
 
-    try {
-      const token = localStorage.getItem('token');
-      const res = await fetch(`/api/v1/auth/${userToDelete.id}/`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
+      try {
+        const res = await authFetch(`/api/v1/auth/${userToDelete.id}/`, {
+          method: 'DELETE'
+        });
 
       if (res.ok) {
         setSuccess(`已刪除用戶 ${userToDelete.email}`);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,3 +1,5 @@
+import { authFetch } from './auth';
+
 const API_BASE = '/api/v1/auth';
 
 export interface Problem {
@@ -25,11 +27,8 @@ export interface AuthResponse {
 
 export const api = {
   getProblems: async (scope?: string): Promise<Problem[]> => {
-    const token = localStorage.getItem('token');
     const query = scope ? `?scope=${scope}` : '';
-    const res = await fetch(`/api/v1/problems/${query}`, {
-      headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-    });
+    const res = await authFetch(`/api/v1/problems/${query}`);
     if (!res.ok) {
       throw new Error('Failed to fetch problems');
     }
@@ -39,10 +38,7 @@ export const api = {
   },
 
   getProblem: async (id: string): Promise<Problem | undefined> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/problems/${id}/`, {
-      headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-    });
+    const res = await authFetch(`/api/v1/problems/${id}/`);
     if (!res.ok) {
       return undefined;
     }
@@ -97,12 +93,10 @@ export const api = {
   },
 
   submitSolution: async (data: { problem_id: string; language: string; code: string; contest_id?: string; is_test?: boolean }): Promise<any> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/submissions/`, {
+    const res = await authFetch(`/api/v1/submissions/`, {
       method: 'POST',
-      headers: { 
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+      headers: {
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify({
         problem: data.problem_id,
@@ -121,12 +115,7 @@ export const api = {
 
   // User management (admin only)
   searchUsers: async (query: string): Promise<any> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/auth/search?q=${encodeURIComponent(query)}`, {
-      headers: { 
-        'Authorization': `Bearer ${token}`
-      },
-    });
+    const res = await authFetch(`/api/v1/auth/search?q=${encodeURIComponent(query)}`);
     if (!res.ok) {
       const errorData = await res.json();
       const error: any = new Error('Search failed');
@@ -137,12 +126,10 @@ export const api = {
   },
 
   updateUserRole: async (userId: number, role: string): Promise<any> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/auth/${userId}/role`, {
+    const res = await authFetch(`/api/v1/auth/${userId}/role`, {
       method: 'PATCH',
-      headers: { 
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+      headers: {
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify({ role }),
     });
@@ -157,32 +144,24 @@ export const api = {
 
   // Contest API
   getContests: async (scope?: string): Promise<Contest[]> => {
-    const token = localStorage.getItem('token');
     const query = scope ? `?scope=${scope}` : '';
-    const res = await fetch(`/api/v1/contests/${query}`, {
-      headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-    });
+    const res = await authFetch(`/api/v1/contests/${query}`);
     if (!res.ok) throw new Error('Failed to fetch contests');
     const data = await res.json();
     return data.results || data;
   },
 
   getContest: async (id: string): Promise<Contest | undefined> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/`, {
-      headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-    });
+    const res = await authFetch(`/api/v1/contests/${id}/`);
     if (!res.ok) return undefined;
     return res.json();
   },
 
   createContest: async (data: any): Promise<Contest> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch('/api/v1/contests/', {
+    const res = await authFetch('/api/v1/contests/', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify(data)
     });
@@ -194,12 +173,10 @@ export const api = {
   },
 
   updateContest: async (id: string, data: any): Promise<Contest> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/`, {
+    const res = await authFetch(`/api/v1/contests/${id}/`, {
       method: 'PATCH',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify(data)
     });
@@ -211,23 +188,17 @@ export const api = {
   },
 
   deleteContest: async (id: string): Promise<void> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/`, {
-      method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
+    const res = await authFetch(`/api/v1/contests/${id}/`, {
+      method: 'DELETE'
     });
     if (!res.ok) throw new Error('Failed to delete contest');
   },
 
   registerContest: async (id: string, password?: string): Promise<any> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/register/`, {
+    const res = await authFetch(`/api/v1/contests/${id}/register/`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify({ password })
     });
@@ -239,12 +210,8 @@ export const api = {
   },
 
   enterContest: async (id: string): Promise<any> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/enter/`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
+    const res = await authFetch(`/api/v1/contests/${id}/enter/`, {
+      method: 'POST'
     });
     if (!res.ok) {
       const errorData = await res.json();
@@ -254,33 +221,24 @@ export const api = {
   },
 
   leaveContest: async (id: string): Promise<any> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/leave/`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
+    const res = await authFetch(`/api/v1/contests/${id}/leave/`, {
+      method: 'POST'
     });
     if (!res.ok) throw new Error('Failed to leave contest');
     return res.json();
   },
 
   getContestAnnouncements: async (id: string): Promise<any[]> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/announcements/`, {
-      headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-    });
+    const res = await authFetch(`/api/v1/contests/${id}/announcements/`);
     if (!res.ok) throw new Error('Failed to fetch announcements');
     return res.json();
   },
 
   createContestAnnouncement: async (contestId: string, data: { title: string; content: string }): Promise<any> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${contestId}/announcements/`, {
+    const res = await authFetch(`/api/v1/contests/${contestId}/announcements/`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify(data)
     });
@@ -289,36 +247,27 @@ export const api = {
   },
 
   deleteContestAnnouncement: async (contestId: string, announcementId: string): Promise<void> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${contestId}/announcements/${announcementId}/`, {
-      method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
+    const res = await authFetch(`/api/v1/contests/${contestId}/announcements/${announcementId}/`, {
+      method: 'DELETE'
     });
     if (!res.ok) throw new Error('Failed to delete announcement');
   },
 
   getContestStandings: async (id: string): Promise<any[]> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${id}/standings/`, {
-      headers: token ? { 'Authorization': `Bearer ${token}` } : {}
-    });
+    const res = await authFetch(`/api/v1/contests/${id}/standings/`);
     if (!res.ok) throw new Error('Failed to fetch standings');
     return res.json();
   },
 
   addContestProblem: async (contestId: string, sourceProblemId: string | null, title?: string): Promise<Problem> => {
-    const token = localStorage.getItem('token');
-    const res = await fetch(`/api/v1/contests/${contestId}/add_problem/`, {
+    const res = await authFetch(`/api/v1/contests/${contestId}/add_problem/`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+        'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ 
+      body: JSON.stringify({
         source_problem_id: sourceProblemId,
-        title: title 
+        title: title
       })
     });
     if (!res.ok) {

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,37 @@
+export const clearAuthStorage = () => {
+  localStorage.removeItem('token');
+  localStorage.removeItem('user');
+  window.dispatchEvent(new Event('storage'));
+};
+
+export const redirectToLogin = () => {
+  if (!window.location.pathname.startsWith('/login')) {
+    window.location.href = '/login';
+  }
+};
+
+export const handleUnauthorized = (response: Response): boolean => {
+  if (response.status === 401) {
+    clearAuthStorage();
+    redirectToLogin();
+    return true;
+  }
+  return false;
+};
+
+export const authFetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
+  const headers = new Headers(init.headers || {});
+  const token = localStorage.getItem('token');
+
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const response = await fetch(input, { ...init, headers });
+
+  if (handleUnauthorized(response)) {
+    throw new Error('Unauthorized');
+  }
+
+  return response;
+};

--- a/frontend/src/services/mockContestData.ts
+++ b/frontend/src/services/mockContestData.ts
@@ -239,7 +239,7 @@ export const mockContestService = {
     return false;
   },
 
-  getAnnouncements: async (contestId: string): Promise<{id: string, title: string, content: string, time: string}[]> => {
+  getAnnouncements: async (_contestId: string): Promise<{id: string, title: string, content: string, time: string}[]> => {
     // Mock announcements
     return [
       { id: '1', title: '歡迎參加', content: '請遵守考試規則，切勿作弊。', time: new Date().toISOString() },


### PR DESCRIPTION
## Summary
- add shared auth utility that clears stored tokens and redirects to login on 401 responses
- update frontend API and fetch calls to use auth-aware fetch helper and standardize logout behavior
- clean up unused imports/state to keep TypeScript build passing

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bc202aa98832d9973a1edbed16d4f)