### PR TITLE
fix: resolve theme persistence and synchronization issues

### DIFF
--- a/frontend/src/domains/docs/components/DocsHeader.tsx
+++ b/frontend/src/domains/docs/components/DocsHeader.tsx
@@ -36,7 +36,8 @@ const DocsHeader: React.FC = () => {
   const [isSideNavExpanded, setIsSideNavExpanded] = useState(false);
   const [docsConfig, setDocsConfig] = useState<DocConfig | null>(null);
   const [currentTheme, setCurrentTheme] = useState<ThemeValue>(() => {
-    const stored = localStorage.getItem("theme-preference");
+    // Use unified localStorage key (same as useUserPreferences)
+    const stored = localStorage.getItem("themePreference");
     return (stored as ThemeValue) || "system";
   });
 
@@ -69,7 +70,8 @@ const DocsHeader: React.FC = () => {
 
   const handleThemeChange = (value: ThemeValue) => {
     setCurrentTheme(value);
-    localStorage.setItem("theme-preference", value);
+    // Use unified localStorage key (same as useUserPreferences)
+    localStorage.setItem("themePreference", value);
 
     if (value === "system") {
       const prefersDark = window.matchMedia(

--- a/frontend/src/domains/docs/pages/DocumentationPage.tsx
+++ b/frontend/src/domains/docs/pages/DocumentationPage.tsx
@@ -43,7 +43,8 @@ const DocumentationPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [currentTheme, setCurrentTheme] = useState<ThemeValue>(() => {
-    const stored = localStorage.getItem("theme-preference");
+    // Use unified localStorage key (same as useUserPreferences)
+    const stored = localStorage.getItem("themePreference");
     return (stored as ThemeValue) || "system";
   });
 
@@ -138,7 +139,8 @@ const DocumentationPage: React.FC = () => {
   // Theme handling
   const handleThemeChange = (value: ThemeValue) => {
     setCurrentTheme(value);
-    localStorage.setItem("theme-preference", value);
+    // Use unified localStorage key (same as useUserPreferences)
+    localStorage.setItem("themePreference", value);
 
     if (value === "system") {
       const prefersDark = window.matchMedia(

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -64,6 +64,17 @@ export interface UseUserPreferencesReturn {
   refresh: () => Promise<void>;
 }
 
+// Get initial theme preference from localStorage
+const getInitialThemePreference = (): ThemePreference => {
+  if (typeof window !== "undefined") {
+    const saved = localStorage.getItem("themePreference") as ThemePreference;
+    if (saved && ["light", "dark", "system"].includes(saved)) {
+      return saved;
+    }
+  }
+  return "system";
+};
+
 export const useUserPreferences = (): UseUserPreferencesReturn => {
   const { user } = useAuth();
   const { setTheme } = useTheme();
@@ -72,8 +83,10 @@ export const useUserPreferences = (): UseUserPreferencesReturn => {
   const [preferences, setPreferences] = useState<UserPreferences | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const [themePreference, setThemePreference] =
-    useState<ThemePreference>("system");
+  // Initialize from localStorage instead of defaulting to "system"
+  const [themePreference, setThemePreference] = useState<ThemePreference>(
+    getInitialThemePreference
+  );
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">(
     getSystemTheme()
   );

--- a/frontend/src/ui/theme/ThemeContext.tsx
+++ b/frontend/src/ui/theme/ThemeContext.tsx
@@ -1,8 +1,9 @@
-import { createContext, useContext, useState, useEffect } from 'react';
-import type { ReactNode } from 'react';
-import { Theme } from '@carbon/react';
+import { createContext, useContext, useState, useEffect } from "react";
+import type { ReactNode } from "react";
+import { Theme } from "@carbon/react";
 
-type ThemeType = 'white' | 'g100' | 'g90' | 'g10';
+type ThemeType = "white" | "g100" | "g90" | "g10";
+type ThemePreference = "light" | "dark" | "system";
 
 interface ThemeContextType {
   theme: ThemeType;
@@ -12,35 +13,85 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setThemeState] = useState<ThemeType>('g100');
+// Unified localStorage key - same as useUserPreferences
+const THEME_PREFERENCE_KEY = "themePreference";
 
+// Get system preferred theme
+const getSystemTheme = (): ThemeType => {
+  if (typeof window !== "undefined" && window.matchMedia) {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "g100"
+      : "white";
+  }
+  return "g100";
+};
+
+// Convert preference to Carbon theme
+const preferenceToTheme = (pref: ThemePreference): ThemeType => {
+  if (pref === "system") return getSystemTheme();
+  return pref === "dark" ? "g100" : "white";
+};
+
+// Convert Carbon theme to preference
+const themeToPreference = (theme: ThemeType): ThemePreference => {
+  return theme === "g100" || theme === "g90" ? "dark" : "light";
+};
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setThemeState] = useState<ThemeType>("g100");
+
+  // Initialize from localStorage (using unified key)
   useEffect(() => {
-    const savedTheme = localStorage.getItem('theme') as ThemeType;
-    if (savedTheme) {
-      setThemeState(savedTheme);
+    const savedPref = localStorage.getItem(
+      THEME_PREFERENCE_KEY
+    ) as ThemePreference;
+    if (savedPref) {
+      setThemeState(preferenceToTheme(savedPref));
+    } else {
+      // Fallback: check old key for migration
+      const oldTheme = localStorage.getItem("theme") as ThemeType;
+      if (oldTheme) {
+        setThemeState(oldTheme);
+        // Migrate to new key
+        localStorage.setItem(THEME_PREFERENCE_KEY, themeToPreference(oldTheme));
+        localStorage.removeItem("theme");
+      }
+    }
+  }, []);
+
+  // Listen for system theme changes when preference is "system"
+  useEffect(() => {
+    const savedPref = localStorage.getItem(
+      THEME_PREFERENCE_KEY
+    ) as ThemePreference;
+    if (savedPref === "system") {
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+      const handleChange = (e: MediaQueryListEvent) => {
+        setThemeState(e.matches ? "g100" : "white");
+      };
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
     }
   }, []);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-carbon-theme', theme);
+    document.documentElement.setAttribute("data-carbon-theme", theme);
   }, [theme]);
 
   const setTheme = (newTheme: ThemeType) => {
     setThemeState(newTheme);
-    localStorage.setItem('theme', newTheme);
+    // Save as preference format
+    localStorage.setItem(THEME_PREFERENCE_KEY, themeToPreference(newTheme));
   };
 
   const toggleTheme = () => {
-    const newTheme = theme === 'white' ? 'g100' : 'white';
+    const newTheme = theme === "white" ? "g100" : "white";
     setTheme(newTheme);
   };
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
-      <Theme theme={theme}>
-        {children}
-      </Theme>
+      <Theme theme={theme}>{children}</Theme>
     </ThemeContext.Provider>
   );
 };
@@ -48,7 +99,7 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 export const useTheme = () => {
   const context = useContext(ThemeContext);
   if (context === undefined) {
-    throw new Error('useTheme must be used within a ThemeProvider');
+    throw new Error("useTheme must be used within a ThemeProvider");
   }
   return context;
 };

--- a/frontend/src/ui/theme/ThemeContext.tsx
+++ b/frontend/src/ui/theme/ThemeContext.tsx
@@ -80,13 +80,16 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 
   const setTheme = (newTheme: ThemeType) => {
     setThemeState(newTheme);
-    // Save as preference format
-    localStorage.setItem(THEME_PREFERENCE_KEY, themeToPreference(newTheme));
+    // Note: Don't save to localStorage here!
+    // useUserPreferences handles saving the preference (including "system")
+    // If we save here, "system" preference would be lost (converted to "light"/"dark")
   };
 
   const toggleTheme = () => {
     const newTheme = theme === "white" ? "g100" : "white";
-    setTheme(newTheme);
+    setThemeState(newTheme);
+    // Save when using toggleTheme directly (not via useUserPreferences)
+    localStorage.setItem(THEME_PREFERENCE_KEY, themeToPreference(newTheme));
   };
 
   return (


### PR DESCRIPTION
## Summary
- 🎨 統一主題 localStorage key 為 `themePreference`
- 🔄 修復主題切換不同步問題（/docs ↔ /dashboard）
- 💾 修復刷新後主題回到 system 的問題
- ✨ 支援 "system" 主題偏好持久化

## Technical Details
- `ThemeContext.tsx`: 統一使用 `themePreference` key，支援 system 主題監聽
- `useUserPreferences.ts`: 從 localStorage 初始化而非默認 "system"
- `DocsHeader.tsx` / `DocumentationPage.tsx`: 使用統一的 localStorage key

## Test plan
- [x] 在 /dashboard 切換主題，刷新後保持
- [x] 在 /docs 切換主題，導航到 /dashboard 後保持一致
- [x] 選擇 "system" 主題，刷新後保持
- [x] Light/Dark 主題都能正確切換