### PR TITLE
Add backend pytest coverage for auth and judge flows

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -66,7 +66,17 @@ jobs:
         run: |
           docker images | grep oj-judge
           docker run --rm oj-judge:latest g++ --version
-      
+
+      - name: Run Database Migrations
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_oj
+          REDIS_URL: redis://localhost:6379/0
+          DJANGO_SETTINGS_MODULE: config.settings.test
+          SECRET_KEY: test-secret-key-for-ci
+        run: |
+          cd backend
+          python manage.py migrate --noinput
+
       - name: Run Backend Tests
         env:
           DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_oj
@@ -78,6 +88,4 @@ jobs:
           DOCKER_IMAGE_JUDGE: oj-judge:latest
         run: |
           cd backend
-          # Run all tests EXCEPT apps.judge (which is handled by judge-tests.yml)
-          # But include apps.submissions which now has integration tests
-          python manage.py test --exclude-tag=judge_engine --verbosity=2
+          pytest

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,6 +68,21 @@ This project uses **pytest** for testing.
 pytest
 ```
 
+### Run Module-Specific Tests
+
+```bash
+# Authentication and permissions
+pytest tests/test_users.py
+
+# Problem and contest CRUD
+pytest tests/test_problems.py tests/test_contests.py
+
+# Judge status mapping (uses monkeypatched Docker runner)
+pytest tests/test_judge.py
+```
+
+> These commands expect a running PostgreSQL and Redis instance configured via `.env`. The `backend-tests` CI workflow runs the same suite with `pytest` after building the `oj-judge` image.
+
 ### Run Specific Test File
 
 ```bash

