### PR TITLE
refactor(docs): improve language switcher UI

### DIFF
--- a/frontend/src/domains/docs/components/DocsHeader.tsx
+++ b/frontend/src/domains/docs/components/DocsHeader.tsx
@@ -298,7 +298,7 @@ const DocsHeader: React.FC = () => {
                 }}
               >
                 <Launch size={16} />
-                <span>{t("nav.dashboard")}</span>
+                <span>QJudge</span>
               </a>
             </SideNavItems>
           </SideNav>

--- a/frontend/src/domains/docs/pages/DocumentationPage.module.scss
+++ b/frontend/src/domains/docs/pages/DocumentationPage.module.scss
@@ -59,7 +59,8 @@
   gap: 0.5rem;
 }
 
-.themeBtn {
+.themeBtn,
+.langBtn {
   flex: 1;
   display: flex;
   align-items: center;
@@ -72,6 +73,7 @@
   cursor: pointer;
   color: var(--cds-text-secondary);
   font-size: 0.75rem;
+  font-weight: 500;
   transition: all 0.15s ease;
 
   &:hover {
@@ -84,6 +86,11 @@
     border-color: var(--cds-border-interactive);
     color: var(--cds-text-primary);
   }
+}
+
+.languageButtons {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .dashboardLink {

--- a/frontend/src/domains/docs/pages/DocumentationPage.tsx
+++ b/frontend/src/domains/docs/pages/DocumentationPage.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { SkeletonText, IconButton, Select, SelectItem } from "@carbon/react";
-import { ArrowLeft, Light, Asleep, Laptop, Launch } from "@carbon/icons-react";
+import { SkeletonText, IconButton } from "@carbon/react";
+import {
+  ArrowLeft,
+  Light,
+  Asleep,
+  Laptop,
+  Launch,
+  Language,
+} from "@carbon/icons-react";
 import MarkdownRenderer from "@/ui/components/common/MarkdownRenderer";
 import DocSidebar from "../components/DocSidebar";
 import DocTableOfContents from "../components/DocTableOfContents";
@@ -221,17 +228,25 @@ const DocumentationPage: React.FC = () => {
 
           {/* Language Section */}
           <div className={styles.settingsSection}>
-            <Select
-              id="language-select"
-              labelText={tCommon("preferences.languageSection")}
-              value={i18n.language}
-              onChange={(e) => handleLanguageSelect(e.target.value)}
-              size="sm"
-            >
+            <div className={styles.settingsLabel}>
+              <Language size={16} />
+              <span>{tCommon("preferences.languageSection")}</span>
+            </div>
+            <div className={styles.languageButtons}>
               {SUPPORTED_LANGUAGES.map((lang) => (
-                <SelectItem key={lang.id} value={lang.id} text={lang.label} />
+                <button
+                  key={lang.id}
+                  type="button"
+                  onClick={() => handleLanguageSelect(lang.id)}
+                  className={`${styles.langBtn} ${
+                    i18n.language === lang.id ? styles.active : ""
+                  }`}
+                  title={lang.label}
+                >
+                  {lang.shortLabel}
+                </button>
               ))}
-            </Select>
+            </div>
           </div>
 
           <div className={styles.settingsDivider} />
@@ -244,7 +259,7 @@ const DocumentationPage: React.FC = () => {
             className={styles.dashboardLink}
           >
             <Launch size={16} />
-            <span>{tCommon("nav.dashboard")}</span>
+            <span>QJudge</span>
           </a>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- 將文檔頁面的語言選擇從 Select 下拉選單改為按鈕選擇方式，與 UserMenu 風格一致
- 新增 Language 圖示和一致的按鈕樣式
- 將儀表板連結標籤改為 "QJudge"

## Changes
- `DocumentationPage.tsx`: 移除 Select 組件，改用按鈕選擇器
- `DocumentationPage.module.scss`: 新增 `.languageButtons` 和 `.langBtn` 樣式
- `DocsHeader.tsx`: 更新儀表板連結標籤

## Test plan
- [ ] 確認語言切換按鈕正常運作
- [ ] 確認按鈕樣式與主題切換按鈕一致
- [ ] 確認儀表板連結顯示為 "QJudge"