### PR TITLE
feat: i18n enhancements and IME-safe exam anti-cheat guards

### DIFF
--- a/frontend/src/features/chatbot/components/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { Loading } from "@carbon/react";
 import type { BackgroundInformation } from "@/core/types/chatbot.types";
 import { AgentAvatar } from "@/shared/ui/chatbot/components/AgentAvatar";
@@ -31,6 +32,8 @@ export const ChatbotWidget: FC<ChatbotWidgetProps> = ({
   backgroundInfo = null,
   onProblemUpdated,
 }) => {
+  const { t } = useTranslation("chatbot");
+  const { t: tc } = useTranslation("common");
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   // 追蹤是否曾經展開過，用於延遲初始化（一旦展開過就永遠為 true）
   const [hasBeenExpanded, setHasBeenExpanded] = useState(defaultExpanded);
@@ -76,8 +79,8 @@ export const ChatbotWidget: FC<ChatbotWidgetProps> = ({
         <button
           className={styles.collapsedButton}
           onClick={handleToggle}
-          aria-label="展開 Qgent TA"
-          title="展開 Qgent TA"
+          aria-label={t("widget.expandLabel")}
+          title={t("widget.expandLabel")}
         >
           <AgentAvatar size="md" />
         </button>
@@ -89,7 +92,7 @@ export const ChatbotWidget: FC<ChatbotWidgetProps> = ({
           {isInitializing ? (
             <div className={styles.loadingContainer}>
               <Loading withOverlay={false} small />
-              <span>載入中...</span>
+              <span>{tc("message.loading")}</span>
             </div>
           ) : (
             <ChatWindow

--- a/frontend/src/features/chatbot/hooks/useChatbot.ts
+++ b/frontend/src/features/chatbot/hooks/useChatbot.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import i18n from "i18next";
 import type {
   ApprovalRequest,
   BackgroundInformation,
@@ -120,7 +121,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
       }
     } catch (err) {
       console.error("Failed to load sessions:", err);
-      setError("無法載入對話記錄");
+      setError(i18n.t("chatbot:errors.loadSessionsFailed"));
     }
   }, [setCurrentSessionId]);
 
@@ -187,7 +188,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         }
       } catch (err) {
         console.error("Failed to initialize chatbot:", err);
-        const errorMessage = err instanceof Error ? err.message : "未知錯誤";
+        const errorMessage = err instanceof Error ? err.message : i18n.t("chatbot:errors.unknownError");
         setError(errorMessage);
         setIsInitializing(false);
         return;
@@ -212,7 +213,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
       return newSession.id;
     } catch (err) {
       console.error("Failed to create session:", err);
-      setError("無法創建新對話");
+      setError(i18n.t("chatbot:errors.createSessionFailed"));
       return null;
     }
   }, [setCurrentSessionId]);
@@ -241,7 +242,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         });
       } catch (err) {
         console.error("Failed to delete session:", err);
-        setError("無法刪除對話");
+        setError(i18n.t("chatbot:errors.deleteSessionFailed"));
       }
     },
     [currentSessionId, createSession],
@@ -272,7 +273,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         );
       } catch (err) {
         console.error("Failed to rename session:", err);
-        setError("無法重新命名對話");
+        setError(i18n.t("chatbot:errors.renameSessionFailed"));
       }
     },
     [],
@@ -316,7 +317,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
           );
         } catch (err) {
           console.error("Failed to create backend session:", err);
-          setError("無法建立對話，請稍後再試");
+          setError(i18n.t("chatbot:errors.createBackendSessionFailed"));
           return;
         }
       }
@@ -417,7 +418,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
                           message.id === tempAssistantId
                             ? {
                                 ...message,
-                                content: "抱歉，AI 服務暫時無法使用，請稍後再試。",
+                                content: i18n.t("chatbot:errors.aiServiceUnavailable"),
                                 isThinking: false,
                               }
                             : message,
@@ -455,7 +456,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
           return;
         }
         console.error("Stream error:", err);
-        setError("無法發送訊息");
+        setError(i18n.t("chatbot:errors.sendMessageFailed"));
 
         // 更新臨時 AI 訊息為錯誤訊息
         setSessions((prev) =>
@@ -467,7 +468,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
                     message.id === tempAssistantId
                       ? {
                           ...message,
-                          content: "抱歉，AI 服務暫時無法使用，請稍後再試。",
+                          content: i18n.t("chatbot:errors.aiServiceUnavailable"),
                           isThinking: false,
                         }
                       : message,
@@ -559,7 +560,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         );
       } catch (err) {
         console.error("Resume stream error:", err);
-        setError("無法恢復 agent 執行");
+        setError(i18n.t("chatbot:errors.resumeAgentFailed"));
         setIsStreaming(false);
         setIsLoading(false);
       }
@@ -586,7 +587,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
       onProblemUpdated?.();
     } catch (err) {
       console.error("Failed to confirm action:", err);
-      setError("確認操作失敗，請重試");
+      setError(i18n.t("chatbot:errors.confirmActionFailed"));
     }
   }, [currentSessionId, pendingApproval, resumeAgent, onProblemUpdated]);
 
@@ -607,7 +608,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
       await resumeAgent("reject");
     } catch (err) {
       console.error("Failed to cancel action:", err);
-      setError("取消操作失敗");
+      setError(i18n.t("chatbot:errors.cancelActionFailed"));
     }
   }, [currentSessionId, pendingApproval, resumeAgent]);
 
@@ -629,7 +630,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         );
       } catch (err) {
         console.error("Failed to submit answer:", err);
-        setError("無法提交回答");
+        setError(i18n.t("chatbot:errors.submitAnswerFailed"));
         return;
       }
 
@@ -638,7 +639,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         await resumeAgent("approve");
       } catch (err) {
         console.error("Failed to resume agent after answer submission:", err);
-        setError("回答已送出，但恢復串流失敗，請重新整理頁面");
+        setError(i18n.t("chatbot:errors.resumeAfterAnswerFailed"));
       }
     },
     [currentSessionId, resumeAgent],

