### PR TITLE
Release dev to main

### DIFF
--- a/docs/superpowers/plans/2026-04-11-mcp-server-exam-questions.md
+++ b/docs/superpowers/plans/2026-04-11-mcp-server-exam-questions.md
@@ -2,13 +2,20 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build an MCP Server that lets teachers/TAs edit exam questions via AI tools, with OAuth 2.1 authentication through Django.
+**Goal:** Build an MCP Server that lets teachers/TAs edit `paper_exam` questions via AI tools, with OAuth 2.1 authentication through Django, explicit contest-type guardrails, and batch create support.
 
-**Architecture:** Standalone FastMCP service (`:9000`) acts as stateless proxy to Django backend (`:8000`). Django gains `django-oauth-toolkit` as Authorization Server. OAuth token passthrough — MCP Server forwards Bearer token to Django API, which handles all auth and business logic.
+**Architecture:** Standalone FastMCP service (`:9000`) acts as stateless proxy to Django backend (`:8000`). Django gains `django-oauth-toolkit` as Authorization Server. OAuth token passthrough — MCP Server forwards Bearer token to Django API, which handles all auth and business logic. MCP additionally enforces tool-level contest-type guardrails so AI clients do not mix up `paper_exam` and `coding` contests.
 
 **Tech Stack:** Python `mcp[cli]` (FastMCP), `httpx` (async HTTP), `django-oauth-toolkit` (OAuth AS), Docker Compose
 
 **Spec:** `docs/superpowers/specs/2026-04-11-mcp-server-exam-questions.md`
+
+## Current Notes
+
+- `qjudge_exam` should only operate on `paper_exam` contests.
+- `qjudge_coding` should only operate on `coding` contests.
+- `qjudge_exam.create` / `qjudge_exam.update` must support `explanation`.
+- `qjudge_exam.batch_create` must support `mode="append"` and `mode="overwrite"`.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-11-mcp-server-exam-questions.md
+++ b/docs/superpowers/specs/2026-04-11-mcp-server-exam-questions.md
@@ -2,13 +2,13 @@
 
 **Date:** 2026-04-11
 **Status:** Draft
-**Scope:** MCP Server with OAuth 2.1, exam question CRUD + reorder
+**Scope:** MCP Server with OAuth 2.1, paper-exam question CRUD + reorder + batch create
 
 ---
 
 ## Overview
 
-建立一個獨立的 MCP Server，讓老師/助教透過 AI 工具（Claude Code、Cursor 等）編輯競賽的 exam questions。MCP Server 作為 stateless thin proxy，所有業務邏輯和權限檢查由 Django backend 處理。
+建立一個獨立的 MCP Server，讓老師/助教透過 AI 工具（Claude Code、Cursor 等）編輯 `paper_exam` 競賽的 exam questions。MCP Server 作為 stateless thin proxy，所有業務邏輯和權限檢查由 Django backend 處理；MCP 只補工具導向的 orchestration 與 contest 類型防呆。
 
 ## Architecture
 
@@ -93,7 +93,17 @@ dev 環境需在 Django 建立一個 OAuth Application：
 
 ### qjudge_exam
 
-管理考試題目 CRUD + 排序。Actions: `list`, `get`, `create`, `update`, `delete`, `reorder`
+管理 `paper_exam` contest 的考試題目。Actions: `list`, `get`, `create`, `update`, `delete`, `reorder`, `import_from_bank`, `batch_create`
+
+- `create` / `update` 支援 `explanation`
+- `batch_create` 支援：
+  - `mode="append"`：逐筆新增
+  - `mode="overwrite"`：先刪除 contest 既有 exam 題目，再逐筆新增
+- 如果 contest 實際上是 `coding`，MCP 直接回錯誤，提示改用 `qjudge_coding`
+
+### qjudge_coding
+
+管理 `coding` contest 的程式題目。若 contest 實際上是 `paper_exam`，MCP 直接回錯誤，提示改用 `qjudge_exam`。
 
 ### qjudge_grading
 
@@ -115,6 +125,7 @@ MCP Server 直接轉發 Django 的回應：
 | 400 | 回傳 validation error message |
 | 401 | 提示使用者重新授權 |
 | 403 | 回傳權限拒絕原因（question_edit_locked、not owner 等） |
+| 400 | 回傳固定工具錯誤（如 contest type 不符、batch mode 無效） |
 | 404 | 回傳 "contest or question not found" |
 | 5xx | 回傳 "QJudge 服務暫時不可用" |
 
@@ -171,7 +182,5 @@ qjudge-mcp:
 ## Out of Scope
 
 - list_contests tool（contest ID 由使用者提供）
-- Batch 操作
-- import-from-bank
 - 學生端功能
 - MCP Resources（第一版只用 Tools）