--- a/backend/tests/test_contests.py
+++ b/backend/tests/test_contests.py
@@ -1,0 +1,54 @@
+import pytest
+from rest_framework import status
+from apps.contests.models import Contest
+
+
+@pytest.mark.django_db
+def test_authenticated_user_can_create_contest(authenticated_client):
+    client, user = authenticated_client
+
+    response = client.post(
+        "/api/v1/contests/",
+        {"name": "Weekly Contest", "visibility": "public"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    contest = Contest.objects.get(id=response.json()["id"])
+    assert contest.owner == user
+    assert contest.status == "inactive"
+
+
+@pytest.mark.django_db
+def test_unauthenticated_user_cannot_create_contest(api_client):
+    response = api_client.post(
+        "/api/v1/contests/",
+        {"name": "Unauthorized Contest"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_owner_can_update_contest(api_client, user_factory):
+    owner = user_factory(username="contest-owner", email="owner@example.com")
+    api_client.force_authenticate(user=owner)
+
+    create_response = api_client.post(
+        "/api/v1/contests/",
+        {"name": "Initial Name"},
+        format="json",
+    )
+    contest_id = create_response.json()["id"]
+
+    update_response = api_client.patch(
+        f"/api/v1/contests/{contest_id}/",
+        {"name": "Updated Contest"},
+        format="json",
+    )
+
+    assert update_response.status_code == status.HTTP_200_OK
+    contest = Contest.objects.get(id=contest_id)
+    assert contest.name == "Updated Contest"
+    assert contest.owner == owner

--- a/backend/tests/test_judge.py
+++ b/backend/tests/test_judge.py
@@ -1,0 +1,45 @@
+import pytest
+from apps.judge.docker_runner import CppJudge
+
+
+@pytest.mark.parametrize(
+    "exit_code,output,expected_status",
+    [
+        (124, "", "TLE"),
+        (1, "error: compile failed", "CE"),
+        (137, "Segmentation fault", "RE"),
+    ],
+)
+def test_cpp_judge_error_status_mapping(monkeypatch, exit_code, output, expected_status):
+    judge = CppJudge()
+    monkeypatch.setattr(judge, "_ensure_docker_client", lambda: None)
+
+    def fake_run(_command, _timeout, _mem_limit):
+        return {"exit_code": exit_code, "output": output, "time": 10, "memory": 5}
+
+    monkeypatch.setattr(judge, "_run_in_container", fake_run)
+
+    result = judge.execute("int main(){}", "", "", 1000, 128)
+    assert result["status"] == expected_status
+
+
+def test_cpp_judge_success_and_wrong_answer(monkeypatch):
+    judge = CppJudge()
+    monkeypatch.setattr(judge, "_ensure_docker_client", lambda: None)
+    responses = [
+        {"exit_code": 0, "output": "42\n", "time": 8, "memory": 4},
+        {"exit_code": 0, "output": "41\n", "time": 8, "memory": 4},
+    ]
+
+    def fake_run(_command, _timeout, _mem_limit):
+        return responses.pop(0)
+
+    monkeypatch.setattr(judge, "_run_in_container", fake_run)
+
+    ac_result = judge.execute("int main(){return 0;}", "", "42", 1000, 128)
+    assert ac_result["status"] == "AC"
+    assert ac_result["error"] == ""
+
+    wa_result = judge.execute("int main(){return 0;}", "", "42", 1000, 128)
+    assert wa_result["status"] == "WA"
+    assert wa_result["error"] == "Wrong Answer"

--- a/backend/tests/test_problems.py
+++ b/backend/tests/test_problems.py
@@ -1,0 +1,72 @@
+import pytest
+from rest_framework import status
+from apps.problems.models import Problem
+
+
+@pytest.mark.django_db
+def test_teacher_can_create_problem(api_client, user_factory):
+    teacher = user_factory(
+        username="teacher1",
+        email="teacher@example.com",
+        role="teacher",
+        is_staff=False,
+    )
+    api_client.force_authenticate(user=teacher)
+
+    response = api_client.post(
+        "/api/v1/problems/",
+        {
+            "title": "Two Sum",
+            "slug": "two-sum",
+            "difficulty": "easy",
+            "is_practice_visible": True,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    problem = Problem.objects.get(slug="two-sum")
+    assert problem.created_by == teacher
+    assert problem.difficulty == "easy"
+
+
+@pytest.mark.django_db
+def test_student_cannot_create_problem(authenticated_client):
+    client, _user = authenticated_client
+
+    response = client.post(
+        "/api/v1/problems/",
+        {"title": "Forbidden", "slug": "forbidden"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_teacher_can_update_own_problem(api_client, user_factory):
+    teacher = user_factory(
+        username="teacher2",
+        email="teacher2@example.com",
+        role="teacher",
+    )
+    api_client.force_authenticate(user=teacher)
+
+    create_response = api_client.post(
+        "/api/v1/problems/",
+        {"title": "Original Title", "slug": "original-title"},
+        format="json",
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED
+    problem_id = create_response.json()["id"]
+
+    update_response = api_client.patch(
+        f"/api/v1/problems/{problem_id}/",
+        {"title": "Updated Title"},
+        format="json",
+    )
+
+    assert update_response.status_code == status.HTTP_200_OK
+    problem = Problem.objects.get(id=problem_id)
+    assert problem.title == "Updated Title"
+    assert problem.created_by == teacher

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,87 @@
+import pytest
+from rest_framework import status
+from apps.users.models import User
+
+
+@pytest.mark.django_db
+def test_registration_flow(api_client):
+    payload = {
+        "username": "newuser",
+        "email": "newuser@example.com",
+        "password": "StrongPass123",
+        "password_confirm": "StrongPass123",
+    }
+
+    response = api_client.post(
+        "/api/v1/auth/email/register",
+        payload,
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["success"] is True
+    assert "access_token" in data["data"]
+    assert "refresh_token" in data["data"]
+    assert User.objects.filter(email=payload["email"]).exists()
+
+
+@pytest.mark.django_db
+def test_login_flow(api_client, user_factory):
+    password = "LoginPass123"
+    user = user_factory(password=password)
+
+    response = api_client.post(
+        "/api/v1/auth/email/login",
+        {"email": user.email, "password": password},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()["data"]
+    assert data["user"]["email"] == user.email
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+
+@pytest.mark.django_db
+def test_token_refresh_flow(api_client, user_factory):
+    password = "RefreshPass123"
+    user = user_factory(password=password)
+    login_response = api_client.post(
+        "/api/v1/auth/email/login",
+        {"email": user.email, "password": password},
+        format="json",
+    )
+    refresh_token = login_response.json()["data"]["refresh_token"]
+
+    response = api_client.post(
+        "/api/v1/auth/refresh",
+        {"refresh": refresh_token},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["success"] is True
+    assert "access_token" in response.json()["data"]
+
+
+@pytest.mark.django_db
+def test_superadmin_permission_required(api_client, user_factory):
+    # Non-admin should be forbidden
+    response = api_client.get("/api/v1/users/search")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # Admin with correct flags should pass
+    admin = user_factory(
+        username="admin-user",
+        email="admin@example.com",
+        role="admin",
+        is_staff=True,
+        is_superuser=True,
+    )
+    api_client.force_authenticate(user=admin)
+
+    response = api_client.get("/api/v1/users/search")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["success"] is True


### PR DESCRIPTION
## Summary
- add module-focused pytest suites for authentication, problems, contests, and judge status handling
- document how to run the backend pytest suites locally
- switch backend CI workflow to run pytest after database migrations

## Testing
- not run (missing Python dependencies in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935562d43dc832d934a32f9da345b31)