### PR TITLE
docs: 更新專案文件與修正連結

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ QJudge 是一個功能完整的線上程式評測平台，專為程式設計課�
 ### 主要功能
 
 #### 👨‍🎓 學生功能
+
 - 瀏覽和解決程式題目
 - 提交程式碼並即時查看評測結果
 - 參加線上競賽並查看排名
 - 查看歷史提交記錄和統計數據
 
 #### 👨‍🏫 教師功能
+
 - 創建和管理程式題目
 - 使用 YAML 格式批量導入題目
 - 舉辦和管理線上競賽
@@ -40,6 +42,7 @@ QJudge 是一個功能完整的線上程式評測平台，專為程式設計課�
 - 自訂測試資料和評分標準
 
 #### 🔧 系統功能
+
 - JWT Token 身份驗證
 - RESTful API 設計
 - Docker 容器化部署
@@ -80,8 +83,7 @@ QJudge 是一個功能完整的線上程式評測平台，專為程式設計課�
 
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f4ecc587-13c2-4ea0-a063-a67b9137de00" />
 
-<img width="1914" height="985" alt="image" src="https://github.com/user-attachments/assets/c89e3953-7ebf-4c00-b8a2-bcc611e93f97" />
----
+## <img width="1914" height="985" alt="image" src="https://github.com/user-attachments/assets/c89e3953-7ebf-4c00-b8a2-bcc611e93f97" />
 
 ## 📚 文件導覽
 
@@ -90,23 +92,28 @@ QJudge 是一個功能完整的線上程式評測平台，專為程式設計課�
 > 📖 **文件總覽**：請參閱 **[docs/README.md](./docs/README.md)** 獲取完整的文件導覽
 
 ### 🏗️ 架構與設計
+
 - **[系統架構](./docs/ARCHITECTURE.md)** - 系統概述、技術架構、前後端設計、評測系統
 - **[資料庫設計](./docs/DATABASE.md)** - 資料模型、ER 圖、索引策略
 
 ### 📡 API 文件