--- a/frontend/src/features/admin/screens/UserManagementScreen.tsx
+++ b/frontend/src/features/admin/screens/UserManagementScreen.tsx
@@ -4,8 +4,6 @@ import {
   Search,
   CheckmarkFilled,
   Copy,
-  TrashCan,
-  WarningAlt,
 } from "@carbon/icons-react";
 import {
   TextInput,
@@ -29,7 +27,6 @@ import { PageHeader } from "@/shared/layout/PageHeader";
 import ContainerCard from "@/shared/layout/ContainerCard";
 import styles from "./AdminScreens.module.scss";
 import {
-  deleteUser,
   issueTeacherActivationInvite,
   searchUsers,
   updateUserRole,
@@ -50,8 +47,6 @@ const UserManagementScreen = () => {
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const [updating, setUpdating] = useState(false);
   const [issuingInvite, setIssuingInvite] = useState(false);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [userToDelete, setUserToDelete] = useState<ManagedUser | null>(null);
   const [roleFilter, setRoleFilter] = useState<"all" | ManagedUser["role"]>("all");
   const [latestInviteUrl, setLatestInviteUrl] = useState("");
   const [latestInviteExpiresAt, setLatestInviteExpiresAt] = useState<string | null>(null);
@@ -154,29 +149,6 @@ const UserManagementScreen = () => {
       }
     } finally {
       setUpdating(false);
-    }
-  };
-
-  const handleDeleteClick = (user: ManagedUser) => {
-    setUserToDelete(user);
-    setIsDeleteModalOpen(true);
-  };
-
-  const handleDeleteConfirm = async () => {
-    if (!userToDelete) return;
-
-    try {
-      await deleteUser(userToDelete.id);
-      setSuccess(
-        t("user.management.userDeleted", { email: userToDelete.email })
-      );
-      // Refresh user list
-      loadAllUsers();
-    } catch {
-      setError(t("user.management.deleteError"));
-    } finally {
-      setIsDeleteModalOpen(false);
-      setUserToDelete(null);
     }
   };
 
@@ -565,18 +537,6 @@ const UserManagementScreen = () => {
                                   text={t("user.role.adminTA")}
                                 />
                               </Select>
-                              <Button
-                                kind="danger--ghost"
-                                size="sm"
-                                renderIcon={TrashCan}
-                                onClick={() => handleDeleteClick(user)}
-                                hasIconOnly
-                                iconDescription={t(
-                                  "user.management.deleteUser"
-                                )}
-                              >
-                                {tc("button.delete")}
-                              </Button>
                             </div>
                           </TableCell>
                         </TableRow>
@@ -622,34 +582,6 @@ const UserManagementScreen = () => {
             )}
           </p>
         )}
-      </Modal>
-
-      {/* Delete Confirmation Modal */}
-      <Modal
-        open={isDeleteModalOpen}
-        modalHeading={t("user.management.confirmDeleteUser")}
-        primaryButtonText={tc("button.delete")}
-        secondaryButtonText={tc("button.cancel")}
-        onRequestClose={() => setIsDeleteModalOpen(false)}
-        onRequestSubmit={handleDeleteConfirm}
-        danger
-      >
-        <p>
-          {t("user.management.confirmDeleteMessage", {
-            email: userToDelete?.email,
-          })}
-        </p>
-        <p
-          style={{
-            marginTop: "1rem",
-            color: "var(--cds-text-error)",
-            display: "flex",
-            alignItems: "center",
-            gap: "0.25rem",
-          }}
-        >
-          <WarningAlt size={16} /> {t("user.management.deleteWarning")}
-        </p>
       </Modal>
     </div>
   );

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -83,13 +83,8 @@
         "loginMethod": "Login Method",
         "username": "Username"
       },
-      "confirmDeleteMessage": "Are you sure you want to delete user {{email}}?",
-      "confirmDeleteUser": "Confirm Delete User",
       "confirmRoleChange": "Confirm Role Change",
       "confirmRoleChangeMessage": "Are you sure you want to change {{username}}'s role from {{oldRole}} to {{newRole}}?",
-      "deleteError": "An error occurred while deleting user",
-      "deleteUser": "Delete User",
-      "deleteWarning": "This action cannot be undone! All user data will be permanently deleted.",
       "description": "View all users and manage roles (use search to filter)",
       "loadFailed": "Failed to load users",
       "loginMethods": {
@@ -109,8 +104,7 @@
       "searchResults": "Search Results ({{count}})",
       "title": "User Management",
       "updateFailed": "Update failed",
-      "updateFailedRetry": "Update failed. Please try again later.",
-      "userDeleted": "User {{email}} has been deleted"
+      "updateFailedRetry": "Update failed. Please try again later."
     },
     "role": {
       "admin": "Admin",

--- a/frontend/src/i18n/locales/ja/admin.json
+++ b/frontend/src/i18n/locales/ja/admin.json
@@ -83,13 +83,8 @@
         "loginMethod": "ログイン方法",
         "username": "ユーザー名"
       },