--- a/frontend/src/features/classroom/components/AnnouncementModal.tsx
+++ b/frontend/src/features/classroom/components/AnnouncementModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { Modal, TextInput, Toggle } from "@carbon/react";
 import { MarkdownField } from "@/shared/ui/markdown/markdownEditor";
 import {
@@ -23,6 +24,7 @@ export const AnnouncementModal: React.FC<AnnouncementModalProps> = ({
   onClose,
   onSaved,
 }) => {
+  const { t } = useTranslation("classroom");
   const isEdit = !!announcement;
 
   const [title, setTitle] = useState("");
@@ -72,30 +74,36 @@ export const AnnouncementModal: React.FC<AnnouncementModalProps> = ({
       open={open}
       onRequestClose={onClose}
       onRequestSubmit={handleSubmit}
-      modalHeading={isEdit ? "編輯公告" : "發佈公告"}
+      modalHeading={
+        isEdit ? t("announcement.modal.titleEdit") : t("announcement.modal.titleCreate")
+      }
       primaryButtonText={
         submitting
-          ? isEdit ? "儲存中..." : "發佈中..."
-          : isEdit ? "儲存" : "發佈"
+          ? isEdit
+            ? t("announcement.modal.submittingEdit")
+            : t("announcement.modal.submittingCreate")
+          : isEdit
+          ? t("announcement.modal.submitEdit")
+          : t("announcement.modal.submitCreate")
       }
       primaryButtonDisabled={submitting || !title.trim()}
-      secondaryButtonText="取消"
+      secondaryButtonText={t("announcement.modal.cancel")}
       size="lg"
     >
       <div style={{ display: "grid", gap: "1rem" }}>
         <TextInput
           id="announcement-title"
-          labelText="標題"
-          placeholder="公告標題"
+          labelText={t("announcement.modal.form.title")}
+          placeholder={t("announcement.modal.form.titlePlaceholder")}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
 
         <Toggle
           id="announcement-pinned"
-          labelText="置頂公告"
-          labelA="否"
-          labelB="是"
+          labelText={t("announcement.modal.form.pinned")}
+          labelA={t("announcement.modal.form.no")}
+          labelB={t("announcement.modal.form.yes")}
           toggled={isPinned}
           onToggle={(checked: boolean) => setIsPinned(checked)}
           size="sm"
@@ -103,10 +111,10 @@ export const AnnouncementModal: React.FC<AnnouncementModalProps> = ({
 
         <MarkdownField
           id="announcement-content"
-          labelText="內容"
+          labelText={t("announcement.modal.form.content")}
           value={content}
           onChange={setContent}
-          placeholder="輸入公告內容，支援 Markdown 語法..."
+          placeholder={t("announcement.modal.form.contentPlaceholder")}
           minHeight="250px"
         />
       </div>

--- a/frontend/src/features/classroom/components/BindContestModal.tsx
+++ b/frontend/src/features/classroom/components/BindContestModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Modal, StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody, RadioButton } from "@carbon/react";
 import { getContests } from "@/infrastructure/api/repositories/contest.repository";
 import { bindContest } from "@/infrastructure/api/repositories/classroom.repository";
@@ -19,6 +20,7 @@ export const BindContestModal: React.FC<BindContestModalProps> = ({
   onClose,
   onBound,
 }) => {
+  const { t } = useTranslation("classroom");
   const [contests, setContests] = useState<Contest[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -52,20 +54,20 @@ export const BindContestModal: React.FC<BindContestModalProps> = ({
       open={open}
       onRequestClose={() => { setSelected(null); onClose(); }}
       onRequestSubmit={handleSubmit}
-      modalHeading="綁定競賽"
-      primaryButtonText={submitting ? "綁定中..." : "綁定"}
+      modalHeading={t("bindContest.modal.title")}
+      primaryButtonText={submitting ? t("bindContest.modal.submitting") : t("bindContest.modal.submit")}
       primaryButtonDisabled={submitting || !selected}
-      secondaryButtonText="取消"
+      secondaryButtonText={t("bindContest.modal.cancel")}
     >
       {contests.length === 0 ? (
-        <p style={{ color: "var(--cds-text-secondary)" }}>沒有可綁定的競賽</p>
+        <p style={{ color: "var(--cds-text-secondary)" }}>{t("bindContest.modal.noContests")}</p>
       ) : (
         <StructuredListWrapper selection>
           <StructuredListHead>
             <StructuredListRow head>
               <StructuredListCell head />
-              <StructuredListCell head>競賽名稱</StructuredListCell>
-              <StructuredListCell head>狀態</StructuredListCell>
+              <StructuredListCell head>{t("bindContest.modal.table.name")}</StructuredListCell>
+              <StructuredListCell head>{t("bindContest.modal.table.status")}</StructuredListCell>
             </StructuredListRow>
           </StructuredListHead>
           <StructuredListBody>

--- a/frontend/src/features/classroom/components/InviteCodeDisplay.tsx
+++ b/frontend/src/features/classroom/components/InviteCodeDisplay.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Button, Stack, Tag } from "@carbon/react";
 import { Copy, Renew } from "@carbon/icons-react";
 
@@ -13,6 +14,7 @@ export const InviteCodeDisplay: React.FC<InviteCodeDisplayProps> = ({
   enabled,
   onRegenerate,
 }) => {
+  const { t } = useTranslation("classroom");
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -33,7 +35,7 @@ export const InviteCodeDisplay: React.FC<InviteCodeDisplayProps> = ({
       }}
     >
       <span style={{ fontSize: "0.875rem", color: "var(--cds-text-secondary)" }}>
-        邀請碼
+        {t("inviteCode.label")}
       </span>
       <code
         style={{
@@ -47,7 +49,7 @@ export const InviteCodeDisplay: React.FC<InviteCodeDisplayProps> = ({
       </code>
       {!enabled && (
         <Tag type="red" size="sm">
-          已停用
+          {t("inviteCode.disabled")}
         </Tag>
       )}
       <Stack orientation="horizontal" gap={3}>
@@ -57,7 +59,7 @@ export const InviteCodeDisplay: React.FC<InviteCodeDisplayProps> = ({
           renderIcon={Copy}
           onClick={handleCopy}
         >
-          {copied ? "已複製" : "複製"}
+          {copied ? t("inviteCode.copied") : t("inviteCode.copy")}
         </Button>
         <Button
           kind="ghost"
@@ -65,7 +67,7 @@ export const InviteCodeDisplay: React.FC<InviteCodeDisplayProps> = ({
           renderIcon={Renew}
           onClick={onRegenerate}
         >
-          重新產生
+          {t("inviteCode.regenerate")}
         </Button>
       </Stack>
     </div>

--- a/frontend/src/features/classroom/components/MemberTable.tsx
+++ b/frontend/src/features/classroom/components/MemberTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import {
   DataTable,
   Table,
@@ -19,19 +20,22 @@ interface MemberTableProps {
   onRemove: (userId: number) => void;
 }
 
-const headers = [
-  { key: "username", header: "Username" },
-  { key: "email", header: "Email" },
-  { key: "role", header: "角色" },
-  { key: "joinedAt", header: "加入時間" },
-  { key: "actions", header: "" },
-];
-
 export const MemberTable: React.FC<MemberTableProps> = ({
   members,
   isPrivileged,
   onRemove,
 }) => {
+  const { t } = useTranslation("classroom");
+  const { t: tc } = useTranslation("common");
+
+  const headers = [
+    { key: "username", header: t("members.headers.username") },
+    { key: "email", header: t("members.headers.email") },
+    { key: "role", header: t("members.headers.role") },
+    { key: "joinedAt", header: t("members.headers.joinedAt") },
+    { key: "actions", header: "" },
+  ];
+
   const rows = members.map((m) => ({
     id: String(m.userId),
     username: m.username,
@@ -62,7 +66,7 @@ export const MemberTable: React.FC<MemberTableProps> = ({
                     return (
                       <TableCell key={cell.id}>
                         <Tag type={cell.value === "ta" ? "purple" : "teal"} size="sm">
-                          {cell.value}
+                          {tc(`user.role.${cell.value}`)}
                         </Tag>
                       </TableCell>
                     );
@@ -75,7 +79,7 @@ export const MemberTable: React.FC<MemberTableProps> = ({
                           size="sm"
                           hasIconOnly
                           renderIcon={TrashCan}
-                          iconDescription="移除"
+                          iconDescription={t("members.actions.remove")}
                           onClick={() => onRemove(cell.value as number)}
                         />
                       </TableCell>

--- a/frontend/src/features/contest/detectors/focusDetector.test.ts
+++ b/frontend/src/features/contest/detectors/focusDetector.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TFunction } from "i18next";
+import { FocusDetector } from "./focusDetector";
+
+const t = ((key: string) => key) as TFunction;
+
+describe("FocusDetector", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("ignores blur while IME composition is active", () => {
+    const onViolation = vi.fn();
+    const detector = new FocusDetector(t);
+    detector.start(onViolation);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+
+    vi.advanceTimersByTime(1000);
+    window.dispatchEvent(new Event("blur"));
+    vi.advanceTimersByTime(1000);
+
+    expect(onViolation).not.toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "window_blur" })
+    );
+
+    input.remove();
+    detector.stop();
+  });
+
+  it("ignores blur shortly after IME composition ends", () => {
+    const onViolation = vi.fn();
+    const detector = new FocusDetector(t);
+    detector.start(onViolation);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    vi.advanceTimersByTime(500);
+    input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+    input.dispatchEvent(new Event("compositionend", { bubbles: true }));
+
+    window.dispatchEvent(new Event("blur"));
+    vi.advanceTimersByTime(1000);
+
+    expect(onViolation).not.toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "window_blur" })
+    );
+
+    input.remove();
+    detector.stop();
+  });
+
+  it("still emits window_blur when not composing", () => {
+    const onViolation = vi.fn();
+    const detector = new FocusDetector(t);
+    detector.start(onViolation);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    vi.advanceTimersByTime(1000);
+    window.dispatchEvent(new Event("blur"));
+    vi.advanceTimersByTime(1000);
+
+    expect(onViolation).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "window_blur", detectorId: "focus" })
+    );
+
+    detector.stop();
+  });
+});

--- a/frontend/src/features/contest/detectors/focusDetector.ts
+++ b/frontend/src/features/contest/detectors/focusDetector.ts
@@ -7,6 +7,8 @@ import {
 import type { ExamDetector, ViolationEvent, CheckResult } from "./types";
 import type { TFunction } from "i18next";
 
+const IME_BLUR_GUARD_MS = 900;
+
 const INTERACTION_EVENTS = [
   "mousedown", "pointerdown", "click", "keydown", "keyup",
   "touchstart", "touchend", "focusin", "focusout", "input",
@@ -26,6 +28,10 @@ export class FocusDetector implements ExamDetector {
   private handleVisibilityChange: ((event: Event) => void) | null = null;
   private lastVerifyResponse: string | null = null;
   private handleBlur: (() => void) | null = null;
+  private handleCompositionStart: (() => void) | null = null;
+  private handleCompositionEnd: (() => void) | null = null;
+  private isComposing = false;
+  private lastCompositionEndAt = 0;
   private onInteractionCallbacks: Array<() => void> = [];
 
   constructor(t: TFunction) {
@@ -58,6 +64,9 @@ export class FocusDetector implements ExamDetector {
     });
 
     this.handleBlur = () => {
+      if (this.isComposing) return;
+      if (Date.now() - this.lastCompositionEndAt < IME_BLUR_GUARD_MS) return;
+
       const timeSinceInteraction = Date.now() - this.lastInteractionTime;
       if (timeSinceInteraction < EXAM_MONITORING_BLUR_DEBOUNCE_MS) return;
 
@@ -90,9 +99,20 @@ export class FocusDetector implements ExamDetector {
       }, EXAM_MONITORING_FOCUS_CHECK_DELAY_MS);
     };
 
+    this.handleCompositionStart = () => {
+      this.isComposing = true;
+    };
+
+    this.handleCompositionEnd = () => {
+      this.isComposing = false;
+      this.lastCompositionEndAt = Date.now();
+    };
+
     INTERACTION_EVENTS.forEach((ev) =>
       document.addEventListener(ev, this.handleInteraction!, true)
     );
+    document.addEventListener("compositionstart", this.handleCompositionStart, true);
+    document.addEventListener("compositionend", this.handleCompositionEnd, true);
     document.addEventListener("visibilitychange", this.handleVisibilityChange as EventListener);
     window.addEventListener("blur", this.handleBlur);
   }
@@ -106,6 +126,12 @@ export class FocusDetector implements ExamDetector {
     if (this.handleVisibilityChange) {
       document.removeEventListener("visibilitychange", this.handleVisibilityChange as EventListener);
     }
+    if (this.handleCompositionStart) {
+      document.removeEventListener("compositionstart", this.handleCompositionStart, true);
+    }
+    if (this.handleCompositionEnd) {
+      document.removeEventListener("compositionend", this.handleCompositionEnd, true);
+    }
     if (this.handleBlur) {
       window.removeEventListener("blur", this.handleBlur);
     }
@@ -114,6 +140,10 @@ export class FocusDetector implements ExamDetector {
     this.blurCheckTimeout = undefined;
     this.blurConfirmTimeout = undefined;
     this.onViolation = null;
+    this.handleCompositionStart = null;
+    this.handleCompositionEnd = null;
+    this.isComposing = false;
+    this.lastCompositionEndAt = 0;
     this.onInteractionCallbacks = [];
   }
 

--- a/frontend/src/features/contest/detectors/mouseLeaveDetector.test.ts
+++ b/frontend/src/features/contest/detectors/mouseLeaveDetector.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EXAM_MONITORING_RECOVERY_GRACE_MS } from "@/features/contest/domain/examMonitoringPolicy";
+import type { TFunction } from "i18next";
+import { MouseLeaveDetector } from "./mouseLeaveDetector";
+
+const t = ((key: string) => key) as TFunction;
+
+describe("MouseLeaveDetector", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ignores mouseleave while IME composition is active", () => {
+    const onViolation = vi.fn();
+    const detector = new MouseLeaveDetector(t);
+    detector.start(onViolation);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+
+    document.documentElement.dispatchEvent(
+      new MouseEvent("mouseleave", { bubbles: false, cancelable: true, relatedTarget: null })
+    );
+    vi.advanceTimersByTime(EXAM_MONITORING_RECOVERY_GRACE_MS + 50);
+
+    expect(onViolation).not.toHaveBeenCalled();
+
+    input.remove();
+    detector.stop();
+  });
+
+  it("ignores mouseleave shortly after IME composition ends", () => {
+    const onViolation = vi.fn();
+    const detector = new MouseLeaveDetector(t);
+    detector.start(onViolation);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+    input.dispatchEvent(new Event("compositionend", { bubbles: true }));
+
+    document.documentElement.dispatchEvent(
+      new MouseEvent("mouseleave", { bubbles: false, cancelable: true, relatedTarget: null })
+    );
+    vi.advanceTimersByTime(EXAM_MONITORING_RECOVERY_GRACE_MS + 50);
+
+    expect(onViolation).not.toHaveBeenCalled();
+
+    input.remove();
+    detector.stop();
+  });
+
+  it("still reports regular mouseleave when not composing", () => {
+    const onViolation = vi.fn();
+    const detector = new MouseLeaveDetector(t);
+    detector.start(onViolation);
+
+    document.documentElement.dispatchEvent(
+      new MouseEvent("mouseleave", { bubbles: false, cancelable: true, relatedTarget: null })
+    );
+
+    expect(onViolation).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "mouse_leave_triggered", detectorId: "mouse-leave" })
+    );
+
+    vi.advanceTimersByTime(EXAM_MONITORING_RECOVERY_GRACE_MS + 50);
+
+    expect(onViolation).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "mouse_leave", detectorId: "mouse-leave" })
+    );
+
+    detector.stop();
+  });
+});

--- a/frontend/src/features/contest/detectors/mouseLeaveDetector.ts
+++ b/frontend/src/features/contest/detectors/mouseLeaveDetector.ts
@@ -5,6 +5,8 @@ import {
 import type { ExamDetector, ViolationEvent, CheckResult } from "./types";
 import type { TFunction } from "i18next";
 
+const IME_COMPOSITION_GUARD_MS = 900;
+
 export interface MouseLeaveDetectorOptions {
   onCountdownChange?: (secondsLeft: number | null) => void;
 }
@@ -23,6 +25,10 @@ export class MouseLeaveDetector implements ExamDetector {
   private recoveryInterval: ReturnType<typeof setInterval> | null = null;
   private recoveryActive = false;
   private graceStartedAt = 0;
+  private isComposing = false;
+  private lastCompositionEndAt = 0;
+  private handleCompositionStart: (() => void) | null = null;
+  private handleCompositionEnd: (() => void) | null = null;
 
   constructor(t: TFunction, options: MouseLeaveDetectorOptions = {}) {
     this.t = t;
@@ -35,12 +41,23 @@ export class MouseLeaveDetector implements ExamDetector {
     this.handleMouseLeave = (e: MouseEvent) => {
       // relatedTarget === null means the mouse truly left the window
       if (e.relatedTarget !== null) return;
+      if (this.isComposing) return;
+      if (Date.now() - this.lastCompositionEndAt < IME_COMPOSITION_GUARD_MS) return;
       if (this.recoveryActive) return; // already in recovery
 
       const now = Date.now();
       if (now - this.lastReportAt < EXAM_MONITORING_MOUSE_LEAVE_COOLDOWN_MS) return;
 
       this.startRecovery();
+    };
+
+    this.handleCompositionStart = () => {
+      this.isComposing = true;
+    };
+
+    this.handleCompositionEnd = () => {
+      this.isComposing = false;
+      this.lastCompositionEndAt = Date.now();
     };
 
     this.handleMouseEnter = () => {
@@ -52,6 +69,8 @@ export class MouseLeaveDetector implements ExamDetector {
 
     document.documentElement.addEventListener("mouseleave", this.handleMouseLeave);
     document.documentElement.addEventListener("mouseenter", this.handleMouseEnter);
+    document.addEventListener("compositionstart", this.handleCompositionStart, true);
+    document.addEventListener("compositionend", this.handleCompositionEnd, true);
   }
 
   stop(): void {
@@ -63,7 +82,17 @@ export class MouseLeaveDetector implements ExamDetector {
       document.documentElement.removeEventListener("mouseenter", this.handleMouseEnter);
       this.handleMouseEnter = null;
     }
+    if (this.handleCompositionStart) {
+      document.removeEventListener("compositionstart", this.handleCompositionStart, true);
+      this.handleCompositionStart = null;
+    }
+    if (this.handleCompositionEnd) {
+      document.removeEventListener("compositionend", this.handleCompositionEnd, true);
+      this.handleCompositionEnd = null;
+    }
     this.clearRecovery();
+    this.isComposing = false;
+    this.lastCompositionEndAt = 0;
     this.onViolation = null;
   }
 

--- a/frontend/src/features/problems/screens/problemsIdEdit/ProblemEditScreen.tsx
+++ b/frontend/src/features/problems/screens/problemsIdEdit/ProblemEditScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { useParams, useNavigate } from "react-router-dom";
 import { useForm, FormProvider, useFormContext } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -73,6 +74,7 @@ const ProblemEditScreenContent: React.FC<ProblemEditScreenContentProps> = ({
   onBack,
   onProblemUpdated,
 }) => {
+  const { t } = useTranslation("problem");
   const { user } = useAuth();
   const { autoSave } = useProblemEdit();
   const { exportFormat, setExportFormat, pdfScale, setPdfScale } =
@@ -89,7 +91,7 @@ const ProblemEditScreenContent: React.FC<ProblemEditScreenContentProps> = ({
   return (
     <div className="problem-edit-page">
       <ProblemEditHeader
-        title={problem.title || "載入中..."}
+        title={problem.title || t("edit.messages.loadFailed")}
         onBack={onBack}
         globalSaveStatus={<GlobalSaveStatus status={autoSave.globalStatus} />}
         actions={
@@ -97,7 +99,7 @@ const ProblemEditScreenContent: React.FC<ProblemEditScreenContentProps> = ({
             <TriggerModal
               trigger={
                 <Button kind="ghost" renderIcon={Upload}>
-                  匯入
+                  {t("edit.actions.import")}
                 </Button>
               }
               renderModal={({ open, onClose }) => (
@@ -112,7 +114,7 @@ const ProblemEditScreenContent: React.FC<ProblemEditScreenContentProps> = ({
             <TriggerModal
               trigger={
                 <Button kind="ghost" renderIcon={Download}>
-                  匯出
+                  {t("edit.actions.export")}
                 </Button>
               }
               renderModal={({ open, onClose }) => (
@@ -132,7 +134,7 @@ const ProblemEditScreenContent: React.FC<ProblemEditScreenContentProps> = ({
               renderIcon={View}
               onClick={() => previewModalRef.current?.open()}
             >
-              預覽
+              {t("edit.actions.preview")}
             </Button>
           </>
         }
@@ -197,6 +199,7 @@ const ProblemEditScreenContent: React.FC<ProblemEditScreenContentProps> = ({
 const ProblemEditPageInner: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation("problem");
   const { user } = useAuth();
   const { showToast } = useToast();
   const { exportFormat, pdfScale } = useProblemEditUI();
@@ -262,14 +265,14 @@ const ProblemEditPageInner: React.FC = () => {
         await patchProblem(id, apiPayload);
         showToast({
           kind: "success",
-          title: "匯入成功",
-          subtitle: "YAML 資料已匯入並儲存",
+          title: t("edit.messages.importSuccess"),
+          subtitle: t("edit.messages.importSuccessDetail"),
         });
       } catch (err) {
         showToast({
           kind: "warning",
-          title: "匯入成功，但自動儲存失敗",
-          subtitle: err instanceof Error ? err.message : "請手動儲存",
+          title: t("edit.messages.importSuccessSaveFailed"),
+          subtitle: err instanceof Error ? err.message : t("button.save"),
         });
       }
     },
@@ -284,9 +287,9 @@ const ProblemEditPageInner: React.FC = () => {
       methods.setValue("visibility", newVisibility);
 
       const labels = {
-        public: "題目已公開",
-        private: "題目已設為私有",
-        hidden: "題目已隱藏"
+        public: t("edit.status.public"),
+        private: t("edit.status.private"),
+        hidden: t("edit.status.hidden")
       };
 
       showToast({
@@ -296,8 +299,8 @@ const ProblemEditPageInner: React.FC = () => {
     } catch (err) {
       showToast({
         kind: "error",
-        title: "操作失敗",
-        subtitle: err instanceof Error ? err.message : "請稍後再試",
+        title: tc("message.error"),
+        subtitle: err instanceof Error ? err.message : t("message.tryAdjustFilters"),
       });
       throw err;
     }
@@ -310,15 +313,15 @@ const ProblemEditPageInner: React.FC = () => {
       await deleteProblem(problem.id);
       showToast({
         kind: "success",
-        title: "刪除成功",
-        subtitle: "正在跳轉...",
+        title: t("edit.messages.deleteSuccess"),
+        subtitle: t("edit.messages.deleteSuccessDetail"),
       });
       setTimeout(() => navigate("/problems"), 1000);
     } catch (err) {
       showToast({
         kind: "error",
-        title: "刪除失敗",
-        subtitle: err instanceof Error ? err.message : "請稍後再試",
+        title: t("edit.messages.deleteFailed"),
+        subtitle: err instanceof Error ? err.message : tc("message.error"),
       });
       throw err;
     }
@@ -344,8 +347,8 @@ const ProblemEditPageInner: React.FC = () => {
         onClose();
         showToast({
           kind: "success",
-          title: "YAML 匯出成功",
-          subtitle: "檔案已下載",
+          title: t("edit.messages.exportSuccess"),
+          subtitle: t("edit.messages.exportSuccessDetail"),
         });
       } else {
         // PDF export
@@ -353,8 +356,8 @@ const ProblemEditPageInner: React.FC = () => {
         onClose();
         showToast({
           kind: "success",
-          title: "PDF 匯出",
-          subtitle: `PDF 匯出功能開發中... (縮放比例: ${pdfScale}%)`,
+          title: "PDF Export",
+          subtitle: `PDF export feature in development... (Scale: ${pdfScale}%)`,
         });
       }
     },
@@ -362,7 +365,7 @@ const ProblemEditPageInner: React.FC = () => {
   );
   const header = (
     <ProblemEditHeader
-      title={problem?.title || "載入中..."}
+      title={problem?.title || tc("message.loading")}
       onBack={() => navigate(-1)}
     />
   );
@@ -387,7 +390,7 @@ const ProblemEditPageInner: React.FC = () => {
     return (
       <ProblemEditError
         header={header}
-        message={error ? "無法載入題目資料" : "題目不存在"}
+        message={error ? t("edit.messages.loadFailed") : t("edit.messages.notFound")}
         onBack={() => navigate(-1)}
       />
     );

--- a/frontend/src/features/problems/screens/problemsIdEdit/components/ProblemEditExportModal.tsx
+++ b/frontend/src/features/problems/screens/problemsIdEdit/components/ProblemEditExportModal.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Modal, ContentSwitcher, Switch, Dropdown } from "@carbon/react";
 
 interface ProblemEditExportModalProps {
@@ -28,14 +29,15 @@ const ProblemEditExportModal: React.FC<ProblemEditExportModalProps> = ({
   pdfScale,
   onPdfScaleChange,
 }) => {
+  const { t } = useTranslation("problem");
   return (
     <Modal
       open={open}
       onRequestClose={onClose}
       onRequestSubmit={onConfirm}
-      modalHeading="匯出題目"
-      primaryButtonText="匯出"
-      secondaryButtonText="取消"
+      modalHeading={t("edit.exportModal.title")}
+      primaryButtonText={t("edit.exportModal.submit")}
+      secondaryButtonText={t("edit.exportModal.cancel")}
       size="sm"
       className="problem-edit-page__export-modal"
     >
@@ -54,8 +56,8 @@ const ProblemEditExportModal: React.FC<ProblemEditExportModalProps> = ({
           <div className="problem-edit-page__export-options">
             <Dropdown
               id="pdf-scale"
-              titleText="縮放比例"
-              label="選擇縮放比例"
+              titleText={t("edit.exportModal.scaleLabel")}
+              label={t("edit.exportModal.scalePlaceholder")}
               items={PDF_SCALE_OPTIONS}
               itemToString={(item) => (item ? item.text : "")}
               selectedItem={PDF_SCALE_OPTIONS.find(
@@ -72,7 +74,7 @@ const ProblemEditExportModal: React.FC<ProblemEditExportModalProps> = ({
 
         {exportFormat === "yaml" && (
           <p className="problem-edit-page__export-description">
-            將題目資料匯出為 YAML 格式，可用於備份或匯入至其他系統。
+            {t("edit.exportModal.description")}
           </p>
         )}
       </div>

--- a/frontend/src/features/problems/screens/problemsIdEdit/components/ProblemEditSections.tsx
+++ b/frontend/src/features/problems/screens/problemsIdEdit/components/ProblemEditSections.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import type { ProblemVisibility } from "@/core/entities/problem.entity";
 import type { NavSection } from "../section/layout";
 import { ScrollSpyLayout } from "../section/layout";
@@ -25,6 +26,7 @@ const ProblemEditSections: React.FC<ProblemEditSectionsProps> = ({
   onVisibilityChange,
   onDelete,
 }) => {
+  const { t } = useTranslation("problem");
   return (
     <ScrollSpyLayout sections={sections} onPreviewClick={onPreviewClick}>
       {({ registerSection }) => (
@@ -35,7 +37,7 @@ const ProblemEditSections: React.FC<ProblemEditSectionsProps> = ({
             ref={registerSection("basic-info")}
             className="problem-edit-page__section"
           >
-            <h2 className="problem-edit-page__section-title">基本資訊</h2>
+            <h2 className="problem-edit-page__section-title">{t("edit.sections.basicInfo")}</h2>
             <BasicInfoSection />
           </section>
 
@@ -45,7 +47,7 @@ const ProblemEditSections: React.FC<ProblemEditSectionsProps> = ({
             ref={registerSection("content")}
             className="problem-edit-page__section"
           >
-            <h2 className="problem-edit-page__section-title">題目內容</h2>
+            <h2 className="problem-edit-page__section-title">{t("edit.sections.content")}</h2>
             <ContentSection />
           </section>
 
@@ -55,7 +57,7 @@ const ProblemEditSections: React.FC<ProblemEditSectionsProps> = ({
             ref={registerSection("test-cases")}
             className="problem-edit-page__section"
           >
-            <h2 className="problem-edit-page__section-title">測試案例</h2>
+            <h2 className="problem-edit-page__section-title">{t("edit.sections.testCases")}</h2>
             <TestCasesSection />
           </section>
 
@@ -65,7 +67,7 @@ const ProblemEditSections: React.FC<ProblemEditSectionsProps> = ({
             ref={registerSection("language-config")}
             className="problem-edit-page__section"
           >
-            <h2 className="problem-edit-page__section-title">語言設定</h2>
+            <h2 className="problem-edit-page__section-title">{t("edit.sections.languageSettings")}</h2>
             <LanguageConfigSection />
           </section>
 

--- a/frontend/src/features/problems/screens/problemsIdEdit/components/ProblemEditState.tsx
+++ b/frontend/src/features/problems/screens/problemsIdEdit/components/ProblemEditState.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Loading, Button } from "@carbon/react";
 
 interface ProblemEditStateProps {
@@ -32,13 +33,14 @@ export const ProblemEditError: React.FC<ProblemEditErrorProps> = ({
   message,
   onBack,
 }) => {
+  const { t } = useTranslation("problem");
   return (
     <div className="problem-edit-page">
       {header}
       <div className="problem-edit-page__error">
         <h3>{message}</h3>
         <Button kind="secondary" onClick={onBack}>
-          返回
+          {t("edit.actions.back")}
         </Button>
       </div>
     </div>
@@ -48,14 +50,15 @@ export const ProblemEditError: React.FC<ProblemEditErrorProps> = ({
 export const ProblemEditPermissionDenied: React.FC<
   ProblemEditPermissionDeniedProps
 > = ({ header, onBack }) => {
+  const { t } = useTranslation("problem");
   return (
     <div className="problem-edit-page">
       {header}
       <div className="problem-edit-page__error">
-        <h3>權限不足</h3>
-        <p>您沒有編輯題目的權限</p>
+        <h3>{t("edit.messages.noPermissionTitle")}</h3>
+        <p>{t("edit.messages.noPermission")}</p>
         <Button kind="secondary" onClick={onBack}>
-          返回
+          {t("edit.actions.back")}
         </Button>
       </div>
     </div>

--- a/frontend/src/features/teacher/components/modals/CreateContestModal.tsx
+++ b/frontend/src/features/teacher/components/modals/CreateContestModal.tsx
@@ -87,7 +87,7 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
         minute: "2-digit",
         hour12: false,
       }).format(computedEndDate)
-    : "請先設定開始時間與有效的比賽長度";
+    : t("createModal.endTimePlaceholder");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -97,23 +97,23 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
     const duration = Number.parseInt(durationMinutes, 10);
 
     if (!startDateTime) {
-      setError(t("validation.invalidDateTime", "請選擇有效的開始時間"));
+      setError(t("validation.invalidDateTime"));
       return;
     }
 
     if (Number.isNaN(duration) || duration <= 0) {
-      setError("比賽長度必須是大於 0 的分鐘數");
+      setError(t("createModal.validation.durationPositive"));
       return;
     }
 
     if (isPrivate && !password.trim()) {
-      setError("私人競賽必須設定密碼");
+      setError(t("createModal.validation.passwordRequired"));
       return;
     }
 
     const endDateTime = computedEndDate?.toISOString();
     if (!endDateTime) {
-      setError("無法計算結束時間，請檢查開始時間與比賽長度");
+      setError(t("createModal.validation.cannotComputeEndTime"));
       return;
     }
 
@@ -137,7 +137,7 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
       const message =
         err instanceof Error
           ? err.message
-          : t("error.createFailed", "建立競賽失敗");
+          : t("error.createFailed");
       setError(message);
     } finally {
       setLoading(false);
@@ -156,8 +156,8 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
       onRequestClose={handleClose}
       modalHeading={
         creationType === "exam"
-          ? "新增紙筆題考試"
-          : tc("page.createContest")
+          ? t("createModal.titleExam")
+          : t("createModal.titleCoding")
       }
       primaryButtonText={tc("button.create")}
       secondaryButtonText={tc("button.cancel")}
@@ -188,8 +188,8 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
             aria-pressed={creationType === "coding_test"}
           >
             <Code size={24} />
-            <span className={styles.typeTitle}>Coding Test</span>
-            <span className={styles.typeSubtitle}>程式題為主，支援提交與判題</span>
+            <span className={styles.typeTitle}>{t("createModal.typeCoding")}</span>
+            <span className={styles.typeSubtitle}>{t("createModal.typeCodingDesc")}</span>
           </button>
           <button
             type="button"
@@ -200,26 +200,26 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
             aria-pressed={creationType === "exam"}
           >
             <Education size={24} />
-            <span className={styles.typeTitle}>紙筆題考試</span>
-            <span className={styles.typeSubtitle}>考卷題型，是非/選擇/問答</span>
+            <span className={styles.typeTitle}>{t("createModal.typeExam")}</span>
+            <span className={styles.typeSubtitle}>{t("createModal.typeExamDesc")}</span>
           </button>
         </div>
 
         <div className={styles.modeDescription}>
-          <strong>{creationType === "exam" ? "紙筆題考試模式" : "Coding Test 模式"}</strong>
+          <strong>{creationType === "exam" ? t("createModal.modeExam") : t("createModal.modeCoding")}</strong>
           <p>
             {creationType === "exam"
-              ? "學生以卷面作答，問答題可由助教批改。"
-              : "學生以程式題為主，走既有提交與排名流程。"}
+              ? t("createModal.descExam")
+              : t("createModal.descCoding")}
           </p>
         </div>
 
         <TextInput
           id="contest-name"
           labelText={
-            creationType === "exam" ? "紙筆題考試名稱" : tc("form.name")
+            creationType === "exam" ? t("createModal.nameExam") : t("createModal.nameCoding")
           }
-          placeholder={t("placeholder.contestName", "輸入競賽名稱")}
+          placeholder={t("placeholder.contestName")}
           value={name}
           onChange={(e) => setName(e.target.value)}
           required
@@ -245,7 +245,7 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
             <div className={styles.fieldBlock}>
               <TimePicker
                 id="start-time"
-                labelText={tc("form.startTime", "開始時間")}
+                labelText={tc("form.startTime")}
                 value={startTime}
                 onChange={(e) => setStartTime(e.target.value)}
                 className={styles.timeField}
@@ -254,7 +254,7 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
             <div className={styles.fieldBlock}>
               <TextInput
                 id="duration-minutes"
-                labelText="比賽長度（分鐘）"
+                labelText={t("createModal.duration")}
                 type="number"
                 min={1}
                 value={durationMinutes}
@@ -274,7 +274,7 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
                         : ""
                     }`}
                   >
-                    {minutes} 分
+                    {minutes} {t("createModal.durationUnit")}
                   </button>
                 ))}
               </div>
@@ -285,7 +285,7 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
         <div className={styles.endTimeHint}>
           <div className={styles.endTimeHintTitle}>
             <Calendar size={16} />
-            <span>預計結束時間</span>
+            <span>{t("createModal.endTime")}</span>
           </div>
           <div className={styles.endTimeHintValue}>
             <Time size={16} />
@@ -296,17 +296,17 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
         <div className={styles.privacySection}>
           <Toggle
             id="contest-private"
-            labelText="私人競賽"
+            labelText={t("createModal.private")}
             toggled={isPrivate}
             onToggle={(checked: boolean) => setIsPrivate(checked)}
-            labelA="公開"
-            labelB="私人"
+            labelA={t("createModal.public")}
+            labelB={t("createModal.privateShort")}
           />
           {isPrivate && (
             <TextInput
               id="contest-password"
-              labelText={t("hero.passwordLabel", "密碼")}
-              placeholder={t("hero.passwordPlaceholder", "請輸入競賽密碼")}
+              labelText={t("hero.passwordLabel")}
+              placeholder={t("hero.passwordPlaceholder")}
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -314,6 +314,7 @@ const CreateContestModal: React.FC<CreateContestModalProps> = ({
             />
           )}
         </div>
+
       </Form>
     </Modal>
   );

--- a/frontend/src/features/teacher/screens/TeacherContestsScreen.tsx
+++ b/frontend/src/features/teacher/screens/TeacherContestsScreen.tsx
@@ -38,7 +38,7 @@ const TeacherContestsScreen = ({
   embedded = false,
 }: TeacherContestsScreenProps) => {
   const navigate = useNavigate();
-  const { t } = useTranslation("common");
+  const { t, i18n } = useTranslation("common");
   const { t: tc } = useTranslation("contest");
 
   const { contests, isLoading, refetch, deleteContest, isDeleting } =
@@ -98,7 +98,7 @@ const TeacherContestsScreen = ({
 
   const formatDateTime = (dateString: string) => {
     const date = new Date(dateString);
-    return date.toLocaleString("zh-TW", {
+    return date.toLocaleString(i18n.language, {
       year: "numeric",
       month: "2-digit",
       day: "2-digit",
@@ -161,7 +161,6 @@ const TeacherContestsScreen = ({
           >
             {tc("management.contestCount", {
               count: filteredContests.length,
-              defaultValue: `共 ${filteredContests.length} 場競賽`,
             })}
           </h2>
           <Dropdown
@@ -284,7 +283,7 @@ const TeacherContestsScreen = ({
 
       <Modal
         open={deleteModalOpen}
-        modalHeading={tc("modal.confirmDelete", "確認刪除")}
+        modalHeading={tc("modal.confirmDelete")}
         primaryButtonText={t("button.delete")}
         secondaryButtonText={t("button.cancel")}
         onRequestClose={() => {
@@ -298,7 +297,6 @@ const TeacherContestsScreen = ({
         <p>
           {tc("modal.deleteConfirmMessage", {
             name: contestToDelete?.name,
-            defaultValue: `確定要刪除競賽「${contestToDelete?.name}」嗎？此操作無法復原。`,
           })}
         </p>
       </Modal>
@@ -323,14 +321,14 @@ const TeacherContestsScreen = ({
               color: "var(--cds-text-secondary)",
             }}
           >
-            {tc("management.description", "管理您建立的競賽")}
+            {tc("management.description")}
           </p>
           <Button
             kind="primary"
             renderIcon={Add}
             onClick={() => setIsCreateModalOpen(true)}
           >
-            {tc("button.createContest", "新增競賽")}
+            {tc("button.createContest")}
           </Button>
         </div>
         {tableContent}
@@ -379,7 +377,7 @@ const TeacherContestsScreen = ({
                       color: "var(--cds-text-secondary)",
                     }}
                   >
-                    {tc("management.description", "管理您建立的競賽")}
+                    {tc("management.description")}
                   </p>
                 </div>
                 <Button
@@ -387,7 +385,7 @@ const TeacherContestsScreen = ({
                   renderIcon={Add}
                   onClick={() => setIsCreateModalOpen(true)}
                 >
-                  {tc("button.createContest", "新增競賽")}
+                  {tc("button.createContest")}
                 </Button>
               </div>
             </div>

--- a/frontend/src/features/teacher/screens/TeacherDashboardScreen.test.tsx
+++ b/frontend/src/features/teacher/screens/TeacherDashboardScreen.test.tsx
@@ -41,6 +41,6 @@ describe("TeacherDashboardScreen", () => {
 
   it("renders the dashboard title", () => {
     render(<TeacherDashboardScreen />);
-    expect(screen.getByText("教師後台")).toBeInTheDocument();
+    expect(screen.getByText("page.teacherDashboard")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/teacher/screens/TeacherDashboardScreen.tsx
+++ b/frontend/src/features/teacher/screens/TeacherDashboardScreen.tsx
@@ -20,7 +20,7 @@ const TeacherDashboardScreen = () => {
         <div className={styles.content}>
           <div className={styles.inner}>
             <h1 className={styles.title}>
-              {t("page.teacherDashboard", "教師後台")}
+              {t("page.teacherDashboard")}
             </h1>
 
             <Tabs

--- a/frontend/src/features/teacher/screens/TeacherProblemsScreen.tsx
+++ b/frontend/src/features/teacher/screens/TeacherProblemsScreen.tsx
@@ -140,7 +140,6 @@ const TeacherProblemsScreen = ({
         >
           {tp("management.problemCount", {
             count: totalCount,
-            defaultValue: `共 ${totalCount} 道題目`,
           })}
         </h2>
         <TableContainer>
@@ -262,7 +261,7 @@ const TeacherProblemsScreen = ({
 
       <Modal
         open={deleteModalOpen}
-        modalHeading={tp("modal.confirmDelete", "確認刪除")}
+        modalHeading={tp("modal.confirmDelete")}
         primaryButtonText={t("button.delete")}
         secondaryButtonText={t("button.cancel")}
         onRequestClose={() => {
@@ -276,7 +275,6 @@ const TeacherProblemsScreen = ({
         <p>
           {tp("modal.deleteConfirmMessage", {
             title: problemToDelete?.title,
-            defaultValue: `確定要刪除題目「${problemToDelete?.title}」嗎？此操作無法復原。`,
           })}
         </p>
       </Modal>
@@ -301,7 +299,7 @@ const TeacherProblemsScreen = ({
               color: "var(--cds-text-secondary)",
             }}
           >
-            {tp("management.description", "管理您建立的題目")}
+            {tp("management.description")}
           </p>
           <Button
             kind="primary"
@@ -357,7 +355,7 @@ const TeacherProblemsScreen = ({
                       color: "var(--cds-text-secondary)",
                     }}
                   >
-                    {tp("management.description", "管理您建立的題目")}
+                    {tp("management.description")}
                   </p>
                 </div>
                 <Button

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -8,6 +8,8 @@ import zhTWContest from "./locales/zh-TW/contest.json";
 import zhTWAdmin from "./locales/zh-TW/admin.json";
 import zhTWDocs from "./locales/zh-TW/docs.json";
 import zhTWLanding from "./locales/zh-TW/landing.json";
+import zhTWClassroom from "./locales/zh-TW/classroom.json";
+import zhTWChatbot from "./locales/zh-TW/chatbot.json";
 
 // English
 import enCommon from "./locales/en/common.json";
@@ -16,6 +18,8 @@ import enContest from "./locales/en/contest.json";
 import enAdmin from "./locales/en/admin.json";
 import enDocs from "./locales/en/docs.json";
 import enLanding from "./locales/en/landing.json";
+import enClassroom from "./locales/en/classroom.json";
+import enChatbot from "./locales/en/chatbot.json";
 
 // Japanese
 import jaCommon from "./locales/ja/common.json";
@@ -24,6 +28,8 @@ import jaContest from "./locales/ja/contest.json";
 import jaAdmin from "./locales/ja/admin.json";
 import jaDocs from "./locales/ja/docs.json";
 import jaLanding from "./locales/ja/landing.json";
+import jaClassroom from "./locales/ja/classroom.json";
+import jaChatbot from "./locales/ja/chatbot.json";
 
 // Korean
 import koCommon from "./locales/ko/common.json";
@@ -32,6 +38,8 @@ import koContest from "./locales/ko/contest.json";
 import koAdmin from "./locales/ko/admin.json";
 import koDocs from "./locales/ko/docs.json";
 import koLanding from "./locales/ko/landing.json";
+import koClassroom from "./locales/ko/classroom.json";
+import koChatbot from "./locales/ko/chatbot.json";
 
 const resources = {
   "zh-TW": {
@@ -41,6 +49,8 @@ const resources = {
     admin: zhTWAdmin,
     docs: zhTWDocs,
     landing: zhTWLanding,
+    classroom: zhTWClassroom,
+    chatbot: zhTWChatbot,
   },
   en: {
     common: enCommon,
@@ -49,6 +59,8 @@ const resources = {
     admin: enAdmin,
     docs: enDocs,
     landing: enLanding,
+    classroom: enClassroom,
+    chatbot: enChatbot,
   },
   ja: {
     common: jaCommon,
@@ -57,6 +69,8 @@ const resources = {
     admin: jaAdmin,
     docs: jaDocs,
     landing: jaLanding,
+    classroom: jaClassroom,
+    chatbot: jaChatbot,
   },
   ko: {
     common: koCommon,
@@ -65,6 +79,8 @@ const resources = {
     admin: koAdmin,
     docs: koDocs,
     landing: koLanding,
+    classroom: koClassroom,
+    chatbot: koChatbot,
   },
 };
 
@@ -82,7 +98,7 @@ i18n.use(initReactI18next).init({
   resources,
   lng: "zh-TW",
   fallbackLng: "zh-TW",
-  ns: ["common", "problem", "contest", "admin", "docs", "landing"],
+  ns: ["common", "problem", "contest", "admin", "docs", "landing", "classroom", "chatbot"],
   defaultNS: "common",
   interpolation: {
     escapeValue: false,

--- a/frontend/src/i18n/locales/en/chatbot.json
+++ b/frontend/src/i18n/locales/en/chatbot.json
@@ -1,0 +1,74 @@
+{
+  "errors": {
+    "loadSessionsFailed": "Failed to load chat history",
+    "createSessionFailed": "Failed to create new conversation",
+    "deleteSessionFailed": "Failed to delete conversation",
+    "renameSessionFailed": "Failed to rename conversation",
+    "sendMessageFailed": "Failed to send message",
+    "createBackendSessionFailed": "Failed to establish connection, please try again later",
+    "aiServiceUnavailable": "Sorry, AI service is temporarily unavailable. Please try again later.",
+    "resumeAgentFailed": "Failed to resume agent execution",
+    "confirmActionFailed": "Failed to confirm action, please try again",
+    "cancelActionFailed": "Failed to cancel action",
+    "submitAnswerFailed": "Failed to submit answer",
+    "resumeAfterAnswerFailed": "Answer sent, but failed to resume stream. Please refresh the page.",
+    "unknownError": "Unknown error"
+  },
+  "widget": {
+    "expandLabel": "Expand Qgent TA",
+    "chatbotTitle": "Qgent TA",
+    "newChat": "New Chat",
+    "inputPlaceholder": "Type a message...",
+    "thinking": "Thinking...",
+    "sessions": "Chat History",
+    "rename": "Rename",
+    "delete": "Delete",
+    "addChat": "New Chat",
+    "collapse": "Collapse Panel",
+    "newChatLabel": "New Chat",
+    "renameModal": {
+      "title": "Rename Chat",
+      "submit": "Save",
+      "cancel": "Cancel",
+      "label": "New Name",
+      "placeholder": "Enter new chat name"
+    },
+    "deleteModal": {
+      "title": "Confirm Delete",
+      "submit": "Delete",
+      "submitting": "Deleting...",
+      "cancel": "Cancel",
+      "confirmMessage": "Are you sure you want to delete conversation \"{{title}}\"?",
+      "undoWarning": "This action cannot be undone."
+    }
+  },
+  "prompts": {
+    "designTestCases": "Help me design test cases",
+    "designTestCasesPrompt": "Please help me design test cases for this problem, including edge cases and special conditions.",
+    "generateDescription": "Generate description examples",
+    "generateDescriptionPrompt": "Please help me generate description examples for this problem to make it easier for students to understand.",
+    "checkCompleteness": "Check problem completeness",
+    "checkCompletenessPrompt": "Please check the completeness of this problem, including descriptions, test cases, and constraints.",
+    "optimizeDifficulty": "Optimize difficulty settings",
+    "optimizeDifficultyPrompt": "Please evaluate and suggest if the difficulty setting for this problem is appropriate.",
+    "howToDesign": "How to design a good problem?",
+    "howToDesignPrompt": "Please teach me how to design a good programming problem?",
+    "testCaseSkills": "Test case design skills",
+    "testCaseSkillsPrompt": "Please share techniques and best practices for test case design."
+  },
+  "welcome": {
+    "title": "How can I help you?",
+    "subtitle": "Assisting with: {{title}}"
+  },
+  "approval": {
+    "title": "Approval Required",
+    "confirm": "Confirm Action",
+    "cancel": "Cancel",
+    "preview": "Preview Changes"
+  },
+  "userInput": {
+    "title": "Question",
+    "submit": "Submit Answer",
+    "cancel": "Skip"
+  }
+}

--- a/frontend/src/i18n/locales/en/classroom.json
+++ b/frontend/src/i18n/locales/en/classroom.json
@@ -1,0 +1,53 @@
+{
+  "members": {
+    "headers": {
+      "username": "Username",
+      "email": "Email",
+      "role": "Role",
+      "joinedAt": "Joined At"
+    },
+    "actions": {
+      "remove": "Remove"
+    }
+  },
+  "announcement": {
+    "modal": {
+      "titleCreate": "Post Announcement",
+      "titleEdit": "Edit Announcement",
+      "submitCreate": "Post",
+      "submitEdit": "Save",
+      "submittingCreate": "Posting...",
+      "submittingEdit": "Saving...",
+      "cancel": "Cancel",
+      "form": {
+        "title": "Title",
+        "titlePlaceholder": "Announcement Title",
+        "pinned": "Pinned",
+        "content": "Content",
+        "contentPlaceholder": "Enter announcement content, Markdown supported...",
+        "yes": "Yes",
+        "no": "No"
+      }
+    }
+  },
+  "inviteCode": {
+    "label": "Invite Code",
+    "disabled": "Disabled",
+    "copy": "Copy",
+    "copied": "Copied",
+    "regenerate": "Regenerate"
+  },
+  "bindContest": {
+    "modal": {
+      "title": "Bind Contest",
+      "submit": "Bind",
+      "submitting": "Binding...",
+      "cancel": "Cancel",
+      "noContests": "No contests available to bind",
+      "table": {
+        "name": "Contest Name",
+        "status": "Status"
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -25,7 +25,10 @@
     "environment": "Environment",
     "createContest": "Create Contest",
     "createProblem": "Create Problem",
-    "editProblem": "Edit Problem"
+    "editProblem": "Edit Problem",
+    "teacherDashboard": "Teacher Dashboard",
+    "problemManagement": "Problem Management",
+    "contestManagement": "Contest Management"
   },
   "tab": {
     "overview": "Overview",

--- a/frontend/src/i18n/locales/en/contest.json
+++ b/frontend/src/i18n/locales/en/contest.json
@@ -102,6 +102,24 @@
   "duration": "Duration",
   "progress": "Progress",
   "notActive": "Not Running",
+  "preRegistration": {
+    "state": {
+      "draft": "Draft",
+      "archived": "Archived",
+      "upcoming": "Upcoming",
+      "running": "Running",
+      "ended": "Ended"
+    },
+    "noDescription": "No description yet",
+    "registerNow": "Register now",
+    "registeredHint": "Registered. Waiting for contest start.",
+    "registrationClosed": "Registration unavailable",
+    "ended": "Contest ended",
+    "openAdminPanel": "Open Admin Panel",
+    "anonymousTitle": "Anonymous Mode",
+    "countdownLabel": "Starts in",
+    "countdownValue": "{{days}}d {{hours}}h {{minutes}}m {{seconds}}s"
+  },
   "precheck": {
     "title": "Exam Pre-check",
     "description": "To ensure fairness, please complete the environment and eligibility checks before entering the exam room. Failure to pass necessary checks will restrict your access.",
@@ -613,6 +631,32 @@
     "autoSubmittedDesc": "Screen sharing was interrupted and could not be restored within the time limit. Your exam has been automatically submitted.",
     "autoSubmittedHint": "If you believe this was an error, please contact your proctor.",
     "returnToDashboard": "Return to Dashboard"
+  },
+  "createModal": {
+    "titleCoding": "Create Coding Test",
+    "titleExam": "Create Paper Exam",
+    "typeCoding": "Coding Test",
+    "typeCodingDesc": "Coding problems with automatic submission and judging",
+    "typeExam": "Paper Exam",
+    "typeExamDesc": "Question types including True/False, Multiple Choice, and Essay",
+    "modeCoding": "Coding Test Mode",
+    "modeExam": "Paper Exam Mode",
+    "descCoding": "Students focus on coding problems with existing submission and ranking flow.",
+    "descExam": "Students answer on screen, essay questions can be graded by TAs.",
+    "nameCoding": "Contest Name",
+    "nameExam": "Paper Exam Name",
+    "duration": "Duration (minutes)",
+    "durationUnit": "min",
+    "endTime": "Estimated End Time",
+    "endTimePlaceholder": "Set start time and valid duration first",
+    "private": "Private Contest",
+    "public": "Public",
+    "privateShort": "Private",
+    "validation": {
+      "durationPositive": "Duration must be greater than 0 minutes",
+      "passwordRequired": "Password is required for private contests",
+      "cannotComputeEndTime": "Cannot compute end time, please check start time and duration"
+    }
   },
   "settings": {
     "title": "Contest Settings",

--- a/frontend/src/i18n/locales/en/problem.json
+++ b/frontend/src/i18n/locales/en/problem.json
@@ -98,5 +98,48 @@
     "easy": "Easy",
     "medium": "Medium",
     "hard": "Hard"
+  },
+  "edit": {
+    "sections": {
+      "basicInfo": "Basic Information",
+      "content": "Problem Content",
+      "testCases": "Test Cases",
+      "languageSettings": "Language Settings"
+    },
+    "actions": {
+      "import": "Import",
+      "export": "Export",
+      "preview": "Preview",
+      "save": "Save",
+      "delete": "Delete",
+      "back": "Back"
+    },
+    "messages": {
+      "importSuccess": "Import Successful",
+      "importSuccessDetail": "YAML data imported and saved",
+      "importSuccessSaveFailed": "Import successful, but auto-save failed",
+      "deleteSuccess": "Delete Successful",
+      "deleteSuccessDetail": "Redirecting...",
+      "deleteFailed": "Delete Failed",
+      "exportSuccess": "YAML Export Successful",
+      "exportSuccessDetail": "File downloaded",
+      "loadFailed": "Failed to load problem data",
+      "notFound": "Problem not found",
+      "noPermission": "You do not have permission to edit this problem",
+      "noPermissionTitle": "Permission Denied"
+    },
+    "status": {
+      "public": "Problem is now public",
+      "private": "Problem set to private",
+      "hidden": "Problem hidden"
+    },
+    "exportModal": {
+      "title": "Export Problem",
+      "submit": "Export",
+      "cancel": "Cancel",
+      "scaleLabel": "Scale",
+      "scalePlaceholder": "Select scale",
+      "description": "Export problem data as YAML for backup or import to other systems."
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja/chatbot.json
+++ b/frontend/src/i18n/locales/ja/chatbot.json
@@ -1,0 +1,74 @@
+{
+  "errors": {
+    "loadSessionsFailed": "Failed to load chat history",
+    "createSessionFailed": "Failed to create new conversation",
+    "deleteSessionFailed": "Failed to delete conversation",
+    "renameSessionFailed": "Failed to rename conversation",
+    "sendMessageFailed": "Failed to send message",
+    "createBackendSessionFailed": "Failed to establish connection, please try again later",
+    "aiServiceUnavailable": "Sorry, AI service is temporarily unavailable. Please try again later.",
+    "resumeAgentFailed": "Failed to resume agent execution",
+    "confirmActionFailed": "Failed to confirm action, please try again",
+    "cancelActionFailed": "Failed to cancel action",
+    "submitAnswerFailed": "Failed to submit answer",
+    "resumeAfterAnswerFailed": "Answer sent, but failed to resume stream. Please refresh the page.",
+    "unknownError": "Unknown error"
+  },
+  "widget": {
+    "expandLabel": "Expand Qgent TA",
+    "chatbotTitle": "Qgent TA",
+    "newChat": "New Chat",
+    "inputPlaceholder": "Type a message...",
+    "thinking": "Thinking...",
+    "sessions": "Chat History",
+    "rename": "Rename",
+    "delete": "Delete",
+    "addChat": "New Chat",
+    "collapse": "Collapse Panel",
+    "newChatLabel": "New Chat",
+    "renameModal": {
+      "title": "Rename Chat",
+      "submit": "Save",
+      "cancel": "Cancel",
+      "label": "New Name",
+      "placeholder": "Enter new chat name"
+    },
+    "deleteModal": {
+      "title": "Confirm Delete",
+      "submit": "Delete",
+      "submitting": "Deleting...",
+      "cancel": "Cancel",
+      "confirmMessage": "Are you sure you want to delete conversation \"{{title}}\"?",
+      "undoWarning": "This action cannot be undone."
+    }
+  },
+  "prompts": {
+    "designTestCases": "Help me design test cases",
+    "designTestCasesPrompt": "Please help me design test cases for this problem, including edge cases and special conditions.",
+    "generateDescription": "Generate description examples",
+    "generateDescriptionPrompt": "Please help me generate description examples for this problem to make it easier for students to understand.",
+    "checkCompleteness": "Check problem completeness",
+    "checkCompletenessPrompt": "Please check the completeness of this problem, including descriptions, test cases, and constraints.",
+    "optimizeDifficulty": "Optimize difficulty settings",
+    "optimizeDifficultyPrompt": "Please evaluate and suggest if the difficulty setting for this problem is appropriate.",
+    "howToDesign": "How to design a good problem?",
+    "howToDesignPrompt": "Please teach me how to design a good programming problem?",
+    "testCaseSkills": "Test case design skills",
+    "testCaseSkillsPrompt": "Please share techniques and best practices for test case design."
+  },
+  "welcome": {
+    "title": "How can I help you?",
+    "subtitle": "Assisting with: {{title}}"
+  },
+  "approval": {
+    "title": "Approval Required",
+    "confirm": "Confirm Action",
+    "cancel": "Cancel",
+    "preview": "Preview Changes"
+  },
+  "userInput": {
+    "title": "Question",
+    "submit": "Submit Answer",
+    "cancel": "Skip"
+  }
+}

--- a/frontend/src/i18n/locales/ja/classroom.json
+++ b/frontend/src/i18n/locales/ja/classroom.json
@@ -1,0 +1,53 @@
+{
+  "members": {
+    "headers": {
+      "username": "Username",
+      "email": "Email",
+      "role": "Role",
+      "joinedAt": "Joined At"
+    },
+    "actions": {
+      "remove": "Remove"
+    }
+  },
+  "announcement": {
+    "modal": {
+      "titleCreate": "Post Announcement",
+      "titleEdit": "Edit Announcement",
+      "submitCreate": "Post",
+      "submitEdit": "Save",
+      "submittingCreate": "Posting...",
+      "submittingEdit": "Saving...",
+      "cancel": "Cancel",
+      "form": {
+        "title": "Title",
+        "titlePlaceholder": "Announcement Title",
+        "pinned": "Pinned",
+        "content": "Content",
+        "contentPlaceholder": "Enter announcement content, Markdown supported...",
+        "yes": "Yes",
+        "no": "No"
+      }
+    }
+  },
+  "inviteCode": {
+    "label": "Invite Code",
+    "disabled": "Disabled",
+    "copy": "Copy",
+    "copied": "Copied",
+    "regenerate": "Regenerate"
+  },
+  "bindContest": {
+    "modal": {
+      "title": "Bind Contest",
+      "submit": "Bind",
+      "submitting": "Binding...",
+      "cancel": "Cancel",
+      "noContests": "No contests available to bind",
+      "table": {
+        "name": "Contest Name",
+        "status": "Status"
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -23,10 +23,13 @@
     "userManagement": "ユーザー管理",
     "announcements": "お知らせ管理",
     "environment": "環境設定",
-    "createContest": "コンテスト作成",
-    "createProblem": "問題作成",
-    "editProblem": "問題編集"
-  },
+    "createContest": "コンテストを作成",
+    "createProblem": "問題を新規作成",
+    "editProblem": "問題を編集",
+    "teacherDashboard": "Teacher Dashboard",
+    "problemManagement": "Problem Management",
+    "contestManagement": "Contest Management"
+    },
   "tab": {
     "overview": "概要",
     "problems": "問題",

--- a/frontend/src/i18n/locales/ja/contest.json
+++ b/frontend/src/i18n/locales/ja/contest.json
@@ -102,6 +102,24 @@
   "duration": "期間",
   "progress": "進捗",
   "notActive": "進行なし",
+  "preRegistration": {
+    "state": {
+      "draft": "下書き",
+      "archived": "アーカイブ済み",
+      "upcoming": "開始前",
+      "running": "開催中",
+      "ended": "終了"
+    },
+    "noDescription": "説明はまだありません",
+    "registerNow": "今すぐ参加登録",
+    "registeredHint": "登録済みです。開始をお待ちください。",
+    "registrationClosed": "現在は登録できません",
+    "ended": "コンテストは終了しました",
+    "openAdminPanel": "管理画面へ",
+    "anonymousTitle": "匿名モード",
+    "countdownLabel": "開始まで",
+    "countdownValue": "{{days}}日 {{hours}}時間 {{minutes}}分 {{seconds}}秒"
+  },
   "precheck": {
     "title": "事前チェック",
     "description": "公平性を保つため、試験開始前に環境と資格のチェックを完了してください。必要なチェックに合格しない場合、試験へのアクセスが制限されます。",
@@ -610,6 +628,32 @@
     "autoSubmittedDesc": "画面共有が中断され、制限時間内に再共有できなかったため、システムが自動的に提出しました。",
     "autoSubmittedHint": "エラーだと思われる場合は、試験監督にお問い合わせください。",
     "returnToDashboard": "ダッシュボードに戻る"
+  },
+  "createModal": {
+    "titleCoding": "Create Coding Test",
+    "titleExam": "Create Paper Exam",
+    "typeCoding": "Coding Test",
+    "typeCodingDesc": "Coding problems with automatic submission and judging",
+    "typeExam": "Paper Exam",
+    "typeExamDesc": "Question types including True/False, Multiple Choice, and Essay",
+    "modeCoding": "Coding Test Mode",
+    "modeExam": "Paper Exam Mode",
+    "descCoding": "Students focus on coding problems with existing submission and ranking flow.",
+    "descExam": "Students answer on screen, essay questions can be graded by TAs.",
+    "nameCoding": "Contest Name",
+    "nameExam": "Paper Exam Name",
+    "duration": "Duration (minutes)",
+    "durationUnit": "min",
+    "endTime": "Estimated End Time",
+    "endTimePlaceholder": "Set start time and valid duration first",
+    "private": "Private Contest",
+    "public": "Public",
+    "privateShort": "Private",
+    "validation": {
+      "durationPositive": "Duration must be greater than 0 minutes",
+      "passwordRequired": "Password is required for private contests",
+      "cannotComputeEndTime": "Cannot compute end time, please check start time and duration"
+    }
   },
   "settings": {
     "title": "コンテスト設定",

--- a/frontend/src/i18n/locales/ja/problem.json
+++ b/frontend/src/i18n/locales/ja/problem.json
@@ -98,5 +98,48 @@
     "easy": "簡単",
     "medium": "普通",
     "hard": "難しい"
+  },
+  "edit": {
+    "sections": {
+      "basicInfo": "基本情報",
+      "content": "問題内容",
+      "testCases": "テストケース",
+      "languageSettings": "言語設定"
+    },
+    "actions": {
+      "import": "インポート",
+      "export": "エクスポート",
+      "preview": "プレビュー",
+      "save": "保存",
+      "delete": "削除",
+      "back": "戻る"
+    },
+    "messages": {
+      "importSuccess": "インポート成功",
+      "importSuccessDetail": "YAMLデータがインポートされ保存されました",
+      "importSuccessSaveFailed": "インポートには成功しましたが、自動保存に失敗しました",
+      "deleteSuccess": "削除成功",
+      "deleteSuccessDetail": "リダイレクト中...",
+      "deleteFailed": "削除失敗",
+      "exportSuccess": "YAMLエクスポート成功",
+      "exportSuccessDetail": "ファイルがダウンロードされました",
+      "loadFailed": "問題データの読み込みに失敗しました",
+      "notFound": "問題が見つかりません",
+      "noPermission": "この問題を編集する権限がありません",
+      "noPermissionTitle": "権限がありません"
+    },
+    "status": {
+      "public": "問題が公開されました",
+      "private": "問題が非公開に設定されました",
+      "hidden": "問題が非表示になりました"
+    },
+    "exportModal": {
+      "title": "問題をエクスポート",
+      "submit": "エクスポート",
+      "cancel": "キャンセル",
+      "scaleLabel": "スケール",
+      "scalePlaceholder": "スケールを選択",
+      "description": "バックアップや他のシステムへのインポート用に、問題データをYAML形式でエクスポートします。"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ko/chatbot.json
+++ b/frontend/src/i18n/locales/ko/chatbot.json
@@ -1,0 +1,74 @@
+{
+  "errors": {
+    "loadSessionsFailed": "Failed to load chat history",
+    "createSessionFailed": "Failed to create new conversation",
+    "deleteSessionFailed": "Failed to delete conversation",
+    "renameSessionFailed": "Failed to rename conversation",
+    "sendMessageFailed": "Failed to send message",
+    "createBackendSessionFailed": "Failed to establish connection, please try again later",
+    "aiServiceUnavailable": "Sorry, AI service is temporarily unavailable. Please try again later.",
+    "resumeAgentFailed": "Failed to resume agent execution",
+    "confirmActionFailed": "Failed to confirm action, please try again",
+    "cancelActionFailed": "Failed to cancel action",
+    "submitAnswerFailed": "Failed to submit answer",
+    "resumeAfterAnswerFailed": "Answer sent, but failed to resume stream. Please refresh the page.",
+    "unknownError": "Unknown error"
+  },
+  "widget": {
+    "expandLabel": "Expand Qgent TA",
+    "chatbotTitle": "Qgent TA",
+    "newChat": "New Chat",
+    "inputPlaceholder": "Type a message...",
+    "thinking": "Thinking...",
+    "sessions": "Chat History",
+    "rename": "Rename",
+    "delete": "Delete",
+    "addChat": "New Chat",
+    "collapse": "Collapse Panel",
+    "newChatLabel": "New Chat",
+    "renameModal": {
+      "title": "Rename Chat",
+      "submit": "Save",
+      "cancel": "Cancel",
+      "label": "New Name",
+      "placeholder": "Enter new chat name"
+    },
+    "deleteModal": {
+      "title": "Confirm Delete",
+      "submit": "Delete",
+      "submitting": "Deleting...",
+      "cancel": "Cancel",
+      "confirmMessage": "Are you sure you want to delete conversation \"{{title}}\"?",
+      "undoWarning": "This action cannot be undone."
+    }
+  },
+  "prompts": {
+    "designTestCases": "Help me design test cases",
+    "designTestCasesPrompt": "Please help me design test cases for this problem, including edge cases and special conditions.",
+    "generateDescription": "Generate description examples",
+    "generateDescriptionPrompt": "Please help me generate description examples for this problem to make it easier for students to understand.",
+    "checkCompleteness": "Check problem completeness",
+    "checkCompletenessPrompt": "Please check the completeness of this problem, including descriptions, test cases, and constraints.",
+    "optimizeDifficulty": "Optimize difficulty settings",
+    "optimizeDifficultyPrompt": "Please evaluate and suggest if the difficulty setting for this problem is appropriate.",
+    "howToDesign": "How to design a good problem?",
+    "howToDesignPrompt": "Please teach me how to design a good programming problem?",
+    "testCaseSkills": "Test case design skills",
+    "testCaseSkillsPrompt": "Please share techniques and best practices for test case design."
+  },
+  "welcome": {
+    "title": "How can I help you?",
+    "subtitle": "Assisting with: {{title}}"
+  },
+  "approval": {
+    "title": "Approval Required",
+    "confirm": "Confirm Action",
+    "cancel": "Cancel",
+    "preview": "Preview Changes"
+  },
+  "userInput": {
+    "title": "Question",
+    "submit": "Submit Answer",
+    "cancel": "Skip"
+  }
+}

--- a/frontend/src/i18n/locales/ko/classroom.json
+++ b/frontend/src/i18n/locales/ko/classroom.json
@@ -1,0 +1,53 @@
+{
+  "members": {
+    "headers": {
+      "username": "Username",
+      "email": "Email",
+      "role": "Role",
+      "joinedAt": "Joined At"
+    },
+    "actions": {
+      "remove": "Remove"
+    }
+  },
+  "announcement": {
+    "modal": {
+      "titleCreate": "Post Announcement",
+      "titleEdit": "Edit Announcement",
+      "submitCreate": "Post",
+      "submitEdit": "Save",
+      "submittingCreate": "Posting...",
+      "submittingEdit": "Saving...",
+      "cancel": "Cancel",
+      "form": {
+        "title": "Title",
+        "titlePlaceholder": "Announcement Title",
+        "pinned": "Pinned",
+        "content": "Content",
+        "contentPlaceholder": "Enter announcement content, Markdown supported...",
+        "yes": "Yes",
+        "no": "No"
+      }
+    }
+  },
+  "inviteCode": {
+    "label": "Invite Code",
+    "disabled": "Disabled",
+    "copy": "Copy",
+    "copied": "Copied",
+    "regenerate": "Regenerate"
+  },
+  "bindContest": {
+    "modal": {
+      "title": "Bind Contest",
+      "submit": "Bind",
+      "submitting": "Binding...",
+      "cancel": "Cancel",
+      "noContests": "No contests available to bind",
+      "table": {
+        "name": "Contest Name",
+        "status": "Status"
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -25,7 +25,10 @@
     "environment": "환경 설정",
     "createContest": "대회 생성",
     "createProblem": "문제 생성",
-    "editProblem": "문제 편집"
+    "editProblem": "문제 편집",
+    "teacherDashboard": "Teacher Dashboard",
+    "problemManagement": "Problem Management",
+    "contestManagement": "Contest Management"
   },
   "tab": {
     "overview": "개요",

--- a/frontend/src/i18n/locales/ko/contest.json
+++ b/frontend/src/i18n/locales/ko/contest.json
@@ -102,6 +102,24 @@
   "duration": "기간",
   "progress": "진행률",
   "notActive": "진행 아님",
+  "preRegistration": {
+    "state": {
+      "draft": "초안",
+      "archived": "보관됨",
+      "upcoming": "시작 예정",
+      "running": "진행 중",
+      "ended": "종료됨"
+    },
+    "noDescription": "설명이 없습니다",
+    "registerNow": "지금 등록",
+    "registeredHint": "등록 완료. 대회 시작을 기다려 주세요.",
+    "registrationClosed": "현재 등록할 수 없습니다",
+    "ended": "대회가 종료되었습니다",
+    "openAdminPanel": "관리 화면으로 이동",
+    "anonymousTitle": "익명 모드",
+    "countdownLabel": "시작까지",
+    "countdownValue": "{{days}}일 {{hours}}시간 {{minutes}}분 {{seconds}}초"
+  },
   "precheck": {
     "title": "사전 체크",
     "description": "공정성을 유지하기 위해 시험 시작 전 환경 및 자격 체크를 완료해 주세요. 필요한 체크를 통과하지 못하면 시험에 대한 액세스가 제한될 수 있습니다.",
@@ -612,6 +630,32 @@
     "autoSubmittedDesc": "화면 공유가 중단되었고 제한 시간 내에 복구되지 않아 시스템이 자동으로 제출했습니다.",
     "autoSubmittedHint": "오류라고 생각되면 감독관에게 문의하세요.",
     "returnToDashboard": "대시보드로 돌아가기"
+  },
+  "createModal": {
+    "titleCoding": "Create Coding Test",
+    "titleExam": "Create Paper Exam",
+    "typeCoding": "Coding Test",
+    "typeCodingDesc": "Coding problems with automatic submission and judging",
+    "typeExam": "Paper Exam",
+    "typeExamDesc": "Question types including True/False, Multiple Choice, and Essay",
+    "modeCoding": "Coding Test Mode",
+    "modeExam": "Paper Exam Mode",
+    "descCoding": "Students focus on coding problems with existing submission and ranking flow.",
+    "descExam": "Students answer on screen, essay questions can be graded by TAs.",
+    "nameCoding": "Contest Name",
+    "nameExam": "Paper Exam Name",
+    "duration": "Duration (minutes)",
+    "durationUnit": "min",
+    "endTime": "Estimated End Time",
+    "endTimePlaceholder": "Set start time and valid duration first",
+    "private": "Private Contest",
+    "public": "Public",
+    "privateShort": "Private",
+    "validation": {
+      "durationPositive": "Duration must be greater than 0 minutes",
+      "passwordRequired": "Password is required for private contests",
+      "cannotComputeEndTime": "Cannot compute end time, please check start time and duration"
+    }
   },
   "settings": {
     "title": "대회 설정",

--- a/frontend/src/i18n/locales/ko/problem.json
+++ b/frontend/src/i18n/locales/ko/problem.json
@@ -98,5 +98,48 @@
     "easy": "쉬움",
     "medium": "보통",
     "hard": "어려움"
+  },
+  "edit": {
+    "sections": {
+      "basicInfo": "기본 정보",
+      "content": "문제 내용",
+      "testCases": "테스트 케이스",
+      "languageSettings": "언어 설정"
+    },
+    "actions": {
+      "import": "가져오기",
+      "export": "내보내기",
+      "preview": "미리보기",
+      "save": "저장",
+      "delete": "삭제",
+      "back": "뒤로"
+    },
+    "messages": {
+      "importSuccess": "가져오기 성공",
+      "importSuccessDetail": "YAML 데이터를 가져와 저장했습니다",
+      "importSuccessSaveFailed": "가져오기는 성공했지만 자동 저장에 실패했습니다",
+      "deleteSuccess": "삭제 성공",
+      "deleteSuccessDetail": "리다이렉트 중...",
+      "deleteFailed": "삭제 실패",
+      "exportSuccess": "YAML 내보내기 성공",
+      "exportSuccessDetail": "파일이 다운로드되었습니다",
+      "loadFailed": "문제 데이터를 불러오는 데 실패했습니다",
+      "notFound": "문제를 찾을 수 없습니다",
+      "noPermission": "이 문제를 편집할 권한이 없습니다",
+      "noPermissionTitle": "권한 없음"
+    },
+    "status": {
+      "public": "문제가 공개되었습니다",
+      "private": "문제가 비공개로 설정되었습니다",
+      "hidden": "문제가 숨김 처리되었습니다"
+    },
+    "exportModal": {
+      "title": "문제 내보내기",
+      "submit": "내보내기",
+      "cancel": "취소",
+      "scaleLabel": "비율",
+      "scalePlaceholder": "비율 선택",
+      "description": "백업이나 다른 시스템으로 가져오기 위해 문제 데이터를 YAML 형식으로 내보냅니다."
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh-TW/chatbot.json
+++ b/frontend/src/i18n/locales/zh-TW/chatbot.json
@@ -1,0 +1,74 @@
+{
+  "errors": {
+    "loadSessionsFailed": "無法載入對話記錄",
+    "createSessionFailed": "無法創建新對話",
+    "deleteSessionFailed": "無法刪除對話",
+    "renameSessionFailed": "無法重新命名對話",
+    "sendMessageFailed": "無法發送訊息",
+    "createBackendSessionFailed": "無法建立對話，請稍後再試",
+    "aiServiceUnavailable": "抱歉，AI 服務暫時無法使用，請稍後再試。",
+    "resumeAgentFailed": "無法恢復 agent 執行",
+    "confirmActionFailed": "確認操作失敗，請重試",
+    "cancelActionFailed": "取消操作失敗",
+    "submitAnswerFailed": "無法提交回答",
+    "resumeAfterAnswerFailed": "回答已送出，但恢復串流失敗，請重新整理頁面",
+    "unknownError": "未知錯誤"
+  },
+  "widget": {
+    "expandLabel": "展開 Qgent TA",
+    "chatbotTitle": "Qgent TA",
+    "newChat": "新對話",
+    "inputPlaceholder": "輸入訊息...",
+    "thinking": "思考中...",
+    "sessions": "對話記錄",
+    "rename": "重命名",
+    "delete": "刪除",
+    "addChat": "新增對話",
+    "collapse": "收合面板",
+    "newChatLabel": "新對話",
+    "renameModal": {
+      "title": "重命名對話",
+      "submit": "儲存",
+      "cancel": "取消",
+      "label": "新名稱",
+      "placeholder": "輸入新的對話名稱"
+    },
+    "deleteModal": {
+      "title": "確認刪除",
+      "submit": "刪除",
+      "submitting": "刪除中...",
+      "cancel": "取消",
+      "confirmMessage": "確定要刪除對話「{{title}}」嗎？",
+      "undoWarning": "此操作無法復原。"
+    }
+  },
+  "prompts": {
+    "designTestCases": "幫我設計這題的測試案例",
+    "designTestCasesPrompt": "請幫我設計這題的測試案例，包含邊界條件和特殊情況。",
+    "generateDescription": "生成題目描述範例",
+    "generateDescriptionPrompt": "請幫我生成這題的題目描述範例，讓學生更容易理解。",
+    "checkCompleteness": "檢查題目完整性",
+    "checkCompletenessPrompt": "請檢查這題的完整性，包含題目描述、測試案例、限制條件等。",
+    "optimizeDifficulty": "優化題目難度設定",
+    "optimizeDifficultyPrompt": "請評估並建議這題的難度設定是否合適。",
+    "howToDesign": "如何設計一個好的題目？",
+    "howToDesignPrompt": "請教我如何設計一個好的程式題目？",
+    "testCaseSkills": "測試案例設計技巧",
+    "testCaseSkillsPrompt": "請分享測試案例設計的技巧和最佳實踐。"
+  },
+  "welcome": {
+    "title": "我能為您做什麼？",
+    "subtitle": "正在協助您編輯：{{title}}"
+  },
+  "approval": {
+    "title": "需要確認操作",
+    "confirm": "確認執行",
+    "cancel": "取消",
+    "preview": "預覽變更"
+  },
+  "userInput": {
+    "title": "請回答問題",
+    "submit": "送出回答",
+    "cancel": "跳過"
+  }
+}

--- a/frontend/src/i18n/locales/zh-TW/classroom.json
+++ b/frontend/src/i18n/locales/zh-TW/classroom.json
@@ -1,0 +1,53 @@
+{
+  "members": {
+    "headers": {
+      "username": "使用者名稱",
+      "email": "電子郵件",
+      "role": "角色",
+      "joinedAt": "加入時間"
+    },
+    "actions": {
+      "remove": "移除"
+    }
+  },
+  "announcement": {
+    "modal": {
+      "titleCreate": "發佈公告",
+      "titleEdit": "編輯公告",
+      "submitCreate": "發佈",
+      "submitEdit": "儲存",
+      "submittingCreate": "發佈中...",
+      "submittingEdit": "儲存中...",
+      "cancel": "取消",
+      "form": {
+        "title": "標題",
+        "titlePlaceholder": "公告標題",
+        "pinned": "置頂公告",
+        "content": "內容",
+        "contentPlaceholder": "輸入公告內容，支援 Markdown 語法...",
+        "yes": "是",
+        "no": "否"
+      }
+    }
+  },
+  "inviteCode": {
+    "label": "邀請碼",
+    "disabled": "已停用",
+    "copy": "複製",
+    "copied": "已複製",
+    "regenerate": "重新產生"
+  },
+  "bindContest": {
+    "modal": {
+      "title": "綁定競賽",
+      "submit": "綁定",
+      "submitting": "綁定中...",
+      "cancel": "取消",
+      "noContests": "沒有可綁定的競賽",
+      "table": {
+        "name": "競賽名稱",
+        "status": "狀態"
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/locales/zh-TW/common.json
+++ b/frontend/src/i18n/locales/zh-TW/common.json
@@ -25,7 +25,10 @@
     "environment": "環境設定",
     "createContest": "建立競賽",
     "createProblem": "新增題目",
-    "editProblem": "編輯題目"
+    "editProblem": "編輯題目",
+    "teacherDashboard": "教師後台",
+    "problemManagement": "題目管理",
+    "contestManagement": "競賽管理"
   },
   "tab": {
     "overview": "總覽",

--- a/frontend/src/i18n/locales/zh-TW/contest.json
+++ b/frontend/src/i18n/locales/zh-TW/contest.json
@@ -52,6 +52,24 @@
   "duration": "時長",
   "progress": "考試進度",
   "notActive": "非進行中",
+  "preRegistration": {
+    "state": {
+      "draft": "草稿",
+      "archived": "已封存",
+      "upcoming": "即將開始",
+      "running": "進行中",
+      "ended": "已結束"
+    },
+    "noDescription": "暫無描述",
+    "registerNow": "立即報名",
+    "registeredHint": "已報名，等待競賽開始",
+    "registrationClosed": "目前不可報名",
+    "ended": "競賽已結束",
+    "openAdminPanel": "前往管理後台",
+    "anonymousTitle": "匿名模式",
+    "countdownLabel": "距離開始",
+    "countdownValue": "{{days}}天 {{hours}}小時 {{minutes}}分 {{seconds}}秒"
+  },
   "precheck": {
     "title": "考前環境與資格檢查",
     "description": "為確保考試公平性，請在進入考場前完成以下環境檢測與資格確認。若未通過必要檢查，系統將限制您的作答權限。",
@@ -560,6 +578,32 @@
     "autoSubmittedDesc": "螢幕分享中斷後未能在時限內重新分享，系統已自動為您交卷。",
     "autoSubmittedHint": "如果您認為這是錯誤，請聯繫監考人員。",
     "returnToDashboard": "返回儀表板"
+  },
+  "createModal": {
+    "titleCoding": "建立 Coding Test",
+    "titleExam": "建立紙筆題考試",
+    "typeCoding": "Coding Test",
+    "typeCodingDesc": "程式題為主，支援提交與判題",
+    "typeExam": "紙筆題考試",
+    "typeExamDesc": "考卷題型，是非/選擇/問答",
+    "modeCoding": "Coding Test 模式",
+    "modeExam": "紙筆題考試模式",
+    "descCoding": "學生以程式題為主，走既有提交與排名流程。",
+    "descExam": "學生以卷面作答，問答題可由助教批改。",
+    "nameCoding": "競賽名稱",
+    "nameExam": "紙筆題考試名稱",
+    "duration": "比賽長度（分鐘）",
+    "durationUnit": "分",
+    "endTime": "預計結束時間",
+    "endTimePlaceholder": "請先設定開始時間與有效的比賽長度",
+    "private": "私人競賽",
+    "public": "公開",
+    "privateShort": "私人",
+    "validation": {
+      "durationPositive": "比賽長度必須是大於 0 的分鐘數",
+      "passwordRequired": "私人競賽必須設定密碼",
+      "cannotComputeEndTime": "無法計算結束時間，請檢查開始時間與比賽長度"
+    }
   },
   "settings": {
     "title": "競賽設定",

--- a/frontend/src/i18n/locales/zh-TW/problem.json
+++ b/frontend/src/i18n/locales/zh-TW/problem.json
@@ -98,5 +98,48 @@
     "easy": "簡單",
     "medium": "中等",
     "hard": "困難"
+  },
+  "edit": {
+    "sections": {
+      "basicInfo": "基本資訊",
+      "content": "題目內容",
+      "testCases": "測試案例",
+      "languageSettings": "語言設定"
+    },
+    "actions": {
+      "import": "匯入",
+      "export": "匯出",
+      "preview": "預覽",
+      "save": "儲存",
+      "delete": "刪除",
+      "back": "返回"
+    },
+    "messages": {
+      "importSuccess": "匯入成功",
+      "importSuccessDetail": "YAML 資料已匯入並儲存",
+      "importSuccessSaveFailed": "匯入成功，但自動儲存失敗",
+      "deleteSuccess": "刪除成功",
+      "deleteSuccessDetail": "正在跳轉...",
+      "deleteFailed": "刪除失敗",
+      "exportSuccess": "YAML 匯出成功",
+      "exportSuccessDetail": "檔案已下載",
+      "loadFailed": "無法載入題目資料",
+      "notFound": "題目不存在",
+      "noPermission": "您沒有編輯題目的權限",
+      "noPermissionTitle": "權限不足"
+    },
+    "status": {
+      "public": "題目已公開",
+      "private": "題目已設為私有",
+      "hidden": "題目已隱藏"
+    },
+    "exportModal": {
+      "title": "匯出題目",
+      "submit": "匯出",
+      "cancel": "取消",
+      "scaleLabel": "縮放比例",
+      "scalePlaceholder": "選擇縮放比例",
+      "description": "將題目資料匯出為 YAML 格式，可用於備份或匯入至其他系統。"
+    }
   }
 }

--- a/frontend/src/shared/ui/chatbot/components/ChatWindow.tsx
+++ b/frontend/src/shared/ui/chatbot/components/ChatWindow.tsx
@@ -1,8 +1,8 @@
 import type { FC } from "react";
 import { useMemo, useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import {
-  IconButton,
-  Dropdown,
+  IconButton,  Dropdown,
   InlineNotification,
   Modal,
   TextInput,
@@ -82,6 +82,8 @@ export const ChatWindow: FC<ChatWindowProps> = ({
   onConfirmAction,
   onCancelAction,
 }) => {
+  const { t } = useTranslation("chatbot");
+  const { t: tc } = useTranslation("common");
   const messages: ChatMessage[] = currentSession?.messages ?? [];
   const isUninitializedTempSession = Boolean(
     currentSession &&
@@ -106,53 +108,53 @@ export const ChatWindow: FC<ChatWindowProps> = ({
       prompts.push(
         {
           icon: Idea,
-          text: "幫我設計這題的測試案例",
-          onClick: () => onSend("請幫我設計這題的測試案例，包含邊界條件和特殊情況。"),
+          text: t("prompts.designTestCases"),
+          onClick: () => onSend(t("prompts.designTestCasesPrompt")),
         },
         {
           icon: DocumentAdd,
-          text: "生成題目描述範例",
-          onClick: () => onSend("請幫我生成這題的題目描述範例，讓學生更容易理解。"),
+          text: t("prompts.generateDescription"),
+          onClick: () => onSend(t("prompts.generateDescriptionPrompt")),
         },
         {
           icon: CheckmarkOutline,
-          text: "檢查題目完整性",
-          onClick: () => onSend("請檢查這題的完整性，包含題目描述、測試案例、限制條件等。"),
+          text: t("prompts.checkCompleteness"),
+          onClick: () => onSend(t("prompts.checkCompletenessPrompt")),
         },
         {
           icon: EditIcon,
-          text: "優化題目難度設定",
-          onClick: () => onSend("請評估並建議這題的難度設定是否合適。"),
+          text: t("prompts.optimizeDifficulty"),
+          onClick: () => onSend(t("prompts.optimizeDifficultyPrompt")),
         }
       );
     } else {
       prompts.push(
         {
           icon: Idea,
-          text: "如何設計一個好的題目？",
-          onClick: () => onSend("請教我如何設計一個好的程式題目？"),
+          text: t("prompts.howToDesign"),
+          onClick: () => onSend(t("prompts.howToDesignPrompt")),
         },
         {
           icon: DocumentAdd,
-          text: "測試案例設計技巧",
-          onClick: () => onSend("請分享測試案例設計的技巧和最佳實踐。"),
+          text: t("prompts.testCaseSkills"),
+          onClick: () => onSend(t("prompts.testCaseSkillsPrompt")),
         }
       );
     }
 
     return prompts;
-  }, [problemContext, onSend]);
+  }, [problemContext, onSend, t]);
 
   // 歡迎畫面
   const welcomeScreen = useMemo(() => {
     return (
       <WelcomeScreen
-        title="我能為您做什麼？"
-        subtitle={problemContext ? `正在協助您編輯：${problemContext.title}` : undefined}
+        title={t("welcome.title")}
+        subtitle={problemContext ? t("welcome.subtitle", { title: problemContext.title }) : undefined}
         suggestedPrompts={suggestedPrompts}
       />
     );
-  }, [problemContext, suggestedPrompts]);
+  }, [problemContext, suggestedPrompts, t]);
 
   return (
     <div className={styles.chatWindow}>
@@ -170,7 +172,7 @@ export const ChatWindow: FC<ChatWindowProps> = ({
           <Dropdown
             id="session-selector"
             titleText=""
-            label={currentSession?.title || "新對話"}
+            label={currentSession?.title || t("widget.newChatLabel")}
             items={sessions.map((s) => s.id)}
             itemToString={(itemId) =>
               sessions.find((s) => s.id === itemId)?.title || ""
@@ -191,7 +193,7 @@ export const ChatWindow: FC<ChatWindowProps> = ({
           {currentSession && (
             <OverflowMenu key={`overflow-${currentSession.id}`} flipped>
               <OverflowMenuItem
-                itemText="重命名"
+                itemText={t("widget.rename")}
                 onClick={() => {
                   setRenameInputValue(currentSession.title);
                   setIsRenameModalOpen(true);
@@ -199,7 +201,7 @@ export const ChatWindow: FC<ChatWindowProps> = ({
               />
               <OverflowMenuItem
                 isDelete
-                itemText="刪除"
+                itemText={t("widget.delete")}
                 onClick={() => {
                   setIsDeleteConfirmOpen(true);
                 }}
@@ -207,7 +209,7 @@ export const ChatWindow: FC<ChatWindowProps> = ({
             </OverflowMenu>
           )}
           <IconButton
-            label="新增對話"
+            label={t("widget.addChat")}
             kind="ghost"
             size="sm"
             onClick={onCreateSession}
@@ -216,7 +218,7 @@ export const ChatWindow: FC<ChatWindowProps> = ({
             <Edit size={16} />
           </IconButton>
           <IconButton
-            label="收合面板"
+            label={t("widget.collapse")}
             kind="ghost"
             size="sm"
             onClick={onCollapse}
@@ -232,7 +234,7 @@ export const ChatWindow: FC<ChatWindowProps> = ({
         <div className={styles.errorContainer}>
           <InlineNotification
             kind="error"
-            title="錯誤"
+            title={tc("error.title")}
             subtitle={error}
             lowContrast
             hideCloseButton={!onClearError}
@@ -254,7 +256,7 @@ export const ChatWindow: FC<ChatWindowProps> = ({
         <div className={styles.approvalBanner}>
           <InlineNotification
             kind="warning"
-            title={pendingApproval.actionType === "create" ? "建立題目確認" : "修改題目確認"}
+            title={t("approval.title")}
             subtitle="Agent 已準備好執行操作，請確認或取消。"
             lowContrast
             hideCloseButton
@@ -264,13 +266,13 @@ export const ChatWindow: FC<ChatWindowProps> = ({
               className={styles.approvalConfirmBtn}
               onClick={onConfirmAction}
             >
-              確認執行
+              {t("approval.confirm")}
             </button>
             <button
               className={styles.approvalCancelBtn}
               onClick={onCancelAction}
             >
-              取消
+              {t("approval.cancel")}
             </button>
           </div>
         </div>
@@ -302,9 +304,9 @@ export const ChatWindow: FC<ChatWindowProps> = ({
       {currentSession && (
         <Modal
           open={isRenameModalOpen}
-          modalHeading="重命名對話"
-          primaryButtonText="儲存"
-          secondaryButtonText="取消"
+          modalHeading={t("widget.renameModal.title")}
+          primaryButtonText={t("widget.renameModal.submit")}
+          secondaryButtonText={t("widget.renameModal.cancel")}
           onRequestClose={() => setIsRenameModalOpen(false)}
           onRequestSubmit={async () => {
             if (
@@ -327,10 +329,10 @@ export const ChatWindow: FC<ChatWindowProps> = ({
           <div style={{ paddingBottom: "1rem" }}>
             <TextInput
               id="rename-input"
-              labelText="新名稱"
+              labelText={t("widget.renameModal.label")}
               value={renameInputValue}
               onChange={(e) => setRenameInputValue(e.target.value)}
-              placeholder="輸入新的對話名稱"
+              placeholder={t("widget.renameModal.placeholder")}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   const submitBtn = e.currentTarget
@@ -351,10 +353,10 @@ export const ChatWindow: FC<ChatWindowProps> = ({
       {currentSession && (
         <Modal
           open={isDeleteConfirmOpen}
-          modalHeading="確認刪除"
-          primaryButtonText={isDeleting ? "刪除中..." : "刪除"}
+          modalHeading={t("widget.deleteModal.title")}
+          primaryButtonText={isDeleting ? t("widget.deleteModal.submitting") : t("widget.deleteModal.submit")}
           primaryButtonDisabled={isDeleting}
-          secondaryButtonText="取消"
+          secondaryButtonText={t("widget.deleteModal.cancel")}
           danger
           onRequestClose={() => !isDeleting && setIsDeleteConfirmOpen(false)}
           onRequestSubmit={async () => {
@@ -373,9 +375,9 @@ export const ChatWindow: FC<ChatWindowProps> = ({
           size="sm"
         >
           <p>
-            確定要刪除對話「<strong>{currentSession.title}</strong>」嗎？
+            {t("widget.deleteModal.confirmMessage", { title: currentSession.title })}
             <br />
-            此操作無法復原。
+            {t("widget.deleteModal.undoWarning")}
           </p>
         </Modal>
       )}


### PR DESCRIPTION
## Summary
- add broader i18n updates for teacher/classroom/chatbot related frontend modules
- guard exam anti-cheat `blur` and `mouseleave` handling during IME composition to avoid false positives while selecting CJK candidates
- add detector tests to preserve normal anti-cheat behavior outside composition windows

## Testing
- bash scripts/pre-push-check.sh
- npx vitest run src/features/contest/detectors/focusDetector.test.ts src/features/contest/detectors/mouseLeaveDetector.test.ts src/features/contest/hooks/useExamMonitoring.test.ts