### PR TITLE
fix: complete API key flow from frontend to ai-service

### DIFF
--- a/backend/apps/ai/tests/test_message_streaming.py
+++ b/backend/apps/ai/tests/test_message_streaming.py
@@ -1,5 +1,6 @@
 """Tests for AI message streaming functionality."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
@@ -8,8 +9,22 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.ai.models import AIMessage, AISession
+from apps.users.models import UserAPIKey
 
 User = get_user_model()
+
+FAKE_KEY = "sk-ant-api03-fakekey1234567890"
+
+
+def _create_user_with_api_key(username, email, password="testpass123"):
+    """Helper: create a user and attach an active, validated API key."""
+    user = User.objects.create_user(
+        username=username, email=email, password=password,
+    )
+    api_key = UserAPIKey.objects.create(user=user, is_validated=True, is_active=True)
+    api_key.set_key(FAKE_KEY)
+    api_key.save()
+    return user
 
 
 class MessageStreamingTestCase(TestCase):
@@ -17,16 +32,8 @@ class MessageStreamingTestCase(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user(
-            username="testuser",
-            email="test@example.com",
-            password="testpass123",
-        )
-        self.other_user = User.objects.create_user(
-            username="otheruser",
-            email="other@example.com",
-            password="testpass123",
-        )
+        self.user = _create_user_with_api_key("testuser", "test@example.com")
+        self.other_user = _create_user_with_api_key("otheruser", "other@example.com")
         self.session = AISession.objects.create(
             session_id="44444444-4444-4444-4444-444444444444",
             user=self.user,
@@ -148,6 +155,42 @@ class MessageStreamingTestCase(TestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             payload = b"".join(response.streaming_content).decode("utf-8", errors="ignore")
             self.assertIn('"type": "error"', payload)
+
+    def test_send_message_without_api_key_returns_400(self):
+        """Users without an API key should get 400 on streaming."""
+        user_no_key = User.objects.create_user(
+            username="nokey", email="nokey@example.com", password="testpass123",
+        )
+        self.client.force_authenticate(user=user_no_key)
+        response = self.client.post(
+            f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
+            {"content": "Hello"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("API Key", response.data["error"])
+
+    def test_api_key_override_passed_to_ai_service(self):
+        """Verify api_key_override is included in the ai-service payload."""
+        self.client.force_authenticate(user=self.user)
+        with patch("apps.ai.views.build_ai_service_headers", return_value={"X-AI-Internal-Token": "test"}), \
+             patch("apps.ai.views.httpx.stream") as mock_stream:
+            mock_stream.return_value.__enter__.return_value = self._mock_stream_response(
+                self.session.session_id
+            )
+            response = self.client.post(
+                f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
+                {"content": "Hello"},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            _ = b"".join(response.streaming_content)
+
+            # Check the payload sent to httpx.stream
+            call_args = mock_stream.call_args
+            payload = call_args.kwargs.get("json") or call_args[1].get("json")
+            self.assertIn("api_key_override", payload)
+            self.assertEqual(payload["api_key_override"], FAKE_KEY)
 
 
 class MessagePersistenceTestCase(TestCase):

--- a/backend/apps/ai/tests/test_session_access_control.py
+++ b/backend/apps/ai/tests/test_session_access_control.py
@@ -8,8 +8,19 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.ai.models import AIExecutionLog, AISession
+from apps.users.models import UserAPIKey
 
 User = get_user_model()
+
+FAKE_KEY = "sk-ant-api03-fakekey1234567890"
+
+
+def _create_user_with_api_key(username, email, password="testpass123"):
+    user = User.objects.create_user(username=username, email=email, password=password)
+    api_key = UserAPIKey.objects.create(user=user, is_validated=True, is_active=True)
+    api_key.set_key(FAKE_KEY)
+    api_key.save()
+    return user
 
 
 class SessionAccessControlTestCase(TestCase):
@@ -17,16 +28,8 @@ class SessionAccessControlTestCase(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user1 = User.objects.create_user(
-            username="user1",
-            email="user1@example.com",
-            password="testpass123",
-        )
-        self.user2 = User.objects.create_user(
-            username="user2",
-            email="user2@example.com",
-            password="testpass123",
-        )
+        self.user1 = _create_user_with_api_key("user1", "user1@example.com")
+        self.user2 = _create_user_with_api_key("user2", "user2@example.com")
 
         self.user1_session = AISession.objects.create(
             session_id="11111111-1111-1111-1111-111111111111",

--- a/backend/apps/ai/views.py
+++ b/backend/apps/ai/views.py
@@ -122,6 +122,21 @@ class AISessionViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_401_UNAUTHORIZED,
             )
 
+        # 取得使用者的 API Key（若有設定）
+        user_api_key = None
+        try:
+            user_api_key_obj = request.user.api_key
+            if user_api_key_obj.is_active:
+                user_api_key = user_api_key_obj.get_key()
+        except Exception:
+            pass  # 使用者未設定 API Key，ai-service 會 fallback 到 env var
+
+        if not user_api_key:
+            return Response(
+                {"error": "請先在設定頁面設定您的 API Key"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         # 獲取或創建 session
         session = None
 
@@ -231,6 +246,10 @@ class AISessionViewSet(viewsets.ModelViewSet):
                 "content": content,
                 "conversation": [],
             }
+
+            # 傳遞使用者 API Key 給 ai-service
+            if user_api_key:
+                ai_service_payload["api_key_override"] = user_api_key
 
             # v2: model_id from serializer
             model_id = serializer.validated_data.get("model_id")

--- a/backend/apps/users/encryption.py
+++ b/backend/apps/users/encryption.py
@@ -55,7 +55,8 @@ def decrypt_api_key(encrypted_key: bytes) -> str:
     """
     cipher = get_cipher()
     try:
-        return cipher.decrypt(encrypted_key).decode()
+        raw = bytes(encrypted_key) if not isinstance(encrypted_key, bytes) else encrypted_key
+        return cipher.decrypt(raw).decode()
     except InvalidToken:
         raise ValueError('Failed to decrypt API key. The key may be corrupted.')
     except Exception as e:

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -256,7 +256,7 @@ class APIKeyService:
     """Service for managing user API keys and validation."""
 
     @staticmethod
-    async def validate_anthropic_key(api_key: str) -> tuple[bool, str]:
+    def validate_anthropic_key(api_key: str) -> tuple[bool, str]:
         """驗證 Anthropic API Key 是否有效
 
         Args:
@@ -276,9 +276,9 @@ class APIKeyService:
             # 使用提供的 API Key 初始化 client
             client = anthropic.Anthropic(api_key=api_key)
 
-            # 發送最小測試請求（使用免費的 haiku 模型）
+            # 發送最小測試請求（使用最便宜的 haiku 模型）
             response = client.messages.create(
-                model="claude-3-5-haiku-20241022",
+                model="claude-haiku-4-5-20251001",
                 max_tokens=10,
                 messages=[{"role": "user", "content": "test"}]
             )

--- a/backend/apps/users/tests/test_api_key.py
+++ b/backend/apps/users/tests/test_api_key.py
@@ -1,0 +1,135 @@
+"""Tests for API Key management endpoints."""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.users.models import UserAPIKey
+
+User = get_user_model()
+
+FAKE_KEY = "sk-ant-api03-fakekey1234567890"
+
+
+class APIKeyViewTestCase(TestCase):
+    """Test /api/v1/users/me/api-key endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        self.url = "/api/v1/users/me/api-key"
+
+    # ── GET ────────────────────────────────────────────────────────────
+
+    def test_get_api_key_info_unauthenticated(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_get_api_key_info_no_key(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+        self.assertFalse(response.data["data"]["has_key"])
+
+    def test_get_api_key_info_with_key(self):
+        self.client.force_authenticate(user=self.user)
+        api_key = UserAPIKey.objects.create(user=self.user)
+        api_key.set_key(FAKE_KEY)
+        api_key.is_validated = True
+        api_key.save()
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data["data"]
+        self.assertTrue(data["has_key"])
+        self.assertTrue(data["is_validated"])
+        # Key should never be exposed in response
+        self.assertNotIn("encrypted_key", data)
+        self.assertNotIn("api_key", data)
+
+    # ── POST ───────────────────────────────────────────────────────────
+
+    def test_set_api_key_invalid_format(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(self.url, {"api_key": "invalid-key"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("apps.users.services.APIKeyService.validate_anthropic_key")
+    def test_set_api_key_success(self, mock_validate):
+        mock_validate.return_value = (True, "")
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            self.url,
+            {"api_key": FAKE_KEY, "key_name": "Test Key"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.data["success"])
+
+        # Verify stored and encrypted
+        api_key = UserAPIKey.objects.get(user=self.user)
+        self.assertTrue(api_key.is_validated)
+        self.assertEqual(api_key.key_name, "Test Key")
+        self.assertEqual(api_key.get_key(), FAKE_KEY)
+
+    @patch("apps.users.services.APIKeyService.validate_anthropic_key")
+    def test_set_api_key_validation_failure(self, mock_validate):
+        mock_validate.return_value = (False, "Invalid API key")
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(self.url, {"api_key": FAKE_KEY})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(UserAPIKey.objects.filter(user=self.user).exists())
+
+    # ── DELETE ─────────────────────────────────────────────────────────
+
+    def test_delete_api_key_success(self):
+        self.client.force_authenticate(user=self.user)
+        api_key = UserAPIKey.objects.create(user=self.user)
+        api_key.set_key(FAKE_KEY)
+        api_key.save()
+
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(UserAPIKey.objects.filter(user=self.user).exists())
+
+    def test_delete_api_key_not_found(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class APIKeyEncryptionTestCase(TestCase):
+    """Test API key encryption round-trip."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="enctest",
+            email="enc@example.com",
+            password="testpass123",
+        )
+
+    def test_encrypt_decrypt_roundtrip(self):
+        api_key = UserAPIKey.objects.create(user=self.user)
+        api_key.set_key(FAKE_KEY)
+        api_key.save()
+
+        # Re-fetch from DB to ensure binary storage works
+        api_key.refresh_from_db()
+        self.assertEqual(api_key.get_key(), FAKE_KEY)
+
+    def test_encrypted_key_is_not_plaintext(self):
+        api_key = UserAPIKey.objects.create(user=self.user)
+        api_key.set_key(FAKE_KEY)
+        api_key.save()
+
+        raw = bytes(api_key.encrypted_key)
+        self.assertNotIn(FAKE_KEY.encode(), raw)

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -218,7 +218,7 @@ class APIKeyServiceTests(TestCase):
         fake_module = types.SimpleNamespace(Anthropic=FakeClient)
 
         with patch.dict(sys.modules, {"anthropic": fake_module}):
-            valid, error = asyncio.run(APIKeyService.validate_anthropic_key("sk-test"))
+            valid, error = APIKeyService.validate_anthropic_key("sk-test")
 
         self.assertTrue(valid)
         self.assertEqual(error, "")
@@ -237,7 +237,7 @@ class APIKeyServiceTests(TestCase):
         fake_module = types.SimpleNamespace(Anthropic=FakeClient)
 
         with patch.dict(sys.modules, {"anthropic": fake_module}):
-            valid, error = asyncio.run(APIKeyService.validate_anthropic_key("invalid"))
+            valid, error = APIKeyService.validate_anthropic_key("invalid")
 
         self.assertFalse(valid)
         self.assertEqual(error, "Invalid API key")

--- a/backend/apps/users/views/_impl.py
+++ b/backend/apps/users/views/_impl.py
@@ -811,10 +811,8 @@ class UserAPIKeyView(SchemaAPIView):
         api_key_str = serializer.validated_data['api_key']
         key_name = serializer.validated_data.get('key_name', 'My API Key')
 
-        # Validate API key asynchronously
-        is_valid, error_msg = asyncio.run(
-            APIKeyService.validate_anthropic_key(api_key_str)
-        )
+        # Validate API key
+        is_valid, error_msg = APIKeyService.validate_anthropic_key(api_key_str)
 
         if not is_valid:
             return Response({
@@ -888,10 +886,8 @@ class ValidateAPIKeyView(SchemaAPIView):
 
         api_key_str = serializer.validated_data['api_key']
 
-        # Validate API key asynchronously
-        is_valid, error_msg = asyncio.run(
-            APIKeyService.validate_anthropic_key(api_key_str)
-        )
+        # Validate API key
+        is_valid, error_msg = APIKeyService.validate_anthropic_key(api_key_str)
 
         return Response({
             'success': True,
@@ -919,17 +915,22 @@ class GetUsageStatsView(SchemaAPIView):
         from apps.ai.models import AIExecutionLog
         from datetime import datetime
 
-        # Check if user has API key
+        # If user has no API key, return empty stats instead of error
         try:
             request.user.api_key
         except UserAPIKey.DoesNotExist:
             return Response({
-                'success': False,
-                'error': {
-                    'code': 'NO_API_KEY',
-                    'message': '未找到 API Key。請先設定 API Key'
+                'success': True,
+                'data': {
+                    'total': {
+                        'input_tokens': 0,
+                        'output_tokens': 0,
+                        'requests': 0,
+                        'cost_usd': 0,
+                    },
+                    'breakdown': [],
                 }
-            }, status=status.HTTP_400_BAD_REQUEST)
+            })
 
         # Parse query parameters
         start_date_str = request.query_params.get('start_date')

--- a/backend/config/settings/test.py
+++ b/backend/config/settings/test.py
@@ -10,6 +10,10 @@ DEBUG = False
 
 SECRET_KEY = 'test-secret-key-not-for-production'
 
+# Fernet encryption key for API key storage (test-only, not for production)
+ENCRYPTION_KEY = '5CWm28LUn1E789amAyyHhlKpAempbJ7tI08p5FdibrE='
+
+
 # Test database
 # 優先使用 DATABASE_URL（CI 標準格式）
 DATABASE_URL = os.getenv('DATABASE_URL')

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -27,3 +27,4 @@ channels>=4.0,<5.0
 channels-redis>=4.1,<5.0
 httpx>=0.26.0  # Async HTTP client for AI Service communication
 jsonpatch>=1.33  # RFC 6902 JSON Patch for problem mutations
+anthropic>=0.40.0  # Anthropic API client for API key validation

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,7 +61,6 @@ services:
     env_file:
       - .env
     environment:
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - AI_STATE_POSTGRES_URL=postgresql://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-online_judge}
       - BACKEND_INTERNAL_URL=http://backend:8000/api/v1/ai
       - AI_SERVICE_ID=${AI_SERVICE_ID:-ai-service-dev}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
     env_file:
       - .env
     environment:
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - AI_STATE_POSTGRES_URL=postgresql://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-online_judge}
       - BACKEND_INTERNAL_URL=http://backend:8000/api/v1/ai
       - AI_SERVICE_ID=${AI_SERVICE_ID:-ai-service-01}

--- a/frontend/src/features/auth/components/APIKeyPanel.test.tsx
+++ b/frontend/src/features/auth/components/APIKeyPanel.test.tsx
@@ -1,0 +1,207 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { APIKeyPanel } from "./APIKeyPanel";
+
+// Mock i18n
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Mock repository
+vi.mock("@/infrastructure/api/repositories/auth.repository", () => ({
+  getAPIKeyInfo: vi.fn(),
+  setAPIKey: vi.fn(),
+  deleteAPIKey: vi.fn(),
+}));
+
+import {
+  getAPIKeyInfo,
+  setAPIKey,
+  deleteAPIKey,
+} from "@/infrastructure/api/repositories/auth.repository";
+
+const mockGetAPIKeyInfo = vi.mocked(getAPIKeyInfo);
+const mockSetAPIKey = vi.mocked(setAPIKey);
+const mockDeleteAPIKey = vi.mocked(deleteAPIKey);
+
+/** Helper: get the "新增 API Key" CTA button (not the modal heading) */
+const getAddButton = () =>
+  screen.getByRole("button", { name: /新增 API Key/ });
+
+/** Helper: open the add/update modal by clicking the CTA button */
+const openModal = async (buttonText: RegExp) => {
+  const btn = await screen.findByRole("button", { name: buttonText });
+  fireEvent.click(btn);
+  // Wait for modal input to appear
+  return screen.findByLabelText("Anthropic API Key");
+};
+
+describe("APIKeyPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Display states ─────────────────────────────────────────────────
+
+  it("shows empty state when user has no API key", async () => {
+    mockGetAPIKeyInfo.mockResolvedValue({
+      success: true,
+      data: { has_key: false },
+    } as any);
+
+    render(<APIKeyPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("尚未設定 API Key")).toBeInTheDocument();
+    });
+    expect(getAddButton()).toBeInTheDocument();
+  });
+
+  it("shows API key info when user has a key", async () => {
+    mockGetAPIKeyInfo.mockResolvedValue({
+      success: true,
+      data: {
+        has_key: true,
+        is_validated: true,
+        is_active: true,
+        key_name: "My Key",
+        total_requests: 42,
+        total_input_tokens: 1000,
+        total_output_tokens: 500,
+        total_cost_usd: 0.05,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    } as any);
+
+    render(<APIKeyPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("API Key 資訊")).toBeInTheDocument();
+    });
+    expect(screen.getByText("My Key")).toBeInTheDocument();
+    expect(screen.getByText("已驗證")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("shows error notification when getAPIKeyInfo fails", async () => {
+    mockGetAPIKeyInfo.mockRejectedValue(new Error("Network error"));
+
+    render(<APIKeyPanel />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Network error/).length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Modal & save flow ──────────────────────────────────────────────
+
+  it("opens modal when clicking add button", async () => {
+    mockGetAPIKeyInfo.mockResolvedValue({
+      success: true,
+      data: { has_key: false },
+    } as any);
+
+    render(<APIKeyPanel />);
+    const input = await openModal(/新增 API Key/);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("validates API key format client-side", async () => {
+    mockGetAPIKeyInfo.mockResolvedValue({
+      success: true,
+      data: { has_key: false },
+    } as any);
+
+    render(<APIKeyPanel />);
+    const input = await openModal(/新增 API Key/);
+
+    fireEvent.change(input, { target: { value: "invalid-key" } });
+    fireEvent.click(screen.getByText("儲存"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/無效的 API Key 格式/).length).toBeGreaterThan(0);
+    });
+    expect(mockSetAPIKey).not.toHaveBeenCalled();
+  });
+
+  it("submits valid API key successfully", async () => {
+    mockGetAPIKeyInfo
+      .mockResolvedValueOnce({ success: true, data: { has_key: false } } as any)
+      .mockResolvedValueOnce({
+        success: true,
+        data: { has_key: true, is_validated: true, is_active: true, key_name: "My API Key" },
+      } as any);
+    mockSetAPIKey.mockResolvedValue({ success: true } as any);
+
+    render(<APIKeyPanel />);
+    const input = await openModal(/新增 API Key/);
+
+    fireEvent.change(input, { target: { value: "sk-ant-api03-testkey123" } });
+    fireEvent.click(screen.getByText("儲存"));
+
+    await waitFor(() => {
+      expect(mockSetAPIKey).toHaveBeenCalledWith({
+        api_key: "sk-ant-api03-testkey123",
+        key_name: "My API Key",
+      });
+    });
+  });
+
+  it("shows error when API key save fails", async () => {
+    mockGetAPIKeyInfo.mockResolvedValue({
+      success: true,
+      data: { has_key: false },
+    } as any);
+    mockSetAPIKey.mockRejectedValue(new Error("Validation failed"));
+
+    render(<APIKeyPanel />);
+    const input = await openModal(/新增 API Key/);
+
+    fireEvent.change(input, { target: { value: "sk-ant-api03-badkey" } });
+    fireEvent.click(screen.getByText("儲存"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Validation failed/).length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Delete flow ────────────────────────────────────────────────────
+
+  it("deletes API key after confirmation", async () => {
+    mockGetAPIKeyInfo
+      .mockResolvedValueOnce({
+        success: true,
+        data: { has_key: true, is_validated: true, is_active: true, key_name: "My Key" },
+      } as any)
+      .mockResolvedValueOnce({ success: true, data: { has_key: false } } as any);
+    mockDeleteAPIKey.mockResolvedValue({ success: true });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<APIKeyPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("刪除 Key")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("刪除 Key"));
+
+    await waitFor(() => {
+      expect(mockDeleteAPIKey).toHaveBeenCalled();
+    });
+  });
+
+  it("does not delete when user cancels confirmation", async () => {
+    mockGetAPIKeyInfo.mockResolvedValue({
+      success: true,
+      data: { has_key: true, is_validated: true, is_active: true, key_name: "My Key" },
+    } as any);
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<APIKeyPanel />);
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("刪除 Key"));
+    });
+
+    expect(mockDeleteAPIKey).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/auth/components/APIKeyPanel.tsx
+++ b/frontend/src/features/auth/components/APIKeyPanel.tsx
@@ -96,7 +96,11 @@ export const APIKeyPanel: React.FC = () => {
         setSuccess(null);
       }, 1500);
     } catch (err: any) {
-      const errorMsg = err.response?.data?.error || err.message || "儲存失敗";
+      const rawError = err.response?.data?.error;
+      const errorMsg =
+        typeof rawError === "string"
+          ? rawError
+          : rawError?.message || err.message || "儲存失敗";
       setError(errorMsg);
     } finally {
       setIsSaving(false);

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -1,3 +1,6 @@
+@use "@carbon/styles/scss/config" with (
+  $css--font-face: false
+);
 @use "@carbon/react";
 @use "./scrollbar" as *;
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,13 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+// Polyfill ResizeObserver for Carbon components (Modal, etc.)
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // Mock window.matchMedia
 Object.defineProperty(window, "matchMedia", {
   writable: true,

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -35,6 +35,7 @@
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.spec.ts",
-    "src/**/*.spec.tsx"
+    "src/**/*.spec.tsx",
+    "src/test/**"
   ]
 }


### PR DESCRIPTION
## Summary
- **Backend**: retrieve user API key and pass `api_key_override` to ai-service payload, fixing the broken key flow
- **Backend**: fix `validate_anthropic_key` — change from `async` to sync, update model from deprecated `claude-3-5-haiku-20241022` to `claude-haiku-4-5-20251001`, add `anthropic` to requirements
- **Backend**: fix `memoryview` → `bytes` conversion in `encryption.py` for PostgreSQL BinaryField compatibility
- **Backend**: return empty usage stats (200) instead of 400 when user has no API key
- **Docker**: remove `ANTHROPIC_API_KEY` env injection from compose files (keys now come from per-user settings)
- **Frontend**: fix error display (`[object Object]` → proper message extraction), disable Carbon font-face (CDN), add ResizeObserver polyfill for tests, exclude `src/test/` from app build
- **Tests**: add API key endpoint tests, streaming tests with key override verification, frontend APIKeyPanel tests

## Test plan
- [x] Backend: 64 tests passing (including new API key + streaming tests)
- [x] Frontend: 9 APIKeyPanel tests passing
- [x] Manual: verified API key save flow works end-to-end in dev environment
- [ ] CI: verify all workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)