-      "confirmDeleteMessage": "ユーザー{{email}}を削除してもよろしいですか？",
-      "confirmDeleteUser": "ユーザー削除の確認",
       "confirmRoleChange": "役割変更の確認",
       "confirmRoleChangeMessage": "{{username}}の役割を{{oldRole}}から{{newRole}}に変更してもよろしいですか？",
-      "deleteError": "ユーザーの削除中にエラーが発生しました",
-      "deleteUser": "ユーザー削除",
-      "deleteWarning": "この操作は取り消せません！ユーザーのすべてのデータが完全に削除されます。",
       "description": "すべてのユーザーを表示し、役割を管理（検索機能でフィルタリング可能）",
       "loadFailed": "ユーザーを読み込めません",
       "loginMethods": {
@@ -109,8 +104,7 @@
       "searchResults": "検索結果（{{count}}件）",
       "title": "ユーザー管理",
       "updateFailed": "更新に失敗しました",
-      "updateFailedRetry": "更新に失敗しました。後でもう一度お試しください",
-      "userDeleted": "ユーザー{{email}}を削除しました"
+      "updateFailedRetry": "更新に失敗しました。後でもう一度お試しください"
     },
     "role": {
       "admin": "管理者",

--- a/frontend/src/i18n/locales/ko/admin.json
+++ b/frontend/src/i18n/locales/ko/admin.json
@@ -83,13 +83,8 @@
         "loginMethod": "로그인 방법",
         "username": "사용자 이름"
       },
-      "confirmDeleteMessage": "사용자 {{email}}을(를) 삭제하시겠습니까?",
-      "confirmDeleteUser": "사용자 삭제 확인",
       "confirmRoleChange": "역할 변경 확인",
       "confirmRoleChangeMessage": "{{username}}의 역할을 {{oldRole}}에서 {{newRole}}로 변경하시겠습니까?",
-      "deleteError": "사용자 삭제 중 오류가 발생했습니다",
-      "deleteUser": "사용자 삭제",
-      "deleteWarning": "이 작업은 취소할 수 없습니다! 사용자의 모든 데이터가 영구적으로 삭제됩니다.",
       "description": "모든 사용자를 보고 역할 관리 (검색 기능으로 필터링 가능)",
       "loadFailed": "사용자를 불러올 수 없습니다",
       "loginMethods": {
@@ -109,8 +104,7 @@
       "searchResults": "검색 결과 ({{count}}명)",
       "title": "사용자 관리",
       "updateFailed": "업데이트 실패",
-      "updateFailedRetry": "업데이트 실패. 나중에 다시 시도하세요",
-      "userDeleted": "사용자 {{email}}이(가) 삭제되었습니다"
+      "updateFailedRetry": "업데이트 실패. 나중에 다시 시도하세요"
     },
     "role": {
       "admin": "관리자",

--- a/frontend/src/i18n/locales/zh-TW/admin.json
+++ b/frontend/src/i18n/locales/zh-TW/admin.json
@@ -83,13 +83,8 @@
         "loginMethod": "登入方式",
         "username": "使用者名稱"
       },
-      "confirmDeleteMessage": "確定要刪除用戶 {{email}} 嗎？",
-      "confirmDeleteUser": "確認刪除用戶",
       "confirmRoleChange": "確認變更角色",
       "confirmRoleChangeMessage": "確定要將 {{username}} 的角色從 {{oldRole}} 變更為 {{newRole}} 嗎？",
-      "deleteError": "刪除用戶時發生錯誤",
-      "deleteUser": "刪除用戶",
-      "deleteWarning": "此操作無法復原！用戶的所有數據將被永久刪除。",
       "description": "查看所有使用者並管理角色（可使用搜尋功能過濾）",
       "loadFailed": "無法載入使用者",
       "loginMethods": {
@@ -109,8 +104,7 @@
       "searchResults": "搜尋結果 ({{count}})",
       "title": "使用者管理",
       "updateFailed": "更新失敗",
-      "updateFailedRetry": "更新失敗，請稍後再試",
-      "userDeleted": "已刪除用戶 {{email}}"
+      "updateFailedRetry": "更新失敗，請稍後再試"
     },
     "role": {
       "admin": "管理員",

--- a/frontend/src/infrastructure/api/repositories/auth.repository.test.ts
+++ b/frontend/src/infrastructure/api/repositories/auth.repository.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  issueTeacherActivationInvite,
+  searchUsers,
+  updateUserRole,
+} from "./auth.repository";
+
+describe("auth repository admin endpoints", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    document.cookie = "csrftoken=test-csrf-token";
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.cookie = "csrftoken=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    window.localStorage.clear();
+  });
+
+  it("searchUsers calls the auth search endpoint with q", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await searchUsers("alice");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/auth/search?q=alice");
+    expect(options.method).toBe("GET");
+    expect(options.credentials).toBe("include");
+  });
+
+  it("updateUserRole calls the auth role endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: { id: 7, role: "teacher" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await updateUserRole(7, "teacher");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/auth/7/role");
+    expect(options.method).toBe("PATCH");
+    expect(JSON.parse(options.body as string)).toEqual({ role: "teacher" });
+  });
+
+  it("issueTeacherActivationInvite calls teacher-activations", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            id: 1,
+            created_at: "2026-04-14T00:00:00Z",
+            expires_at: "2026-04-15T00:00:00Z",
+            status: "pending",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await issueTeacherActivationInvite("teacher@example.com");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/auth/teacher-activations");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body as string)).toEqual({ email: "teacher@example.com" });
+  });
+});