+
 - **[API 規範](./docs/API.md)** - 完整的 RESTful API 端點說明
 - **[Swagger UI](http://localhost:8000/api/schema/swagger-ui/)** - 線上 API 文件（需啟動後端）
 
 ### 🚀 部署與測試
+
 - **[部署與測試指南](./docs/DEPLOYMENT_AND_TESTING.md)** - 本地開發、生產部署、CI/CD
 - **[E2E 測試指南](./E2E_TESTING.md)** - Playwright 端對端測試
 
 ### 💻 開發指南
+
 - **[後端開發](./backend/README.md)** - Django 後端開發指南
 - **[前端開發](./frontend/README.md)** - React 前端開發指南
 - **[題目導入格式](./docs/problem-import-format.md)** - YAML 題目格式規範
 
 ### 🔍 程式碼品質
+
 - **[Code Review 報告](./docs/CODE_REVIEW_REPORT.md)** - 程式碼審查與改進建議
 
 ---
@@ -116,11 +123,13 @@ QJudge 是一個功能完整的線上程式評測平台，專為程式設計課�
 ### 新手入門
 
 1. **選擇你的身份**：
+
    - 👨‍🎓 學生使用者：直接訪問 [Demo](https://q-judge.quan.wtf/contests/3?tab=overview) 體驗
    - 👨‍🏫 教師使用者：閱讀 [系統架構](./docs/ARCHITECTURE.md) 瞭解系統功能
    - 💻 開發者：閱讀 [部署與測試指南](./docs/DEPLOYMENT_AND_TESTING.md)
 
 2. **本地開發環境設置**：
+
 ```bash
 # 參考完整設置步驟請見 docs/DEPLOYMENT_AND_TESTING.md
 
@@ -139,6 +148,7 @@ npm run dev
 ```
 
 3. **使用 Docker 快速啟動**：
+
 ```bash
 # 開發環境
 docker-compose -f docker-compose.dev.yml up
@@ -169,13 +179,15 @@ graph TB
 ### 技術棧詳細說明
 
 #### 前端技術
+
 - **React 19**: 現代化的使用者介面框架
 - **Carbon Design System**: IBM 開源設計系統
 - **React Router**: 單頁應用路由管理
 - **Monaco Editor**: 線上程式碼編輯器（VS Code 核心）
 - **Vite**: 快速的前端建置工具
 
-#### 後端技術  
+#### 後端技術
+
 - **Django 4**: Python Web 框架
 - **Django REST Framework**: RESTful API 建構
 - **PostgreSQL 15**: 關聯式資料庫
@@ -184,12 +196,14 @@ graph TB
 - **JWT**: 無狀態身份驗證
 
 #### 評測系統
+
 - **Docker**: 安全的程式碼執行沙箱
 - **支援語言**: C++17、Python 3、Java 17、JavaScript (Node.js)
 - **資源限制**: CPU 時間、記憶體、輸出大小限制
 - **安全機制**: 網路隔離、檔案系統限制、系統呼叫過濾
 
 #### 部署技術
+
 - **Docker Compose**: 容器編排
 - **Cloudflare Tunnel**: 安全的網路連接
 - **GitHub Actions**: CI/CD 自動化
@@ -200,11 +214,13 @@ graph TB
 ## 📊 系統功能模組
 
 ### 1. 認證與授權模組
+
 - JWT Token 身份驗證
 - 使用者註冊與登入
 - 權限管理（學生、教師、管理員）
 
 ### 2. 題目管理模組
+
 - 題目的 CRUD 操作
 - 多語言題目描述支援
 - YAML 格式批量導入
@@ -212,6 +228,7 @@ graph TB
 - 範例測試與隱藏測試
 
 ### 3. 提交評測模組
+
 - 多語言編譯與執行
 - 即時評測狀態更新（WebSocket）
 - 評測結果詳細回饋
@@ -219,6 +236,7 @@ graph TB
 - 程式碼相似度檢測（計劃中）
 
 ### 4. 競賽系統模組
+
 - 競賽創建與管理
 - 競賽密碼保護
 - 即時排名系統
@@ -227,6 +245,7 @@ graph TB
 - 競賽公告系統
 
 ### 5. 通知系統模組
+
 - 系統通知
 - 競賽公告
 - 評測結果通知
@@ -237,6 +256,7 @@ graph TB
 ## 🎯 主要使用場景
 
 ### 學生使用流程
+
 1. 註冊並登入系統
 2. 瀏覽題目列表，選擇題目
 3. 閱讀題目描述與範例
@@ -245,6 +265,7 @@ graph TB
 6. 參加競賽並查看即時排名
 
 ### 教師使用流程
+
 1. 登入教師帳號
 2. 創建新題目或批量導入題目
 3. 設置題目的測試資料與評分
@@ -258,6 +279,7 @@ graph TB
 ## 🔒 安全性設計
 
 ### 程式碼執行安全
+
 - **Docker 容器隔離**: 每個提交在獨立容器中執行
 - **資源限制**: CPU、記憶體、磁碟空間限制
 - **網路隔離**: 禁止網路存取
@@ -265,6 +287,7 @@ graph TB
 - **執行時間限制**: 防止無窮迴圈
 
 ### 應用程式安全
+
 - **JWT Token 認證**: 無狀態、安全的身份驗證
 - **CORS 配置**: 跨域請求保護
 - **SQL 注入防護**: ORM 查詢防護
@@ -277,24 +300,28 @@ graph TB
 ## 🌟 專案特色
 
 ### 1. 教育友善設計
+
 - 清晰的題目描述與範例
 - 詳細的錯誤訊息回饋
 - 支援多種程式語言
 - 提供程式碼模板
 
 ### 2. 效能優化
+
 - Redis 快取減少資料庫查詢
 - Celery 非同步任務處理
 - 資料庫索引優化
 - 靜態檔案 CDN 加速
 
 ### 3. 可擴展性
+
 - 微服務架構設計
 - Docker 容器化部署
 - 水平擴展評測 Worker
 - 模組化程式碼設計
 
 ### 4. 開發友善
+
 - RESTful API 設計
 - 完整的 API 文件
 - 測試驅動開發
@@ -349,6 +376,7 @@ QJudge/
 歡迎提交 Issue 和 Pull Request！
 
 ### 開發流程
+
 1. Fork 本專案
 2. 創建功能分支 (`git checkout -b feature/AmazingFeature`)
 3. 提交變更 (`git commit -m 'Add some AmazingFeature'`)
@@ -356,11 +384,13 @@ QJudge/
 5. 開啟 Pull Request
 
 ### 程式碼規範
+
 - 後端：遵循 PEP 8 Python 編碼規範
 - 前端：遵循 ESLint 和 Prettier 設定
 - 提交訊息：使用清晰的提交訊息描述變更
 
 ### 測試要求
+
 - 後端測試覆蓋率需達到 80% 以上
 - 前端關鍵功能需有單元測試
 - 提交 PR 前需確保所有測試通過
@@ -370,11 +400,13 @@ QJudge/
 ## 📞 聯絡資訊與資源
 
 ### 聯絡方式
+
 - **專案維護者**: NYCU 開發團隊
 - **專案網站**: [nycu-coding-lab.quan.wtf](https://nycu-coding-lab.quan.wtf)
 - **問題回報**: [GitHub Issues](https://github.com/quan0715/QJudge/issues)
 
 ### 相關資源
+
 - **Django REST Framework**: https://www.django-rest-framework.org/
 - **Carbon Design System**: https://carbondesignsystem.com/
 - **PostgreSQL 文件**: https://www.postgresql.org/docs/
@@ -401,6 +433,7 @@ QJudge/
 ## 📝 更新紀錄
 
 - **v1.2.0** (2025-12-11) - 文件整合更新
+
   - 整合所有技術文件至 `docs/` 目錄
   - 新增系統架構文件 (ARCHITECTURE.md)
   - 新增詳細 API 文件 (API.md)
@@ -409,6 +442,7 @@ QJudge/
   - 新增程式碼審查報告 (CODE_REVIEW_REPORT.md)
 
 - **v1.1.0** (2025-12-03) - 更新中文文件
+
   - 新增完整的中文 README
   - 新增使用者指南文件
   - 優化文件結構

--- a/README.md
+++ b/README.md
@@ -87,25 +87,27 @@ QJudge 是一個功能完整的線上程式評測平台，專為程式設計課�
 
 本專案提供完整的中文使用指南和技術文件，涵蓋開發、部署、使用等各個方面。
 
-### 🚀 快速開始
-- **[執行與部署指南](./docs/RUN_AND_DEPLOY.md)** - 本地開發環境設置與生產環境部署
-- **[DEPLOYMENT.md](./DEPLOYMENT.md)** - Docker Compose 與 Cloudflare Tunnel 詳細部署指南
+> 📖 **文件總覽**：請參閱 **[docs/README.md](./docs/README.md)** 獲取完整的文件導覽
 
-### 👥 使用者指南
-- **[學生使用指南](./docs/STUDENT_GUIDE.md)** - 如何參加競賽、提交程式碼
-- **[教師競賽指南](./docs/TEACHER_CONTEST_GUIDE.md)** - 如何舉辦和管理競賽
-- **[教師題目管理指南](./docs/TEACHER_PROBLEM_GUIDE.md)** - 如何創建和管理題目
+### 🏗️ 架構與設計
+- **[系統架構](./docs/ARCHITECTURE.md)** - 系統概述、技術架構、前後端設計、評測系統
+- **[資料庫設計](./docs/DATABASE.md)** - 資料模型、ER 圖、索引策略
 
-### 💻 開發者文件
-- **[後端 API 文件](./BACKEND_API.md)** - RESTful API 端點說明
+### 📡 API 文件
+- **[API 規範](./docs/API.md)** - 完整的 RESTful API 端點說明
+- **[Swagger UI](http://localhost:8000/api/schema/swagger-ui/)** - 線上 API 文件（需啟動後端）
+
+### 🚀 部署與測試
+- **[部署與測試指南](./docs/DEPLOYMENT_AND_TESTING.md)** - 本地開發、生產部署、CI/CD
+- **[E2E 測試指南](./E2E_TESTING.md)** - Playwright 端對端測試
+
+### 💻 開發指南
+- **[後端開發](./backend/README.md)** - Django 後端開發指南
+- **[前端開發](./frontend/README.md)** - React 前端開發指南
 - **[題目導入格式](./docs/problem-import-format.md)** - YAML 題目格式規範
-- **[資料庫設計](./DATABASE_DESIGN.md)** - 資料庫結構與關聯
-- **[前端使用案例](./FRONTEND_USECASE.md)** - 前端功能與使用流程
-- **[UI 設計指南](./UI_DESIGN.md)** - 介面設計規範
 
-### 🔧 技術文件
-- **[開發需求](./REQUIREMENTS.md)** - 系統需求與功能規劃
-- **[AI Agent 指南](./AGENT_GUIDE.md)** - AI 協作開發指引
+### 🔍 程式碼品質
+- **[Code Review 報告](./docs/CODE_REVIEW_REPORT.md)** - 程式碼審查與改進建議
 
 ---
 
@@ -114,13 +116,13 @@ QJudge 是一個功能完整的線上程式評測平台，專為程式設計課�
 ### 新手入門
 
 1. **選擇你的身份**：
-   - 👨‍🎓 學生使用者：閱讀 [學生使用指南](./docs/STUDENT_GUIDE.md)
-   - 👨‍🏫 教師使用者：閱讀 [教師競賽指南](./docs/TEACHER_CONTEST_GUIDE.md) 和 [題目管理指南](./docs/TEACHER_PROBLEM_GUIDE.md)
-   - 💻 開發者：閱讀 [執行與部署指南](./docs/RUN_AND_DEPLOY.md)
+   - 👨‍🎓 學生使用者：直接訪問 [Demo](https://q-judge.quan.wtf/contests/3?tab=overview) 體驗
+   - 👨‍🏫 教師使用者：閱讀 [系統架構](./docs/ARCHITECTURE.md) 瞭解系統功能
+   - 💻 開發者：閱讀 [部署與測試指南](./docs/DEPLOYMENT_AND_TESTING.md)
 
 2. **本地開發環境設置**：
 ```bash
-# 參考完整設置步驟請見 docs/RUN_AND_DEPLOY.md
+# 參考完整設置步驟請見 docs/DEPLOYMENT_AND_TESTING.md
 
 # 啟動後端
 cd backend
@@ -397,6 +399,14 @@ QJudge/
 ---
 
 ## 📝 更新紀錄
+
+- **v1.2.0** (2025-12-11) - 文件整合更新
+  - 整合所有技術文件至 `docs/` 目錄
+  - 新增系統架構文件 (ARCHITECTURE.md)
+  - 新增詳細 API 文件 (API.md)
+  - 新增資料庫設計文件 (DATABASE.md)
+  - 新增部署與測試指南 (DEPLOYMENT_AND_TESTING.md)
+  - 新增程式碼審查報告 (CODE_REVIEW_REPORT.md)
 
 - **v1.1.0** (2025-12-03) - 更新中文文件
   - 新增完整的中文 README

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 ### 1. 架構與設計
 
 **[ARCHITECTURE.md](./ARCHITECTURE.md)** - 系統架構文件
+
 - 系統概述與技術棧
 - 前後端架構詳解
 - 資料庫設計概覽
@@ -21,6 +22,7 @@
 ### 2. API 規範
 
 **[API.md](./API.md)** - RESTful API 文件
+
 - 認證系統 API
 - 題目系統 API
 - 提交系統 API
@@ -31,6 +33,7 @@
 ### 3. 資料模型
 
 **[DATABASE.md](./DATABASE.md)** - 資料庫設計文件
+
 - 資料庫架構與連線設定
 - 完整的資料表結構（ER 圖）
 - 索引策略與效能優化
@@ -40,6 +43,7 @@
 ### 4. 部署與測試
 
 **[DEPLOYMENT_AND_TESTING.md](./DEPLOYMENT_AND_TESTING.md)** - 部署與測試指南
+
 - 開發環境快速啟動
 - 生產環境部署步驟
 - 測試策略與覆蓋率
@@ -50,6 +54,7 @@
 ### 5. Code Review 報告
 
 **[CODE_REVIEW_REPORT.md](./CODE_REVIEW_REPORT.md)** - 完整的程式碼審查報告
+
 - 架構與設計評價
 - 安全性分析（包含已識別的漏洞）
 - 程式碼品質評估
@@ -91,15 +96,15 @@
 
 ## 📊 文件概覽
 
-| 文件 | 類型 | 頁數 | 目標讀者 |
-|------|------|------|---------|
-| ARCHITECTURE.md | 技術 | 長 | 開發者、架構師 |
-| API.md | 參考 | 長 | 前端開發者、API 使用者 |
-| DATABASE.md | 參考 | 長 | 後端開發者、DBA |
-| DEPLOYMENT_AND_TESTING.md | 操作 | 長 | 維運人員、DevOps |
-| CODE_REVIEW_REPORT.md | 報告 | 超長 | 所有開發者 |
-| problem-import-format.md | 參考 | 短 | 教師、內容建立者 |
-| E2E_TESTING.md | 操作 | 短 | QA、測試工程師 |
+| 文件                      | 類型 | 頁數 | 目標讀者               |
+| ------------------------- | ---- | ---- | ---------------------- |
+| ARCHITECTURE.md           | 技術 | 長   | 開發者、架構師         |
+| API.md                    | 參考 | 長   | 前端開發者、API 使用者 |
+| DATABASE.md               | 參考 | 長   | 後端開發者、DBA        |
+| DEPLOYMENT_AND_TESTING.md | 操作 | 長   | 維運人員、DevOps       |
+| CODE_REVIEW_REPORT.md     | 報告 | 超長 | 所有開發者             |
+| problem-import-format.md  | 參考 | 短   | 教師、內容建立者       |
+| E2E_TESTING.md            | 操作 | 短   | QA、測試工程師         |
 
 ---
 
@@ -108,6 +113,7 @@
 ### 2025-12-10 - 大規模文件更新
 
 **新增**:
+
 - ✅ `ARCHITECTURE.md` - 完整的系統架構文件
 - ✅ `API.md` - 詳細的 API 規範與範例
 - ✅ `DATABASE.md` - 資料庫設計與索引策略
@@ -115,6 +121,7 @@
 - ✅ `CODE_REVIEW_REPORT.md` - 深度程式碼審查報告
 
 **改進**:
+
 - 📝 重新組織文件結構
 - 📝 新增此 README.md 作為文件導航
 - 📝 統一文件格式與樣式
@@ -148,6 +155,7 @@
 3. 聯絡專案維護者
 
 **文件風格指南**:
+
 - 使用 Markdown 格式
 - 標題層級不超過 4 層
 - 程式碼區塊指定語言（語法高亮）

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # QJudge 文件目錄
 
-> **最後更新**: 2025-12-10
+> **最後更新**: 2025-12-11
 
 本目錄包含 QJudge 專案的完整技術文件，涵蓋架構、API、資料庫、部署、測試以及 Code Review 報告。
 
@@ -62,7 +62,7 @@
 
 **[problem-import-format.md](./problem-import-format.md)** - 題目 YAML 導入格式規範
 
-**[E2E_TESTING.md](./E2E_TESTING.md)** - E2E 測試指南
+**[E2E_TESTING.md](../E2E_TESTING.md)** - E2E 測試指南
 
 **[examples/a-plus-b-problem.yaml](./examples/a-plus-b-problem.yaml)** - 題目 YAML 範例
 
@@ -85,7 +85,7 @@
 - **部署到生產環境** → [DEPLOYMENT_AND_TESTING.md](./DEPLOYMENT_AND_TESTING.md)
 - **查看已知問題與改進建議** → [CODE_REVIEW_REPORT.md](./CODE_REVIEW_REPORT.md)
 - **導入題目** → [problem-import-format.md](./problem-import-format.md)
-- **執行 E2E 測試** → [E2E_TESTING.md](./E2E_TESTING.md)
+- **執行 E2E 測試** → [E2E_TESTING.md](../E2E_TESTING.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- 更新 `docs/README.md` 最後更新日期至 2025-12-11
- 更新主 `README.md` 的版本記錄，新增 v1.2.0 文件整合更新
- 修正 `README.md` 文件導覽區塊，將不存在的連結改為指向實際存在的文件
- 修正 `docs/README.md` 中 `E2E_TESTING.md` 的相對路徑
- 統一 Markdown 格式（列表空行、表格對齊）

## 修正的連結

文件導覽現在正確指向：
- `docs/ARCHITECTURE.md` - 系統架構
- `docs/API.md` - API 規範
- `docs/DATABASE.md` - 資料庫設計
- `docs/DEPLOYMENT_AND_TESTING.md` - 部署與測試指南
- `docs/CODE_REVIEW_REPORT.md` - 程式碼審查報告
- `docs/problem-import-format.md` - 題目導入格式
- `E2E_TESTING.md` - E2E 測試指南

## Test plan

- [x] 確認所有文件連結正確指向存在的檔案
- [x] 驗證文件內容與實際程式碼一致