--- a/frontend/src/infrastructure/api/repositories/auth.repository.ts
+++ b/frontend/src/infrastructure/api/repositories/auth.repository.ts
@@ -122,19 +122,25 @@ export const uploadAvatar = async (file: File): Promise<UploadAvatarResponseDto>
 // ============================================================================
 
 export const searchUsers = async (query: string): Promise<UserSearchResponseDto> => {
+  const trimmedQuery = query.trim();
+  const searchParams = new URLSearchParams();
+  if (trimmedQuery) {
+    searchParams.set("q", trimmedQuery);
+  }
+
   return requestJson<UserSearchResponseDto>(
-    httpClient.get(`/api/v1/management/users/?search=${encodeURIComponent(query)}`),
+    httpClient.get(
+      searchParams.size > 0
+        ? `/api/v1/auth/search?${searchParams.toString()}`
+        : "/api/v1/auth/search"
+    ),
     "Failed to search users"
   );
 };
 
-export const deleteUser = async (id: number | string): Promise<void> => {
-  await ensureOk(httpClient.delete(`/api/v1/management/users/${id}/`), "Failed to delete user");
-};
-
 export const updateUserRole = async (id: number | string, role: string): Promise<any> => {
   return requestJson<any>(
-    httpClient.patch(`/api/v1/management/users/${id}/`, { role }),
+    httpClient.patch(`/api/v1/auth/${id}/role`, { role }),
     "Failed to update user role"
   );
 };
@@ -151,7 +157,7 @@ export const issueTeacherActivationInvite = async (
   email: string
 ): Promise<TeacherActivationIssueResponseDto> => {
   return requestJson<TeacherActivationIssueResponseDto>(
-    httpClient.post("/api/v1/management/teacher-invites/", { email }),
+    httpClient.post("/api/v1/auth/teacher-activations", { email }),
     "Failed to issue invite"
   );
 };
@@ -272,7 +278,6 @@ export const authRepository = {
   updatePreferences,
   uploadAvatar,
   searchUsers,
-  deleteUser,
   updateUserRole,
   logoutOtherDevices,
   issueTeacherActivationInvite,

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -209,6 +209,58 @@ def _compact_dashboard(raw: Any, *, include_full_titles: bool = False) -> Any:
     return data
 
 
+async def _ensure_contest_type(
+    *,
+    contest_id: str,
+    ctx: Context,
+    expected_type: str,
+    tool_name: str,
+    allowed_label: str,
+    disallowed_tool_name: str,
+) -> dict[str, Any] | None:
+    contest = await django_api("GET", f"/api/v1/contests/{contest_id}/", ctx)
+    if isinstance(contest, dict) and contest.get("error"):
+        return contest
+    if not isinstance(contest, dict):
+        return _error("Unable to determine contest type", status=500)
+
+    actual_type = contest.get("contest_type")
+    if actual_type == expected_type:
+        return None
+
+    actual_label = "coding" if actual_type == "coding" else "paper_exam"
+    return _error(
+        f"{tool_name} only supports {allowed_label} contests. "
+        f"This contest is {actual_label}. Use {disallowed_tool_name} instead.",
+        status=400,
+    )
+
+
+def _build_exam_question_body(
+    *,
+    question_type: str | None = None,
+    prompt: str | None = None,
+    explanation: str | None = None,
+    score: int | None = None,
+    options: list[str] | None = None,
+    correct_answer: Any | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    if question_type is not None:
+        body["question_type"] = question_type
+    if prompt is not None:
+        body["prompt"] = prompt
+    if explanation is not None:
+        body["explanation"] = explanation
+    if score is not None:
+        body["score"] = score
+    if options is not None:
+        body["options"] = options
+    if correct_answer is not None:
+        body["correct_answer"] = correct_answer
+    return body
+
+
 mcp = FastMCP(
     "QJudge",
     host=MCP_HOST,
@@ -321,70 +373,133 @@ async def qjudge_exam(
     question_id: str | None = None,
     question_type: str | None = None,
     prompt: str | None = None,
+    explanation: str | None = None,
     score: int | None = None,
     options: list[str] | None = None,
     correct_answer: Any | None = None,
     question_ids: list[str] | None = None,
     items: list[dict] | None = None,
+    mode: str | None = None,
 ) -> Any:
-    """Manage exam questions. Actions: list, get, create, update, delete, reorder, import_from_bank."""
+    """Manage paper-exam questions within a paper_exam contest.
+
+    Use this tool only for contests whose ``contest_type`` is ``paper_exam``.
+    Coding contests must use ``qjudge_coding`` instead.
+
+    Actions: list, get, create, update, delete, reorder, import_from_bank, batch_create.
+    """
     base = f"/api/v1/contests/{contest_id}/exam-questions"
+    valid_actions = {"list", "get", "create", "update", "delete", "reorder", "import_from_bank", "batch_create"}
+    if action not in valid_actions:
+        return _error(f"Unknown action: {action}")
+    if action in {"get", "update", "delete"} and not question_id:
+        return _error("question_id is required")
+    if action == "reorder" and not question_ids:
+        return _error("question_ids is required")
+    if action == "import_from_bank" and not items:
+        return _error("items is required (list of {question_bank_id, question_id})")
+    if action == "update":
+        body = _build_exam_question_body(
+            question_type=question_type,
+            prompt=prompt,
+            explanation=explanation,
+            score=score,
+            options=options,
+            correct_answer=correct_answer,
+        )
+        if not body:
+            return _error("No fields to update")
+    normalized_mode = mode or "append"
+    if action == "batch_create":
+        if not items:
+            return _error("items is required")
+        if normalized_mode not in {"append", "overwrite"}:
+            return _error("mode must be one of: append, overwrite")
+
+    type_error = await _ensure_contest_type(
+        contest_id=contest_id,
+        ctx=ctx,
+        expected_type="paper_exam",
+        tool_name="qjudge_exam",
+        allowed_label="paper_exam",
+        disallowed_tool_name="qjudge_coding",
+    )
+    if type_error:
+        return type_error
 
     if action == "list":
         return await django_api("GET", f"{base}/", ctx)
 
     if action == "get":
-        if not question_id:
-            return _error("question_id is required")
         return await django_api("GET", f"{base}/{question_id}/", ctx)
 
     if action == "create":
-        body: dict[str, Any] = {}
-        if question_type:
-            body["question_type"] = question_type
-        if prompt:
-            body["prompt"] = prompt
-        if score is not None:
-            body["score"] = score
-        if options is not None:
-            body["options"] = options
-        if correct_answer is not None:
-            body["correct_answer"] = correct_answer
+        body = _build_exam_question_body(
+            question_type=question_type,
+            prompt=prompt,
+            explanation=explanation,
+            score=score,
+            options=options,
+            correct_answer=correct_answer,
+        )
         return await django_api("POST", f"{base}/", ctx, json_body=body)
 
     if action == "update":
-        if not question_id:
-            return _error("question_id is required")
-        body = {}
-        if prompt is not None:
-            body["prompt"] = prompt
-        if options is not None:
-            body["options"] = options
-        if correct_answer is not None:
-            body["correct_answer"] = correct_answer
-        if score is not None:
-            body["score"] = score
-        if question_type is not None:
-            body["question_type"] = question_type
-        if not body:
-            return _error("No fields to update")
         return await django_api("PATCH", f"{base}/{question_id}/", ctx, json_body=body)
 
     if action == "delete":
-        if not question_id:
-            return _error("question_id is required")
         return await django_api("DELETE", f"{base}/{question_id}/", ctx)
 
     if action == "reorder":
-        if not question_ids:
-            return _error("question_ids is required")
         orders = [{"id": qid, "order": idx} for idx, qid in enumerate(question_ids)]
         return await django_api("POST", f"{base}/reorder/", ctx, json_body={"orders": orders})
 
     if action == "import_from_bank":
-        if not items:
-            return _error("items is required (list of {question_bank_id, question_id})")
         return await django_api("POST", f"{base}/import-from-bank/", ctx, json_body={"items": items})
+
+    if action == "batch_create":
+        deleted_count = 0
+        if normalized_mode == "overwrite":
+            existing = await django_api("GET", f"{base}/", ctx)
+            if isinstance(existing, dict) and existing.get("error"):
+                return existing
+            if not isinstance(existing, list):
+                return _error("Expected exam question list during overwrite", status=500)
+            for existing_item in existing:
+                if not isinstance(existing_item, dict):
+                    continue
+                existing_id = existing_item.get("id")
+                if not existing_id:
+                    continue
+                deleted = await django_api("DELETE", f"{base}/{existing_id}/", ctx)
+                if isinstance(deleted, dict) and deleted.get("error"):
+                    return deleted
+                deleted_count += 1
+
+        created_items: list[Any] = []
+        for item in items:
+            if not isinstance(item, dict):
+                return _error("Each batch item must be an object")
+            body = _build_exam_question_body(
+                question_type=item.get("question_type"),
+                prompt=item.get("prompt"),
+                explanation=item.get("explanation"),
+                score=item.get("score"),
+                options=item.get("options"),
+                correct_answer=item.get("correct_answer"),
+            )
+            created = await django_api("POST", f"{base}/", ctx, json_body=body)
+            if isinstance(created, dict) and created.get("error"):
+                return created
+            created_items.append(created)
+
+        return {
+            "status": "success",
+            "mode": normalized_mode,
+            "deleted_count": deleted_count,
+            "created_count": len(created_items),
+            "items": created_items,
+        }
 
     return _error(f"Unknown action: {action}")
 
@@ -494,7 +609,10 @@ async def qjudge_coding(
     use_samples: bool = True,
     custom_test_cases: list[dict] | None = None,
 ) -> Any:
-    """Manage coding problems within a contest.
+    """Manage coding problems within a coding contest.
+
+    Use this tool only for contests whose ``contest_type`` is ``coding``.
+    Paper-exam contests must use ``qjudge_exam`` instead.
 
     Actions:
       list         — List coding problems in a contest (required: contest_id)
@@ -505,45 +623,57 @@ async def qjudge_coding(
       delete       — Remove problem from contest (required: contest_id, problem_id)
       test_run     — Execute code against test cases (required: problem_id, language, code)
     """
+    valid_actions = {"list", "get", "create", "import_from_bank", "update_score", "delete", "test_run"}
+    if action not in valid_actions:
+        return _error(f"Unknown action: {action}")
+    if action in {"list", "get", "create", "import_from_bank", "update_score", "delete"} and not contest_id:
+        return _error("contest_id is required")
+    if action in {"get", "update_score", "delete"} and not problem_id:
+        return _error("problem_id is required")
+    if action == "create" and not title:
+        return _error("title is required")
+    if action == "import_from_bank" and not items:
+        return _error("items is required (list of {question_bank_id, question_id})")
+    if action == "update_score" and max_score is None:
+        return _error("max_score is required")
+    if action == "test_run" and not problem_id:
+        return _error("problem_id is required")
+    if action == "test_run" and not language:
+        return _error("language is required")
+    if action == "test_run" and not code:
+        return _error("code is required")
+
+    if contest_id is not None:
+        type_error = await _ensure_contest_type(
+            contest_id=contest_id,
+            ctx=ctx,
+            expected_type="coding",
+            tool_name="qjudge_coding",
+            allowed_label="coding",
+            disallowed_tool_name="qjudge_exam",
+        )
+        if type_error:
+            return type_error
+
     if action == "list":
-        if not contest_id:
-            return _error("contest_id is required")
         return await django_api("GET", f"/api/v1/contests/{contest_id}/problems/", ctx)
 
     if action == "get":
-        if not contest_id:
-            return _error("contest_id is required")
-        if not problem_id:
-            return _error("problem_id is required")
         return await django_api("GET", f"/api/v1/contests/{contest_id}/problems/{problem_id}/", ctx)
 
     if action == "create":
-        if not contest_id:
-            return _error("contest_id is required")
-        if not title:
-            return _error("title is required")
         body: dict[str, Any] = {"title": title}
         if max_score is not None:
             body["max_score"] = max_score
         return await django_api("POST", f"/api/v1/contests/{contest_id}/problems/", ctx, json_body=body)
 
     if action == "import_from_bank":
-        if not contest_id:
-            return _error("contest_id is required")
-        if not items:
-            return _error("items is required (list of {question_bank_id, question_id})")
         return await django_api(
             "POST", f"/api/v1/contests/{contest_id}/problems/import-from-bank/",
             ctx, json_body={"items": items},
         )
 
     if action == "update_score":
-        if not contest_id:
-            return _error("contest_id is required")
-        if not problem_id:
-            return _error("problem_id is required")
-        if max_score is None:
-            return _error("max_score is required")
         return await django_api(
             "PATCH",
             f"/api/v1/contests/{contest_id}/problems/{problem_id}/score/",
@@ -552,19 +682,9 @@ async def qjudge_coding(
         )
 
     if action == "delete":
-        if not contest_id:
-            return _error("contest_id is required")
-        if not problem_id:
-            return _error("problem_id is required")
         return await django_api("DELETE", f"/api/v1/contests/{contest_id}/problems/{problem_id}/", ctx)
 
     if action == "test_run":
-        if not problem_id:
-            return _error("problem_id is required")
-        if not language:
-            return _error("language is required")
-        if not code:
-            return _error("code is required")
         body = {
             "language": language,
             "code": code,

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -65,6 +65,13 @@ class FakeAsyncClient:
         return self._response
 
 
+def contest_detail(*, contest_id="contest-1", contest_type="paper_exam"):
+    return {
+        "id": contest_id,
+        "contest_type": contest_type,
+    }
+
+
 def test_django_api_forwards_auth_header_and_json_body(monkeypatch):
     calls = []
     response = FakeResponse(200, payload={"ok": True})
@@ -205,6 +212,8 @@ def test_qjudge_exam_reorder_generates_orders(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/contest-1/":
+            return contest_detail()
         captured["method"] = method
         captured["path"] = path
         captured["json_body"] = json_body
@@ -543,6 +552,8 @@ def test_qjudge_exam_import_from_bank(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/contest-1/":
+            return contest_detail()
         captured["method"] = method
         captured["path"] = path
         captured["json_body"] = json_body
@@ -570,6 +581,176 @@ def test_qjudge_exam_import_from_bank_requires_items():
     assert "items" in result["detail"]
 
 
+def test_qjudge_exam_create_passes_explanation(monkeypatch):
+    captured = {}
+
+    async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/contest-1/":
+            return contest_detail()
+        captured["method"] = method
+        captured["path"] = path
+        captured["json_body"] = json_body
+        return {"id": "eq-new"}
+
+    monkeypatch.setattr(server, "django_api", fake_django_api)
+
+    result = run(
+        server.qjudge_exam(
+            "create",
+            "contest-1",
+            DummyContext(),
+            question_type="essay",
+            prompt="Explain CAP theorem.",
+            explanation="Consistency, availability, and partition tolerance trade off.",
+            score=10,
+        )
+    )
+
+    assert result == {"id": "eq-new"}
+    assert captured == {
+        "method": "POST",
+        "path": "/api/v1/contests/contest-1/exam-questions/",
+        "json_body": {
+            "question_type": "essay",
+            "prompt": "Explain CAP theorem.",
+            "explanation": "Consistency, availability, and partition tolerance trade off.",
+            "score": 10,
+        },
+    }
+
+
+def test_qjudge_exam_update_passes_explanation(monkeypatch):
+    captured = {}
+
+    async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/contest-1/":
+            return contest_detail()
+        captured["method"] = method
+        captured["path"] = path
+        captured["json_body"] = json_body
+        return {"id": "eq-1"}
+
+    monkeypatch.setattr(server, "django_api", fake_django_api)
+
+    result = run(
+        server.qjudge_exam(
+            "update",
+            "contest-1",
+            DummyContext(),
+            question_id="eq-1",
+            explanation="Updated explanation",
+        )
+    )
+
+    assert result == {"id": "eq-1"}
+    assert captured == {
+        "method": "PATCH",
+        "path": "/api/v1/contests/contest-1/exam-questions/eq-1/",
+        "json_body": {"explanation": "Updated explanation"},
+    }
+
+
+def test_qjudge_exam_batch_create_append(monkeypatch):
+    calls = []
+
+    async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/contest-1/":
+            return contest_detail()
+        calls.append((method, path, json_body))
+        return {"id": f"eq-{len(calls)}"}
+
+    monkeypatch.setattr(server, "django_api", fake_django_api)
+
+    result = run(
+        server.qjudge_exam(
+            "batch_create",
+            "contest-1",
+            DummyContext(),
+            mode="append",
+            items=[
+                {"question_type": "essay", "prompt": "Q1", "explanation": "E1", "score": 5},
+                {"question_type": "single_choice", "prompt": "Q2", "options": ["A", "B"], "correct_answer": 0, "score": 3},
+            ],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["mode"] == "append"
+    assert result["deleted_count"] == 0
+    assert result["created_count"] == 2
+    assert calls == [
+        ("POST", "/api/v1/contests/contest-1/exam-questions/", {"question_type": "essay", "prompt": "Q1", "explanation": "E1", "score": 5}),
+        ("POST", "/api/v1/contests/contest-1/exam-questions/", {"question_type": "single_choice", "prompt": "Q2", "score": 3, "options": ["A", "B"], "correct_answer": 0}),
+    ]
+
+
+def test_qjudge_exam_batch_create_overwrite(monkeypatch):
+    calls = []
+
+    async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/contest-1/":
+            return contest_detail()
+        calls.append((method, path, json_body))
+        if method == "GET" and path == "/api/v1/contests/contest-1/exam-questions/":
+            return [{"id": "old-1"}, {"id": "old-2"}]
+        if method == "DELETE":
+            return {"status": "success"}
+        return {"id": f"new-{len(calls)}"}
+
+    monkeypatch.setattr(server, "django_api", fake_django_api)
+
+    result = run(
+        server.qjudge_exam(
+            "batch_create",
+            "contest-1",
+            DummyContext(),
+            mode="overwrite",
+            items=[{"question_type": "essay", "prompt": "Fresh question", "score": 10}],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["mode"] == "overwrite"
+    assert result["deleted_count"] == 2
+    assert result["created_count"] == 1
+    assert calls == [
+        ("GET", "/api/v1/contests/contest-1/exam-questions/", None),
+        ("DELETE", "/api/v1/contests/contest-1/exam-questions/old-1/", None),
+        ("DELETE", "/api/v1/contests/contest-1/exam-questions/old-2/", None),
+        ("POST", "/api/v1/contests/contest-1/exam-questions/", {"question_type": "essay", "prompt": "Fresh question", "score": 10}),
+    ]
+
+
+def test_qjudge_exam_batch_create_requires_valid_mode():
+    result = run(
+        server.qjudge_exam(
+            "batch_create",
+            "contest-1",
+            DummyContext(),
+            mode="replace",
+            items=[{"question_type": "essay", "prompt": "Q"}],
+        )
+    )
+    assert result == {"error": True, "detail": "mode must be one of: append, overwrite"}
+
+
+def test_qjudge_exam_rejects_coding_contest(monkeypatch):
+    async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/contest-1/":
+            return contest_detail(contest_type="coding")
+        raise AssertionError("Should stop before exam-question endpoint call")
+
+    monkeypatch.setattr(server, "django_api", fake_django_api)
+
+    result = run(server.qjudge_exam("create", "contest-1", DummyContext(), question_type="essay", prompt="Q"))
+
+    assert result == {
+        "error": True,
+        "detail": "qjudge_exam only supports paper_exam contests. This contest is coding. Use qjudge_coding instead.",
+        "status": 400,
+    }
+
+
 # ---------- qjudge_coding tests (contest-scoped) ----------
 
 
@@ -577,6 +758,8 @@ def test_qjudge_coding_list(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/c-1/":
+            return contest_detail(contest_id="c-1", contest_type="coding")
         captured["method"] = method
         captured["path"] = path
         return [{"id": "b-1", "title": "A+B"}]
@@ -598,6 +781,8 @@ def test_qjudge_coding_get(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/c-1/":
+            return contest_detail(contest_id="c-1", contest_type="coding")
         captured["method"] = method
         captured["path"] = path
         return {"id": "p-1", "title": "A+B"}
@@ -619,6 +804,8 @@ def test_qjudge_coding_create(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/c-1/":
+            return contest_detail(contest_id="c-1", contest_type="coding")
         captured["method"] = method
         captured["path"] = path
         captured["json_body"] = json_body
@@ -645,6 +832,8 @@ def test_qjudge_coding_import_from_bank(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/c-1/":
+            return contest_detail(contest_id="c-1", contest_type="coding")
         captured["method"] = method
         captured["path"] = path
         captured["json_body"] = json_body
@@ -675,6 +864,8 @@ def test_qjudge_coding_update_score(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/c-1/":
+            return contest_detail(contest_id="c-1", contest_type="coding")
         captured["method"] = method
         captured["path"] = path
         captured["json_body"] = json_body
@@ -704,6 +895,8 @@ def test_qjudge_coding_delete(monkeypatch):
     captured = {}
 
     async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/c-1/":
+            return contest_detail(contest_id="c-1", contest_type="coding")
         captured["method"] = method
         captured["path"] = path
         return {"status": "success"}
@@ -780,6 +973,23 @@ def test_qjudge_coding_test_run_requires_fields():
 def test_qjudge_coding_unknown_action():
     result = run(server.qjudge_coding("wat", DummyContext()))
     assert result == {"error": True, "detail": "Unknown action: wat"}
+
+
+def test_qjudge_coding_rejects_paper_exam_contest(monkeypatch):
+    async def fake_django_api(method, path, ctx, *, json_body=None):
+        if path == "/api/v1/contests/c-1/":
+            return contest_detail(contest_id="c-1", contest_type="paper_exam")
+        raise AssertionError("Should stop before coding endpoint call")
+
+    monkeypatch.setattr(server, "django_api", fake_django_api)
+
+    result = run(server.qjudge_coding("create", DummyContext(), contest_id="c-1", title="A+B"))
+
+    assert result == {
+        "error": True,
+        "detail": "qjudge_coding only supports coding contests. This contest is paper_exam. Use qjudge_exam instead.",
+        "status": 400,
+    }
 
 
 def test_auth_settings_configured():


### PR DESCRIPTION
## Summary
- release `dev` into `main`
- improve MCP server coverage for exam workflows, including paper-exam guardrails, batch create, and explanation support
- fix user management frontend API endpoints and remove delete-user management flow
- include the accumulated dev changes currently ahead of `main`, including MCP test coverage, auth/security fixes, and E2E/CI updates

## Validation
- MCP server unit tests passed: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest mcp-server/tests/test_server.py -q`
- repo pre-push checks passed on `dev` before push, including frontend lint, TypeScript, build, and Docker Compose validation