### PR TITLE
feat: SSE streaming fix + AI exam cards + AI session stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
     name: Judge Tests
     needs: static-checks
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,13 +413,15 @@ jobs:
         with:
           context: backend/judge
           file: backend/judge/Dockerfile.judge
-          tags: |
-            oj-judge:latest
-            ghcr.io/quan0715/qjudge/judge:latest
-          load: true
+          tags: ghcr.io/quan0715/qjudge/judge:latest
           push: true
+          load: true
           cache-from: type=registry,ref=ghcr.io/quan0715/qjudge/judge:buildcache
           cache-to: type=registry,ref=ghcr.io/quan0715/qjudge/judge:buildcache,mode=max
+
+      - name: Tag judge image for local use
+        if: steps.pull-judge.outcome == 'failure'
+        run: docker tag ghcr.io/quan0715/qjudge/judge:latest oj-judge:latest
 
       - name: Verify Judge Image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,13 +376,14 @@ jobs:
           file: backend/judge/Dockerfile.judge
           tags: ghcr.io/quan0715/qjudge/judge:latest
           push: true
-          load: true
           cache-from: type=registry,ref=ghcr.io/quan0715/qjudge/judge:buildcache
           cache-to: type=registry,ref=ghcr.io/quan0715/qjudge/judge:buildcache,mode=max
 
-      - name: Tag judge image for local use
+      - name: Pull and tag judge image for local use
         if: steps.pull-judge.outcome == 'failure'
-        run: docker tag ghcr.io/quan0715/qjudge/judge:latest oj-judge:latest
+        run: |
+          docker pull ghcr.io/quan0715/qjudge/judge:latest
+          docker tag ghcr.io/quan0715/qjudge/judge:latest oj-judge:latest
 
       - name: Verify Judge Image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,21 +99,18 @@ jobs:
           retention-days: 14
 
   # ============================================
-  # Frontend API Integration Tests (Docker test stack)
+  # Integration Tests (shared test stack — up once)
+  # Covers: Frontend API tests + MCP Server integration tests
+  # Auth E2E moved to e2e-manual.yml (manual dispatch, parallel groups)
   # ============================================
-  frontend-api-integration:
-    name: Frontend API Integration Tests
+  integration-tests:
+    name: Integration Tests
     needs: static-checks
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Show Docker version
-        run: |
-          docker --version
-          docker compose version
 
       - name: Start test stack
         run: docker compose -f docker-compose.test.yml up -d --build
@@ -123,7 +120,6 @@ jobs:
           set -euo pipefail
           DC="docker compose -f docker-compose.test.yml"
           for i in $(seq 1 240); do
-            # Fail fast if the container has exited
             STATE=$($DC ps --format '{{.State}}' backend-test 2>/dev/null || echo "missing")
             if [ "$STATE" = "exited" ] || [ "$STATE" = "dead" ] || [ "$STATE" = "missing" ]; then
               echo "backend-test container is not running (state=$STATE). Dumping logs:"
@@ -151,28 +147,40 @@ jobs:
           $DC logs --tail=200 backend-test frontend-test || true
           exit 1
 
-      - name: Run Frontend API Integration Tests
+      - name: Frontend API Integration Tests
         run: docker compose -f docker-compose.test.yml exec -T frontend-test npm run test:api
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install MCP Server dependencies
+        run: pip install "mcp[cli]>=1.9.0" "httpx>=0.27.0" pytest
+        working-directory: mcp-server
+
+      - name: MCP Server Integration Tests
+        env:
+          DJANGO_BASE_URL: http://localhost:8002
+          DJANGO_FORWARDED_PROTO: http
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+        run: python -m pytest tests/test_integration.py -v
+        working-directory: mcp-server
 
       - name: Collect compose logs
         if: always()
-        run: docker compose -f docker-compose.test.yml logs --no-color > frontend-api-compose.log
+        run: docker compose -f docker-compose.test.yml logs --no-color > integration.log
 
-      - name: Upload Frontend API artifacts
+      - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: frontend-api-integration-artifacts
-          path: frontend-api-compose.log
+          name: integration-artifacts
+          path: integration.log
           retention-days: 14
 
       - name: Cleanup
         if: always()
         run: docker compose -f docker-compose.test.yml down -v
-
-  # ============================================
-  # Auth E2E moved to e2e-manual.yml (manual dispatch, parallel groups)
-  # ============================================
 
   # ============================================
   # Backend Unit Tests (no Judge)
@@ -285,53 +293,6 @@ jobs:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: python -m pytest tests/test_server.py -q
         working-directory: mcp-server
-
-  mcp-server-integration:
-    name: MCP Server Integration Tests
-    needs: static-checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Start test stack
-        run: docker compose -f docker-compose.test.yml up -d --build
-
-      - name: Wait for backend readiness
-        uses: ./.github/actions/wait-test-stack
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install MCP Server dependencies
-        run: pip install "mcp[cli]>=1.9.0" "httpx>=0.27.0" pytest
-        working-directory: mcp-server
-
-      - name: Run MCP Integration Tests
-        env:
-          DJANGO_BASE_URL: http://localhost:8002
-          DJANGO_FORWARDED_PROTO: http
-          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
-        run: python -m pytest tests/test_integration.py -v
-        working-directory: mcp-server
-
-      - name: Collect compose logs
-        if: failure()
-        run: docker compose -f docker-compose.test.yml logs --no-color > mcp-integration.log
-
-      - name: Upload artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mcp-integration-artifacts
-          path: mcp-integration.log
-          retention-days: 14
-
-      - name: Cleanup
-        if: always()
-        run: docker compose -f docker-compose.test.yml down -v
 
   # ============================================
   # Judge System Tests (needs Docker)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Judge Docker Image
+      - name: Pull Judge Image from GHCR
+        id: pull-judge
+        continue-on-error: true
+        run: |
+          docker pull ghcr.io/quan0715/qjudge/judge:latest
+          docker tag ghcr.io/quan0715/qjudge/judge:latest oj-judge:latest
+
+      - name: Build Judge Image (fallback if pull failed)
+        if: steps.pull-judge.outcome == 'failure'
         uses: docker/build-push-action@v5
         with:
           context: backend/judge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,8 +387,18 @@ jobs:
         run: pip install -r requirements/dev.txt
         working-directory: backend
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Judge Docker Image
-        run: docker build -t oj-judge:latest -f backend/judge/Dockerfile.judge backend/judge
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/judge
+          file: backend/judge/Dockerfile.judge
+          tags: oj-judge:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Verify Judge Image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,10 @@ jobs:
     name: Judge Tests
     needs: static-checks
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
 
     services:
       postgres:
@@ -390,6 +393,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull Judge Image from GHCR
         id: pull-judge
         continue-on-error: true
@@ -397,16 +407,19 @@ jobs:
           docker pull ghcr.io/quan0715/qjudge/judge:latest
           docker tag ghcr.io/quan0715/qjudge/judge:latest oj-judge:latest
 
-      - name: Build Judge Image (fallback if pull failed)
+      - name: Build and push Judge Image (when pull failed or Dockerfile changed)
         if: steps.pull-judge.outcome == 'failure'
         uses: docker/build-push-action@v5
         with:
           context: backend/judge
           file: backend/judge/Dockerfile.judge
-          tags: oj-judge:latest
+          tags: |
+            oj-judge:latest
+            ghcr.io/quan0715/qjudge/judge:latest
           load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          push: true
+          cache-from: type=registry,ref=ghcr.io/quan0715/qjudge/judge:buildcache
+          cache-to: type=registry,ref=ghcr.io/quan0715/qjudge/judge:buildcache,mode=max
 
       - name: Verify Judge Image
         run: |

--- a/.github/workflows/publish-judge-image.yml
+++ b/.github/workflows/publish-judge-image.yml
@@ -1,0 +1,48 @@
+name: Publish Judge Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/judge/Dockerfile.judge"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-judge-image
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/qjudge/judge
+
+jobs:
+  build-and-push:
+    name: Build & Push Judge Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/judge
+          file: backend/judge/Dockerfile.judge
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/.github/workflows/publish-judge-image.yml
+++ b/.github/workflows/publish-judge-image.yml
@@ -1,10 +1,6 @@
 name: Publish Judge Image
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "backend/judge/Dockerfile.judge"
   workflow_dispatch:
 
 concurrency:

--- a/ai-service/routers/chat.py
+++ b/ai-service/routers/chat.py
@@ -110,6 +110,24 @@ async def generate_resume_events(
         }
 
 
+@router.delete("/thread/{thread_id}")
+async def delete_thread(thread_id: str, app_request: Request) -> dict:
+    """Delete all LangGraph checkpoint state for a thread.
+
+    Used when a session becomes unrecoverable (e.g. dangling tool_calls
+    that can't be repaired). Clears the checkpoint so the next message
+    starts from a clean state on the same session ID.
+    """
+    validate_internal_auth(app_request)
+    runner = app_request.app.state.deepagent_runner
+    try:
+        await runner.delete_thread(thread_id)
+        return {"deleted": True, "thread_id": thread_id}
+    except Exception as e:
+        logger.exception("Failed to delete thread %s: %s", thread_id, e)
+        return {"deleted": False, "thread_id": thread_id, "error": str(e)}
+
+
 @router.post("/resume")
 async def chat_resume(request: ResumeRequest, app_request: Request) -> EventSourceResponse:
     """Resume an interrupted agent with a user decision (approve/reject).

--- a/ai-service/services/deepagent_runner.py
+++ b/ai-service/services/deepagent_runner.py
@@ -335,6 +335,16 @@ class DeepAgentRunner:
                                 await self._checkpointer.adelete_thread(thread_id)
                             raise retry_exc
                     else:
+                        # Repair found nothing to fix in raw messages — the problem
+                        # is likely in _summarization_event state (bad cutoff_index).
+                        # Delete the checkpoint so the next request starts clean.
+                        if "insufficient tool messages" in error_str:
+                            logger.warning(
+                                "Cannot repair dangling tool_calls (summarization state corrupt), "
+                                "deleting checkpoint for thread %s",
+                                thread_id,
+                            )
+                            await self._checkpointer.adelete_thread(thread_id)
                         raise
                 else:
                     raise

--- a/ai-service/services/deepagent_runner.py
+++ b/ai-service/services/deepagent_runner.py
@@ -109,6 +109,13 @@ class DeepAgentRunner:
             await self._checkpointer_cm.__aexit__(None, None, None)
         logger.info("DeepAgent runner shut down.")
 
+    async def delete_thread(self, thread_id: str) -> None:
+        """Delete all checkpoint state for a thread (used to recover broken sessions)."""
+        if self._checkpointer is None:
+            raise RuntimeError("Checkpointer not initialized")
+        await self._checkpointer.adelete_thread(thread_id)
+        logger.info("Deleted LangGraph checkpoint for thread %s", thread_id)
+
     def _build_agent(
         self,
         model_id: str,
@@ -260,13 +267,30 @@ class DeepAgentRunner:
                     yield sse_dict
             except Exception as exc:
                 # Detect dangling tool_calls error → repair and retry once
-                if not retried and "insufficient tool messages" in str(exc):
+                error_str = str(exc)
+                # Also check nested ExceptionGroup sub-exceptions
+                if hasattr(exc, "exceptions"):
+                    error_str += " ".join(str(e) for e in exc.exceptions)
+                if not retried and "insufficient tool messages" in error_str:
                     logger.warning("Dangling tool_calls detected, attempting repair...")
                     repaired = await self._repair_dangling_tool_calls(agent, config)
                     if repaired:
                         retried = True
-                        async for sse_dict in _run_stream():
-                            yield sse_dict
+                        try:
+                            async for sse_dict in _run_stream():
+                                yield sse_dict
+                        except Exception as retry_exc:
+                            # Repair didn't help — nuclear option: delete checkpoint
+                            retry_str = str(retry_exc)
+                            if hasattr(retry_exc, "exceptions"):
+                                retry_str += " ".join(str(e) for e in retry_exc.exceptions)
+                            if "insufficient tool messages" in retry_str:
+                                logger.warning(
+                                    "Repair insufficient, deleting checkpoint for thread %s",
+                                    thread_id,
+                                )
+                                await self._checkpointer.adelete_thread(thread_id)
+                            raise retry_exc
                     else:
                         raise
                 else:

--- a/ai-service/services/deepagent_runner.py
+++ b/ai-service/services/deepagent_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from typing import Any, AsyncGenerator
@@ -19,6 +20,7 @@ from services.event_adapter import (
     RunCompleted,
     RunFailed,
     RunStarted,
+    SummarizationStarted,
     UsageReport,
     adapt_langgraph_event,
     to_sse_dict,
@@ -40,7 +42,14 @@ class _SafeSummarizationMiddleware(SummarizationMiddleware):
     langchain 1.2.15 already has the fix in _lc_helper._find_safe_cutoff_point.
     This subclass simply wires it up until deepagents releases a fix.
     See: https://github.com/langchain-ai/langchain/issues/34282
+
+    Also emits a SummarizationStarted event via an asyncio.Queue side-channel
+    so callers can surface a visible SSE event when compaction fires.
     """
+
+    def __init__(self, *args: Any, event_queue: asyncio.Queue | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._event_queue: asyncio.Queue | None = event_queue
 
     def _partition_messages(
         self,
@@ -51,6 +60,29 @@ class _SafeSummarizationMiddleware(SummarizationMiddleware):
             conversation_messages, cutoff_index
         )
         return self._lc_helper._partition_messages(conversation_messages, safe_cutoff)
+
+    async def awrap_model_call(self, request: Any, handler: Any) -> Any:
+        logger.info("_SafeSummarizationMiddleware.awrap_model_call called")
+        # Mirror the parent's token-count check (read-only) to detect when
+        # compaction will fire so we can emit a side-channel SSE event.
+        try:
+            counted = ([request.system_message, *request.messages]
+                       if request.system_message is not None
+                       else list(request.messages))
+            try:
+                total_tokens = self.token_counter(counted, tools=request.tools)
+            except TypeError:
+                total_tokens = self.token_counter(counted)
+            should = self._should_summarize(list(request.messages), total_tokens)
+            logger.info("SummarizationMiddleware: total_tokens=%d should_summarize=%s trigger=%s", total_tokens, should, getattr(self, 'trigger', '?'))
+            if should:
+                logger.info("SummarizationMiddleware: compaction triggered")
+                if self._event_queue is not None:
+                    await self._event_queue.put(to_sse_dict(SummarizationStarted()))
+        except Exception as e:
+            logger.warning("SummarizationMiddleware observability error: %s", e)
+
+        return await super().awrap_model_call(request, handler)
 
 
 # Default system prompt for the TA agent
@@ -121,6 +153,7 @@ class DeepAgentRunner:
         model_id: str,
         system_prompt: str | None,
         tools: list[Any],
+        event_queue: asyncio.Queue | None = None,
     ):
         """Build a DeepAgent with tools.
 
@@ -148,7 +181,10 @@ class DeepAgentRunner:
             middleware=[
                 TodoListMiddleware(),
                 FilesystemMiddleware(backend=backend),
-                _SafeSummarizationMiddleware(model=summarization_model, backend=backend),
+                # Trigger at ~95k local tokens ≈ ~108k actual tokens (DeepSeek R1 limit: 131k).
+                # count_tokens_approximately underestimates by ~12%, so 95k local ≈ 108k actual,
+                # giving enough headroom for the summarization LLM call output before hitting the limit.
+                _SafeSummarizationMiddleware(model=summarization_model, backend=backend, event_queue=event_queue, trigger=("tokens", 95000)),
             ],
             checkpointer=self._checkpointer,
         )
@@ -229,6 +265,7 @@ class DeepAgentRunner:
         run_id: str,
         thread_id: str,
         model_id: str,
+        event_queue: asyncio.Queue | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Stream agent execution events as SSE-serialisable dicts.
 
@@ -248,6 +285,12 @@ class DeepAgentRunner:
                 config=config,
                 version="v2",
             ):
+                # Drain side-channel events (e.g. summarization_started) before
+                # each LangGraph event so they arrive in roughly the right order.
+                if event_queue is not None:
+                    while not event_queue.empty():
+                        yield event_queue.get_nowait()
+
                 if event.get("event") == "on_chat_model_end":
                     usage_meta = event.get("data", {}).get("output", None)
                     if usage_meta and hasattr(usage_meta, "usage_metadata"):
@@ -365,6 +408,7 @@ class DeepAgentRunner:
         if thread_id is None:
             thread_id = uuid.uuid4().hex
 
+        event_queue: asyncio.Queue = asyncio.Queue()
         async with MCPToolProvider(
             server_url=self._mcp_server_url,
             authorization_header=(
@@ -372,7 +416,7 @@ class DeepAgentRunner:
             ),
         ) as tool_provider:
             tools = await tool_provider.load_tools()
-            agent = self._build_agent(model_id, system_prompt, tools)
+            agent = self._build_agent(model_id, system_prompt, tools, event_queue=event_queue)
 
             config = {
                 "configurable": {"thread_id": thread_id},
@@ -383,7 +427,7 @@ class DeepAgentRunner:
             agent_input: dict[str, Any] = {"messages": messages}
 
             async for sse_dict in self._stream_events(
-                agent, agent_input, config, run_id, thread_id, model_id
+                agent, agent_input, config, run_id, thread_id, model_id, event_queue=event_queue
             ):
                 yield sse_dict
 
@@ -398,6 +442,7 @@ class DeepAgentRunner:
         """Resume an interrupted agent with a user decision and stream events."""
         run_id = uuid.uuid4().hex
 
+        event_queue: asyncio.Queue = asyncio.Queue()
         async with MCPToolProvider(
             server_url=self._mcp_server_url,
             authorization_header=(
@@ -405,7 +450,7 @@ class DeepAgentRunner:
             ),
         ) as tool_provider:
             tools = await tool_provider.load_tools()
-            agent = self._build_agent(model_id, system_prompt, tools)
+            agent = self._build_agent(model_id, system_prompt, tools, event_queue=event_queue)
 
             config = {
                 "configurable": {"thread_id": thread_id},
@@ -416,7 +461,7 @@ class DeepAgentRunner:
             resume_value = Command(resume={"decisions": [{"type": decision}]})
 
             async for sse_dict in self._stream_events(
-                agent, resume_value, config, run_id, thread_id, model_id
+                agent, resume_value, config, run_id, thread_id, model_id, event_queue=event_queue
             ):
                 yield sse_dict
 

--- a/ai-service/services/event_adapter.py
+++ b/ai-service/services/event_adapter.py
@@ -34,6 +34,11 @@ class ThinkingDelta:
 
 
 @dataclass(slots=True)
+class SummarizationStarted:
+    pass
+
+
+@dataclass(slots=True)
 class VerificationReport:
     iteration: int
     passed: bool
@@ -87,6 +92,7 @@ InternalEvent = Union[
     RunStarted,
     AgentMessageDelta,
     ThinkingDelta,
+    SummarizationStarted,
     VerificationReport,
     ToolCallStarted,
     ToolCallFinished,
@@ -100,6 +106,7 @@ _TYPE_NAME_MAP: dict[type, str] = {
     RunStarted: "run_started",
     AgentMessageDelta: "agent_message_delta",
     ThinkingDelta: "thinking_delta",
+    SummarizationStarted: "summarization_started",
     VerificationReport: "verification_report",
     ToolCallStarted: "tool_call_started",
     ToolCallFinished: "tool_call_finished",

--- a/backend/apps/ai/services/session_runtime.py
+++ b/backend/apps/ai/services/session_runtime.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncGenerator, Callable
 from typing import Any
 
 import httpx
+from asgiref.sync import sync_to_async
 from django.http import StreamingHttpResponse
 from django.utils import timezone
 
@@ -286,13 +287,13 @@ class ChatStreamRuntime(BaseAIStreamRuntime):
 
     async def generate(self) -> AsyncGenerator[str, None]:
         if self.session:
-            AIMessage.objects.create(
+            await sync_to_async(AIMessage.objects.create)(
                 session=self.session,
                 role=AIMessage.Role.USER,
                 content=self.content,
                 message_type=AIMessage.MessageType.TEXT,
             )
-            self._ensure_log()
+            await sync_to_async(self._ensure_log)()
 
         init_event = {
             "type": "init",
@@ -308,9 +309,9 @@ class ChatStreamRuntime(BaseAIStreamRuntime):
         ):
             yield chunk
 
-        self._persist_session()
-        self._persist_response()
-        self._complete_log()
+        await sync_to_async(self._persist_session)()
+        await sync_to_async(self._persist_response)()
+        await sync_to_async(self._complete_log)()
 
 
 class ResumeStreamRuntime(BaseAIStreamRuntime):
@@ -392,4 +393,4 @@ class ResumeStreamRuntime(BaseAIStreamRuntime):
             error_prefix="Error proxying resume to ai-service",
         ):
             yield chunk
-        self._persist_response()
+        await sync_to_async(self._persist_response)()

--- a/backend/apps/ai/services/session_runtime.py
+++ b/backend/apps/ai/services/session_runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import AsyncGenerator, Callable
 from typing import Any
 
 import httpx
@@ -22,8 +22,8 @@ from .stream_proxy import (
 logger = logging.getLogger(__name__)
 
 
-def build_sse_response(generator: Generator[str, None, None]) -> StreamingHttpResponse:
-    """Wrap a generator in a standard SSE response."""
+def build_sse_response(generator: AsyncGenerator[str, None]) -> StreamingHttpResponse:
+    """Wrap an async generator in a standard SSE response."""
     response = StreamingHttpResponse(generator, content_type="text/event-stream")
     response["Cache-Control"] = "no-cache"
     response["X-Accel-Buffering"] = "no"
@@ -38,13 +38,13 @@ class BaseAIStreamRuntime:
     def _error_event(self, message: str) -> str:
         return f"data: {json.dumps({'type': 'error', 'content': message})}\n\n"
 
-    def _proxy_stream(
+    async def _proxy_stream(
         self,
         *,
         payload: dict[str, Any],
         on_event: Callable[[dict[str, Any]], None],
         error_prefix: str,
-    ) -> Generator[str, None, None]:
+    ) -> AsyncGenerator[str, None]:
         try:
             ai_headers = build_ai_service_headers(getattr(self, "user", None))
         except RuntimeError as exc:
@@ -54,35 +54,47 @@ class BaseAIStreamRuntime:
             return
 
         try:
-            with httpx.stream(
-                "POST",
-                f"{ai_service_base_url()}{self.endpoint}",
-                json=payload,
-                headers=ai_headers,
-                timeout=httpx.Timeout(10.0, read=120.0),
-            ) as response:
-                if response.status_code != 200:
-                    response.read()
-                    error_text = response.text
-                    logger.error(
-                        "%s: %s - %s",
-                        error_prefix,
-                        response.status_code,
-                        error_text,
-                    )
-                    self.stream_error = f"ai-service error: {response.status_code}"
-                    yield self._error_event(self.stream_error)
-                    return
+            async with httpx.AsyncClient() as client:
+                async with client.stream(
+                    "POST",
+                    f"{ai_service_base_url()}{self.endpoint}",
+                    json=payload,
+                    headers=ai_headers,
+                    timeout=httpx.Timeout(10.0, read=120.0),
+                ) as response:
+                    if response.status_code != 200:
+                        await response.aread()
+                        error_text = response.text
+                        logger.error(
+                            "%s: %s - %s",
+                            error_prefix,
+                            response.status_code,
+                            error_text,
+                        )
+                        self.stream_error = f"ai-service error: {response.status_code}"
+                        yield self._error_event(self.stream_error)
+                        return
 
-                # Use iter_bytes for real-time streaming (iter_lines buffers too aggressively)
-                buffer = ""
-                for chunk in response.iter_bytes():
-                    buffer += chunk.decode("utf-8", errors="replace")
-                    while "\n" in buffer:
-                        line, buffer = buffer.split("\n", 1)
-                        line = line.strip()
-                        if not line:
-                            continue
+                    buffer = ""
+                    async for chunk in response.aiter_bytes():
+                        buffer += chunk.decode("utf-8", errors="replace")
+                        while "\n" in buffer:
+                            line, buffer = buffer.split("\n", 1)
+                            line = line.strip()
+                            if not line:
+                                continue
+                            if line.startswith("data: "):
+                                try:
+                                    event = json.loads(line[6:])
+                                    on_event(event)
+                                except json.JSONDecodeError:
+                                    pass
+                                yield f"{line}\n\n"
+                            else:
+                                yield f"{line}\n"
+                    # Flush remaining buffer
+                    if buffer.strip():
+                        line = buffer.strip()
                         if line.startswith("data: "):
                             try:
                                 event = json.loads(line[6:])
@@ -92,18 +104,6 @@ class BaseAIStreamRuntime:
                             yield f"{line}\n\n"
                         else:
                             yield f"{line}\n"
-                # Flush any remaining content in buffer (last line without trailing \n)
-                if buffer.strip():
-                    line = buffer.strip()
-                    if line.startswith("data: "):
-                        try:
-                            event = json.loads(line[6:])
-                            on_event(event)
-                        except json.JSONDecodeError:
-                            pass
-                        yield f"{line}\n\n"
-                    else:
-                        yield f"{line}\n"
         except Exception as exc:
             self.stream_error = str(exc)
             logger.exception("%s: %s", error_prefix, exc)
@@ -284,7 +284,7 @@ class ChatStreamRuntime(BaseAIStreamRuntime):
             total_cost_cents=F("total_cost_cents") + (cost_cents or 0),
         )
 
-    def generate(self) -> Generator[str, None, None]:
+    async def generate(self) -> AsyncGenerator[str, None]:
         if self.session:
             AIMessage.objects.create(
                 session=self.session,
@@ -301,11 +301,12 @@ class ChatStreamRuntime(BaseAIStreamRuntime):
         }
         yield f"data: {json.dumps(init_event)}\n\n"
 
-        yield from self._proxy_stream(
+        async for chunk in self._proxy_stream(
             payload=self._build_payload(),
             on_event=self._handle_event,
             error_prefix="Error proxying to ai-service",
-        )
+        ):
+            yield chunk
 
         self._persist_session()
         self._persist_response()
@@ -384,10 +385,11 @@ class ResumeStreamRuntime(BaseAIStreamRuntime):
                 total_cost_cents=F("total_cost_cents") + cost_cents,
             )
 
-    def generate(self) -> Generator[str, None, None]:
-        yield from self._proxy_stream(
+    async def generate(self) -> AsyncGenerator[str, None]:
+        async for chunk in self._proxy_stream(
             payload=self._build_payload(),
             on_event=self._handle_event,
             error_prefix="Error proxying resume to ai-service",
-        )
+        ):
+            yield chunk
         self._persist_response()

--- a/backend/apps/ai/tests/test_message_streaming.py
+++ b/backend/apps/ai/tests/test_message_streaming.py
@@ -1,5 +1,5 @@
 """Tests for AI message streaming functionality."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -16,6 +16,61 @@ def _create_user(username, email, password="testpass123"):
     return User.objects.create_user(
         username=username, email=email, password=password,
     )
+
+
+def _mock_async_stream(thread_id: str):
+    """Build mock for httpx.AsyncClient.stream (async context manager)."""
+    lines = [
+        f'data: {{"type":"run_started","thread_id":"{thread_id}"}}\n\n',
+        'data: {"type":"agent_message_delta","content":"Hello"}\n\n',
+        'data: {"type":"usage_report","input_tokens":10,"output_tokens":5,"cost_cents":1}\n\n',
+        'data: {"type":"done"}\n\n',
+    ]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    async def aiter_bytes():
+        for line in lines:
+            yield line.encode("utf-8")
+
+    mock_response.aiter_bytes = aiter_bytes
+
+    # async context manager for client.stream()
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__.return_value = mock_response
+    stream_cm.__aexit__.return_value = None
+
+    # async context manager for AsyncClient()
+    mock_client = MagicMock()
+    mock_client.stream.return_value = stream_cm
+
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = mock_client
+    client_cm.__aexit__.return_value = None
+
+    return client_cm
+
+
+def _mock_async_stream_error():
+    """Build mock for httpx.AsyncClient returning 500."""
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+    mock_response.aread = AsyncMock(return_value=b"Internal Server Error")
+
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__.return_value = mock_response
+    stream_cm.__aexit__.return_value = None
+
+    mock_client = MagicMock()
+    mock_client.stream.return_value = stream_cm
+
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = mock_client
+    client_cm.__aexit__.return_value = None
+
+    return client_cm
 
 
 class MessageStreamingTestCase(TestCase):
@@ -36,37 +91,22 @@ class MessageStreamingTestCase(TestCase):
             context={"title": "other"},
         )
 
-    def _mock_stream_response(self, thread_id: str):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        lines = [
-            f'data: {{"type":"run_started","thread_id":"{thread_id}"}}\n\n',
-            'data: {"type":"agent_message_delta","content":"Hello"}\n\n',
-            'data: {"type":"usage_report","input_tokens":10,"output_tokens":5,"cost_cents":1}\n\n',
-            'data: {"type":"done"}\n\n',
-        ]
-        mock_response.iter_bytes.return_value = [line.encode("utf-8") for line in lines]
-        return mock_response
-
     def test_send_message_stream_to_own_session(self):
         self.client.force_authenticate(user=self.user)
         with patch(
             "apps.ai.services.session_runtime.build_ai_service_headers",
             return_value={"X-AI-Internal-Token": "test"},
         ), patch(
-            "apps.ai.services.session_runtime.httpx.stream"
-        ) as mock_stream:
-            mock_stream.return_value.__enter__.return_value = self._mock_stream_response(
-                self.session.session_id
-            )
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream(self.session.session_id),
+        ):
             response = self.client.post(
                 f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
                 {"content": "Hello"},
                 format="json",
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            # Consume stream so finally-block persistence runs.
-            _ = b"".join(response.streaming_content)
+            _ = b"".join(response)
 
     def test_send_message_stream_to_other_user_session_returns_404(self):
         self.client.force_authenticate(user=self.user)
@@ -84,18 +124,15 @@ class MessageStreamingTestCase(TestCase):
             "apps.ai.services.session_runtime.build_ai_service_headers",
             return_value={"X-AI-Internal-Token": "test"},
         ), patch(
-            "apps.ai.services.session_runtime.httpx.stream"
-        ) as mock_stream:
-            mock_stream.return_value.__enter__.return_value = self._mock_stream_response(
-                self.session.session_id
-            )
-
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream(self.session.session_id),
+        ):
             response = self.client.post(
                 f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
                 {"content": "User question"},
                 format="json",
             )
-            _ = b"".join(response.streaming_content)
+            _ = b"".join(response)
 
             user_messages = AIMessage.objects.filter(
                 session=self.session,
@@ -118,18 +155,16 @@ class MessageStreamingTestCase(TestCase):
             "apps.ai.services.session_runtime.build_ai_service_headers",
             return_value={"X-AI-Internal-Token": "test"},
         ), patch(
-            "apps.ai.services.session_runtime.httpx.stream"
-        ) as mock_stream:
-            mock_stream.return_value.__enter__.return_value = self._mock_stream_response(
-                ai_thread_id
-            )
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream(ai_thread_id),
+        ):
             response = self.client.post(
                 f"/api/v1/ai/sessions/{backend_session_id}/send_message_stream/",
                 {"content": "Hello"},
                 format="json",
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            _ = b"".join(response.streaming_content)
+            _ = b"".join(response)
 
         self.assertTrue(
             AISession.objects.filter(session_id=ai_thread_id, user=self.user).exists()
@@ -142,14 +177,9 @@ class MessageStreamingTestCase(TestCase):
             "apps.ai.services.session_runtime.build_ai_service_headers",
             return_value={"X-AI-Internal-Token": "test"},
         ), patch(
-            "apps.ai.services.session_runtime.httpx.stream"
-        ) as mock_stream:
-            mock_response = MagicMock()
-            mock_response.status_code = 500
-            mock_response.text = "Internal Server Error"
-            mock_response.read.return_value = b"Internal Server Error"
-            mock_stream.return_value.__enter__.return_value = mock_response
-
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream_error(),
+        ):
             response = self.client.post(
                 f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
                 {"content": "Hello"},
@@ -157,8 +187,9 @@ class MessageStreamingTestCase(TestCase):
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            payload = b"".join(response.streaming_content).decode("utf-8", errors="ignore")
+            payload = b"".join(response).decode("utf-8", errors="ignore")
             self.assertIn('"type": "error"', payload)
+
 
 class MessagePersistenceTestCase(TestCase):
     """Test message persistence in sessions."""

--- a/backend/apps/ai/views.py
+++ b/backend/apps/ai/views.py
@@ -153,7 +153,14 @@ class AISessionViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"])
     def clear(self, request, pk=None):
-        """Clear all messages in a session."""
+        """Clear all messages in a session and delete the LangGraph checkpoint.
+
+        Deletes both Django messages and the LangGraph checkpoint state so broken
+        threads (e.g. dangling tool_calls) are fully reset on the next message.
+        """
+        import httpx
+        from .services.stream_proxy import ai_service_base_url, build_ai_service_headers
+
         session = self.get_object()
         session.messages.all().delete()
 
@@ -161,6 +168,17 @@ class AISessionViewSet(viewsets.ModelViewSet):
         title = session.context.get("title") if session.context else None
         session.context = {"title": title} if title else {}
         session.save(update_fields=["context", "updated_at"])
+
+        # Delete LangGraph checkpoint so broken state is fully wiped
+        try:
+            ai_headers = build_ai_service_headers(request.user)
+            httpx.delete(
+                f"{ai_service_base_url()}/api/chat/thread/{session.session_id}",
+                headers=ai_headers,
+                timeout=10.0,
+            )
+        except Exception as e:
+            logger.warning("Failed to delete LangGraph thread %s: %s", session.session_id, e)
 
         # Add welcome message
         AIMessage.objects.create(

--- a/backend/apps/ai/views.py
+++ b/backend/apps/ai/views.py
@@ -83,7 +83,7 @@ class AISessionViewSet(viewsets.ModelViewSet):
         })
 
     @action(detail=True, methods=["post"])
-    def send_message_stream(self, request, pk=None):
+    async def send_message_stream(self, request, pk=None):
         """Send a message and stream AI response (proxied to ai-service).
 
         設計說明：
@@ -228,7 +228,7 @@ class AISessionViewSet(viewsets.ModelViewSet):
         })
 
     @action(detail=True, methods=["post"])
-    def resume_stream(self, request, pk=None):
+    async def resume_stream(self, request, pk=None):
         """Resume an interrupted agent and stream the result.
 
         Proxies to ai-service /api/chat/resume endpoint.

--- a/backend/apps/ai/views.py
+++ b/backend/apps/ai/views.py
@@ -83,7 +83,7 @@ class AISessionViewSet(viewsets.ModelViewSet):
         })
 
     @action(detail=True, methods=["post"])
-    async def send_message_stream(self, request, pk=None):
+    def send_message_stream(self, request, pk=None):
         """Send a message and stream AI response (proxied to ai-service).
 
         設計說明：
@@ -228,7 +228,7 @@ class AISessionViewSet(viewsets.ModelViewSet):
         })
 
     @action(detail=True, methods=["post"])
-    async def resume_stream(self, request, pk=None):
+    def resume_stream(self, request, pk=None):
         """Resume an interrupted agent and stream the result.
 
         Proxies to ai-service /api/chat/resume endpoint.

--- a/backend/apps/users/views/_impl.py
+++ b/backend/apps/users/views/_impl.py
@@ -14,6 +14,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.utils.decorators import method_decorator
 from django.core.cache import cache
 from django.urls import reverse
 from django_ratelimit.decorators import ratelimit
@@ -47,10 +49,11 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 
+@method_decorator(ensure_csrf_cookie, name="dispatch")
 class CurrentUserView(SchemaAPIView):
     """
     Get current authenticated user information.
-    
+
     GET /api/v1/users/me
     """
     permission_classes = [IsAuthenticated]

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -258,6 +258,8 @@ CORS_ALLOW_HEADERS = [
 CSRF_TRUSTED_ORIGINS = [
     "http://localhost:3000",
     "http://localhost:5173",
+    "https://q-judge-dev.quan.wtf",
+    "https://q-judge.quan.wtf",
 ]
 
 # Session cookie settings

--- a/backend/config/settings/dev.py
+++ b/backend/config/settings/dev.py
@@ -95,6 +95,11 @@ if os.getenv('FRONTEND_URL'):
 CSRF_TRUSTED_ORIGINS = [origin.strip('/') for origin in os.getenv('CSRF_TRUSTED_ORIGINS', '').split(',') if origin]
 if os.getenv('FRONTEND_URL'):
     CSRF_TRUSTED_ORIGINS.append(os.getenv('FRONTEND_URL').strip('/'))
+# Cloudflare Tunnel dev domains
+for _host in os.getenv('ALLOWED_HOSTS', '').split(','):
+    _host = _host.strip()
+    if _host and _host not in ('localhost', '127.0.0.1', '0.0.0.0', '*'):
+        CSRF_TRUSTED_ORIGINS.append(f'https://{_host}')
 
 # Allow all origins in dev if needed (optional, but good for local dev)
 CORS_ALLOW_ALL_ORIGINS = True

--- a/backend/judge/Dockerfile.judge
+++ b/backend/judge/Dockerfile.judge
@@ -2,7 +2,8 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN for i in 1 2 3; do apt-get update && break || sleep 10; done \
+    && apt-get install -y \
     g++ \
     gcc \
     time \

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -1,6 +1,7 @@
 -r base.txt
 
 # Development tools
+uvicorn[standard]>=0.34,<1.0
 ipython>=8.18,<9.0
 django-debug-toolbar>=4.2,<4.3
 django-extensions>=3.2,<3.3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -145,7 +145,7 @@ services:
         DJANGO_ENV: development
     image: oj_backend_dev_img
     container_name: oj_backend_dev
-    command: python manage.py runserver 0.0.0.0:8000
+    command: uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload --reload-dir /app
     volumes:
       - ./backend:/app
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -145,7 +145,7 @@ services:
         DJANGO_ENV: development
     image: oj_backend_dev_img
     container_name: oj_backend_dev
-    command: uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload --reload-dir /app
+    command: python -m uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload --reload-dir /app
     volumes:
       - ./backend:/app
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -424,12 +424,9 @@ services:
       - oj_network
 
   # Judge Environment Image
-  # This service is only for building the image used by Celery workers.
-  # It exits immediately after starting.
+  # Image is pre-pulled from GHCR by deploy-prod.sh (oj-judge:latest).
+  # This service just ensures the image is present before celery workers start.
   judge-image:
-    build:
-      context: ./backend/judge
-      dockerfile: Dockerfile.judge
     image: oj-judge:latest
     container_name: oj_judge_image
     command: ["true"]

--- a/docs/superpowers/plans/2026-04-16-sse-asgi-streaming.md
+++ b/docs/superpowers/plans/2026-04-16-sse-asgi-streaming.md
@@ -14,22 +14,24 @@
 
 ## File Map
 
-| File | Action | Responsibility |
-|------|--------|---------------|
-| `docker-compose.dev.yml` | Modify line 148 | Switch backend command from `runserver` to `uvicorn` |
-| `backend/apps/ai/services/session_runtime.py` | Rewrite | Convert `_proxy_stream` + `generate` to async generators using `httpx.AsyncClient` |
-| `backend/apps/ai/views.py` | Modify lines 86-137, 231-266 | Make `send_message_stream` and `resume_stream` actions `async` |
-| `backend/apps/ai/tests/test_message_streaming.py` | Modify | Update mocks from sync `httpx.stream` to async `httpx.AsyncClient.stream` |
-| `frontend/nginx/default.conf` | Modify lines 9-15 | Add SSE-specific proxy headers for production Nginx |
+
+| File                                              | Action                       | Responsibility                                                                     |
+| ------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------- |
+| `docker-compose.dev.yml`                          | Modify line 148              | Switch backend command from `runserver` to `uvicorn`                               |
+| `backend/apps/ai/services/session_runtime.py`     | Rewrite                      | Convert `_proxy_stream` + `generate` to async generators using `httpx.AsyncClient` |
+| `backend/apps/ai/views.py`                        | Modify lines 86-137, 231-266 | Make `send_message_stream` and `resume_stream` actions `async`                     |
+| `backend/apps/ai/tests/test_message_streaming.py` | Modify                       | Update mocks from sync `httpx.stream` to async `httpx.AsyncClient.stream`          |
+| `frontend/nginx/default.conf`                     | Modify lines 9-15            | Add SSE-specific proxy headers for production Nginx                                |
+
 
 ---
 
 ### Task 1: Switch dev backend to uvicorn
 
 **Files:**
-- Modify: `docker-compose.dev.yml:148`
 
-- [ ] **Step 1: Change backend command**
+- Modify: `docker-compose.dev.yml:148`
+- **Step 1: Change backend command**
 
 In `docker-compose.dev.yml`, replace the backend command:
 
@@ -43,7 +45,7 @@ In `docker-compose.dev.yml`, replace the backend command:
 
 `--reload-dir /app` scopes the file watcher to the mounted volume (avoids watching node_modules or venv).
 
-- [ ] **Step 2: Verify uvicorn starts**
+- **Step 2: Verify uvicorn starts**
 
 ```bash
 docker compose -f docker-compose.dev.yml up -d --no-deps backend
@@ -52,7 +54,7 @@ docker compose -f docker-compose.dev.yml logs backend --since=10s
 
 Expected: `INFO: Uvicorn running on http://0.0.0.0:8000` (no import errors).
 
-- [ ] **Step 3: Verify existing REST endpoints still work**
+- **Step 3: Verify existing REST endpoints still work**
 
 ```bash
 curl -s http://localhost:8000/api/v1/auth/me -H "Cookie: access_token=<JWT>" | python3 -m json.tool
@@ -60,7 +62,7 @@ curl -s http://localhost:8000/api/v1/auth/me -H "Cookie: access_token=<JWT>" | p
 
 Expected: 200 OK with user JSON. All sync DRF views work unchanged under ASGI.
 
-- [ ] **Step 4: Commit**
+- **Step 4: Commit**
 
 ```bash
 git add docker-compose.dev.yml
@@ -72,11 +74,12 @@ git commit -m "chore: switch dev backend from runserver to uvicorn for ASGI stre
 ### Task 2: Convert session_runtime to async
 
 **Files:**
+
 - Modify: `backend/apps/ai/services/session_runtime.py`
 
 This is the core change. Convert `_proxy_stream` from sync `httpx.stream()` to async `httpx.AsyncClient.stream()`, and convert `generate()` from `Generator` to `AsyncGenerator`.
 
-- [ ] **Step 1: Rewrite `build_sse_response` for async generators**
+- **Step 1: Rewrite `build_sse_response` for async generators**
 
 Replace the existing function at line 25-30:
 
@@ -94,7 +97,7 @@ def build_sse_response(generator: AsyncGenerator[str, None]) -> StreamingHttpRes
 
 Stays sync (no `async def`) — it just constructs the response object. Django 4.2+ `StreamingHttpResponse` accepts async iterators when running under ASGI.
 
-- [ ] **Step 2: Rewrite `BaseAIStreamRuntime._proxy_stream` to async**
+- **Step 2: Rewrite `BaseAIStreamRuntime._proxy_stream` to async**
 
 Replace the entire `_proxy_stream` method (lines 41-110) with:
 
@@ -172,13 +175,13 @@ async def _proxy_stream(
 ```
 
 Key changes from sync version:
+
 - `httpx.stream()` → `httpx.AsyncClient().stream()`
 - `response.iter_bytes()` → `response.aiter_bytes()`
 - `response.read()` → `await response.aread()`
 - `Generator` → `AsyncGenerator`
 - `yield from` is not allowed in async generators, so callers must use `async for`
-
-- [ ] **Step 3: Convert `ChatStreamRuntime.generate` to async**
+- **Step 3: Convert `ChatStreamRuntime.generate` to async**
 
 Replace the `generate` method (lines 287-312):
 
@@ -214,7 +217,7 @@ async def generate(self) -> AsyncGenerator[str, None]:
 
 Note: `yield from` → `async for ... yield`. The ORM calls (`_persist_*`) are sync but Django 4.2 allows sync ORM in async context (auto-wraps in `sync_to_async`).
 
-- [ ] **Step 4: Convert `ResumeStreamRuntime.generate` to async**
+- **Step 4: Convert `ResumeStreamRuntime.generate` to async**
 
 Replace the `generate` method (lines 387-393):
 
@@ -229,7 +232,7 @@ async def generate(self) -> AsyncGenerator[str, None]:
     self._persist_response()
 ```
 
-- [ ] **Step 5: Update imports at top of file**
+- **Step 5: Update imports at top of file**
 
 Replace the imports (lines 1-12):
 
@@ -258,7 +261,7 @@ from .stream_proxy import (
 
 Remove `Generator` from imports, add `AsyncGenerator`.
 
-- [ ] **Step 6: Commit**
+- **Step 6: Commit**
 
 ```bash
 git add backend/apps/ai/services/session_runtime.py
@@ -270,9 +273,9 @@ git commit -m "feat(ai): convert SSE proxy to async for true ASGI streaming"
 ### Task 3: Make SSE view actions async
 
 **Files:**
-- Modify: `backend/apps/ai/views.py:86-137, 231-266`
 
-- [ ] **Step 1: Make `send_message_stream` async**
+- Modify: `backend/apps/ai/views.py:86-137, 231-266`
+- **Step 1: Make `send_message_stream` async**
 
 Change line 86 from `def` to `async def`, and line 137 to `await`:
 
@@ -294,7 +297,7 @@ async def send_message_stream(self, request, pk=None):
 
 Only one change: `async def` on declaration. `build_sse_response` stays sync (just constructs the response object).
 
-- [ ] **Step 2: Make `resume_stream` async**
+- **Step 2: Make `resume_stream` async**
 
 Change line 231 from `def` to `async def`:
 
@@ -312,7 +315,7 @@ async def resume_stream(self, request, pk=None):
     return build_sse_response(runtime.generate())
 ```
 
-- [ ] **Step 3: Commit**
+- **Step 3: Commit**
 
 ```bash
 git add backend/apps/ai/views.py
@@ -324,11 +327,12 @@ git commit -m "feat(ai): make SSE view actions async for ASGI streaming"
 ### Task 4: Update tests for async
 
 **Files:**
+
 - Modify: `backend/apps/ai/tests/test_message_streaming.py`
 
 The tests mock `httpx.stream` (sync context manager). After the change, the code uses `httpx.AsyncClient.stream` (async context manager). Update the mocks.
 
-- [ ] **Step 1: Rewrite the mock helper and patch targets**
+- **Step 1: Rewrite the mock helper and patch targets**
 
 Replace the `_mock_stream_response` method and update all test methods:
 
@@ -526,7 +530,7 @@ class MessageStreamingTestCase(TestCase):
             self.assertIn('"type": "error"', payload)
 ```
 
-- [ ] **Step 2: Run tests**
+- **Step 2: Run tests**
 
 ```bash
 docker compose -f docker-compose.dev.yml exec -T backend python -m pytest apps/ai/tests/test_message_streaming.py -v --no-cov
@@ -534,7 +538,7 @@ docker compose -f docker-compose.dev.yml exec -T backend python -m pytest apps/a
 
 Expected: All 5 tests pass (plus the 2 persistence tests which don't touch streaming).
 
-- [ ] **Step 3: Commit**
+- **Step 3: Commit**
 
 ```bash
 git add backend/apps/ai/tests/test_message_streaming.py
@@ -547,7 +551,7 @@ git commit -m "test(ai): update streaming tests for async httpx mocks"
 
 **Files:** None (manual verification)
 
-- [ ] **Step 1: Restart backend with uvicorn**
+- **Step 1: Restart backend with uvicorn**
 
 ```bash
 docker compose -f docker-compose.dev.yml up -d --no-deps --build backend
@@ -556,7 +560,7 @@ docker compose -f docker-compose.dev.yml logs backend --since=10s
 
 Expected: `INFO: Uvicorn running on http://0.0.0.0:8000`
 
-- [ ] **Step 2: Verify SSE streams incrementally via curl**
+- **Step 2: Verify SSE streams incrementally via curl**
 
 Generate a fresh CSRF token and JWT, then:
 
@@ -574,24 +578,25 @@ curl -N --no-buffer --max-time 60 -X POST \
 
 Expected: Events arrive at **different timestamps** — `init` immediately, `run_started` within 1s, then `agent_message_delta` tokens spread across seconds. This is the key success criterion.
 
-- [ ] **Step 3: Verify in browser**
+- **Step 3: Verify in browser**
 
 Open the chatbot in the browser and send a message. Verify:
+
 - Reasoning panel opens and shows thinking content incrementally
 - Chain of Thought steps appear one by one with spinners
 - Text response streams character by character
 - "Response stopped" no longer appears for normal completions
-
-- [ ] **Step 4: Verify non-SSE endpoints unaffected**
+- **Step 4: Verify non-SSE endpoints unaffected**
 
 Spot-check a few REST endpoints:
+
 - `GET /api/v1/ai/sessions/` — list sessions
 - `POST /api/v1/ai/sessions/new_session/` — create session
 - `GET /api/v1/auth/me` — user info
 
 Expected: All return correct JSON responses as before.
 
-- [ ] **Step 5: Commit (if any adjustments were needed)**
+- **Step 5: Commit (if any adjustments were needed)**
 
 ```bash
 git add -A
@@ -603,11 +608,12 @@ git commit -m "fix(ai): verified async SSE streaming works end-to-end"
 ### Task 6: Fix production Nginx SSE config
 
 **Files:**
+
 - Modify: `frontend/nginx/default.conf:9-15`
 
 The production Nginx config lacks SSE-specific headers. While the backend sets `X-Accel-Buffering: no` (which Nginx respects), adding explicit SSE configuration is defensive and handles edge cases.
 
-- [ ] **Step 1: Add SSE proxy settings to `/api/` location**
+- **Step 1: Add SSE proxy settings to `/api/` location**
 
 Replace lines 9-15 in `frontend/nginx/default.conf`:
 
@@ -629,14 +635,15 @@ location /api/ {
 ```
 
 Key additions:
+
 - `proxy_http_version 1.1` — required for chunked transfer encoding
 - `proxy_set_header Connection ''` — prevents hop-by-hop Connection header issues
 - `proxy_buffering off` — belt-and-suspenders with `X-Accel-Buffering: no`
 - `proxy_cache off` — no caching of SSE responses
-
-- [ ] **Step 2: Commit**
+- **Step 2: Commit**
 
 ```bash
 git add frontend/nginx/default.conf
 git commit -m "fix(nginx): add SSE streaming proxy headers for production"
 ```
+

--- a/docs/superpowers/plans/2026-04-16-sse-asgi-streaming.md
+++ b/docs/superpowers/plans/2026-04-16-sse-asgi-streaming.md
@@ -1,0 +1,642 @@
+# SSE ASGI Streaming Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix SSE streaming so events reach the frontend incrementally instead of being buffered by Django's WSGI `runserver`.
+
+**Architecture:** Switch the dev backend from `python manage.py runserver` (WSGI, buffers `StreamingHttpResponse`) to `uvicorn` (ASGI, true streaming). Convert the two SSE proxy views to async using `httpx.AsyncClient`. The ASGI infrastructure already exists (`config/asgi.py`, `uvicorn` installed, `channels` configured). Non-SSE views remain synchronous and unaffected.
+
+**Tech Stack:** Django 4.2, DRF 3.15, uvicorn 0.35, httpx 0.28 (AsyncClient), channels 4.3
+
+**Root cause (proven):** `python manage.py runserver` uses `wsgiref` (WSGI) which buffers the entire `StreamingHttpResponse` generator output and flushes only when the generator is exhausted. Verified by curl: all SSE events arrive at the same timestamp after 13s delay. Direct httpx test to ai-service confirmed events stream incrementally (timestamps spread across seconds).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `docker-compose.dev.yml` | Modify line 148 | Switch backend command from `runserver` to `uvicorn` |
+| `backend/apps/ai/services/session_runtime.py` | Rewrite | Convert `_proxy_stream` + `generate` to async generators using `httpx.AsyncClient` |
+| `backend/apps/ai/views.py` | Modify lines 86-137, 231-266 | Make `send_message_stream` and `resume_stream` actions `async` |
+| `backend/apps/ai/tests/test_message_streaming.py` | Modify | Update mocks from sync `httpx.stream` to async `httpx.AsyncClient.stream` |
+| `frontend/nginx/default.conf` | Modify lines 9-15 | Add SSE-specific proxy headers for production Nginx |
+
+---
+
+### Task 1: Switch dev backend to uvicorn
+
+**Files:**
+- Modify: `docker-compose.dev.yml:148`
+
+- [ ] **Step 1: Change backend command**
+
+In `docker-compose.dev.yml`, replace the backend command:
+
+```yaml
+# OLD (line 148):
+    command: python manage.py runserver 0.0.0.0:8000
+
+# NEW:
+    command: uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload --reload-dir /app
+```
+
+`--reload-dir /app` scopes the file watcher to the mounted volume (avoids watching node_modules or venv).
+
+- [ ] **Step 2: Verify uvicorn starts**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --no-deps backend
+docker compose -f docker-compose.dev.yml logs backend --since=10s
+```
+
+Expected: `INFO: Uvicorn running on http://0.0.0.0:8000` (no import errors).
+
+- [ ] **Step 3: Verify existing REST endpoints still work**
+
+```bash
+curl -s http://localhost:8000/api/v1/auth/me -H "Cookie: access_token=<JWT>" | python3 -m json.tool
+```
+
+Expected: 200 OK with user JSON. All sync DRF views work unchanged under ASGI.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.dev.yml
+git commit -m "chore: switch dev backend from runserver to uvicorn for ASGI streaming"
+```
+
+---
+
+### Task 2: Convert session_runtime to async
+
+**Files:**
+- Modify: `backend/apps/ai/services/session_runtime.py`
+
+This is the core change. Convert `_proxy_stream` from sync `httpx.stream()` to async `httpx.AsyncClient.stream()`, and convert `generate()` from `Generator` to `AsyncGenerator`.
+
+- [ ] **Step 1: Rewrite `build_sse_response` for async generators**
+
+Replace the existing function at line 25-30:
+
+```python
+from django.http import StreamingHttpResponse
+from collections.abc import AsyncGenerator
+
+def build_sse_response(generator: AsyncGenerator[str, None]) -> StreamingHttpResponse:
+    """Wrap an async generator in a standard SSE response."""
+    response = StreamingHttpResponse(generator, content_type="text/event-stream")
+    response["Cache-Control"] = "no-cache"
+    response["X-Accel-Buffering"] = "no"
+    return response
+```
+
+Stays sync (no `async def`) — it just constructs the response object. Django 4.2+ `StreamingHttpResponse` accepts async iterators when running under ASGI.
+
+- [ ] **Step 2: Rewrite `BaseAIStreamRuntime._proxy_stream` to async**
+
+Replace the entire `_proxy_stream` method (lines 41-110) with:
+
+```python
+async def _proxy_stream(
+    self,
+    *,
+    payload: dict[str, Any],
+    on_event: Callable[[dict[str, Any]], None],
+    error_prefix: str,
+) -> AsyncGenerator[str, None]:
+    try:
+        ai_headers = build_ai_service_headers(getattr(self, "user", None))
+    except RuntimeError as exc:
+        self.stream_error = str(exc)
+        logger.error(self.stream_error)
+        yield self._error_event(self.stream_error)
+        return
+
+    try:
+        async with httpx.AsyncClient() as client:
+            async with client.stream(
+                "POST",
+                f"{ai_service_base_url()}{self.endpoint}",
+                json=payload,
+                headers=ai_headers,
+                timeout=httpx.Timeout(10.0, read=120.0),
+            ) as response:
+                if response.status_code != 200:
+                    await response.aread()
+                    error_text = response.text
+                    logger.error(
+                        "%s: %s - %s",
+                        error_prefix,
+                        response.status_code,
+                        error_text,
+                    )
+                    self.stream_error = f"ai-service error: {response.status_code}"
+                    yield self._error_event(self.stream_error)
+                    return
+
+                buffer = ""
+                async for chunk in response.aiter_bytes():
+                    buffer += chunk.decode("utf-8", errors="replace")
+                    while "\n" in buffer:
+                        line, buffer = buffer.split("\n", 1)
+                        line = line.strip()
+                        if not line:
+                            continue
+                        if line.startswith("data: "):
+                            try:
+                                event = json.loads(line[6:])
+                                on_event(event)
+                            except json.JSONDecodeError:
+                                pass
+                            yield f"{line}\n\n"
+                        else:
+                            yield f"{line}\n"
+                # Flush remaining buffer
+                if buffer.strip():
+                    line = buffer.strip()
+                    if line.startswith("data: "):
+                        try:
+                            event = json.loads(line[6:])
+                            on_event(event)
+                        except json.JSONDecodeError:
+                            pass
+                        yield f"{line}\n\n"
+                    else:
+                        yield f"{line}\n"
+    except Exception as exc:
+        self.stream_error = str(exc)
+        logger.exception("%s: %s", error_prefix, exc)
+        yield self._error_event(self.stream_error)
+```
+
+Key changes from sync version:
+- `httpx.stream()` → `httpx.AsyncClient().stream()`
+- `response.iter_bytes()` → `response.aiter_bytes()`
+- `response.read()` → `await response.aread()`
+- `Generator` → `AsyncGenerator`
+- `yield from` is not allowed in async generators, so callers must use `async for`
+
+- [ ] **Step 3: Convert `ChatStreamRuntime.generate` to async**
+
+Replace the `generate` method (lines 287-312):
+
+```python
+async def generate(self) -> AsyncGenerator[str, None]:
+    if self.session:
+        AIMessage.objects.create(
+            session=self.session,
+            role=AIMessage.Role.USER,
+            content=self.content,
+            message_type=AIMessage.MessageType.TEXT,
+        )
+        self._ensure_log()
+
+    init_event = {
+        "type": "init",
+        "backend_session_id": self.backend_session_id,
+        "is_new_session": self.session is None,
+    }
+    yield f"data: {json.dumps(init_event)}\n\n"
+
+    async for chunk in self._proxy_stream(
+        payload=self._build_payload(),
+        on_event=self._handle_event,
+        error_prefix="Error proxying to ai-service",
+    ):
+        yield chunk
+
+    self._persist_session()
+    self._persist_response()
+    self._complete_log()
+```
+
+Note: `yield from` → `async for ... yield`. The ORM calls (`_persist_*`) are sync but Django 4.2 allows sync ORM in async context (auto-wraps in `sync_to_async`).
+
+- [ ] **Step 4: Convert `ResumeStreamRuntime.generate` to async**
+
+Replace the `generate` method (lines 387-393):
+
+```python
+async def generate(self) -> AsyncGenerator[str, None]:
+    async for chunk in self._proxy_stream(
+        payload=self._build_payload(),
+        on_event=self._handle_event,
+        error_prefix="Error proxying resume to ai-service",
+    ):
+        yield chunk
+    self._persist_response()
+```
+
+- [ ] **Step 5: Update imports at top of file**
+
+Replace the imports (lines 1-12):
+
+```python
+"""Runtime helpers for AI session streaming flows."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncGenerator, Callable
+from typing import Any
+
+import httpx
+from django.http import StreamingHttpResponse
+from django.utils import timezone
+
+from ..models import AIMessage, AISession
+from .stream_proxy import (
+    ai_service_base_url,
+    build_ai_service_headers,
+    complete_execution_log,
+    create_execution_log,
+)
+```
+
+Remove `Generator` from imports, add `AsyncGenerator`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/apps/ai/services/session_runtime.py
+git commit -m "feat(ai): convert SSE proxy to async for true ASGI streaming"
+```
+
+---
+
+### Task 3: Make SSE view actions async
+
+**Files:**
+- Modify: `backend/apps/ai/views.py:86-137, 231-266`
+
+- [ ] **Step 1: Make `send_message_stream` async**
+
+Change line 86 from `def` to `async def`, and line 137 to `await`:
+
+```python
+@action(detail=True, methods=["post"])
+async def send_message_stream(self, request, pk=None):
+    """Send a message and stream AI response (proxied to ai-service)."""
+    # ... (all existing validation logic stays identical, lines 101-135) ...
+
+    runtime = ChatStreamRuntime(
+        user=request.user,
+        backend_session_id=pk,
+        session=session,
+        content=content,
+        validated_data=serializer.validated_data,
+    )
+    return build_sse_response(runtime.generate())
+```
+
+Only one change: `async def` on declaration. `build_sse_response` stays sync (just constructs the response object).
+
+- [ ] **Step 2: Make `resume_stream` async**
+
+Change line 231 from `def` to `async def`:
+
+```python
+@action(detail=True, methods=["post"])
+async def resume_stream(self, request, pk=None):
+    """Resume an interrupted agent and stream the result."""
+    # ... (all existing validation logic stays identical, lines 239-259) ...
+
+    runtime = ResumeStreamRuntime(
+        user=request.user,
+        session=session,
+        decision=decision,
+    )
+    return build_sse_response(runtime.generate())
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/apps/ai/views.py
+git commit -m "feat(ai): make SSE view actions async for ASGI streaming"
+```
+
+---
+
+### Task 4: Update tests for async
+
+**Files:**
+- Modify: `backend/apps/ai/tests/test_message_streaming.py`
+
+The tests mock `httpx.stream` (sync context manager). After the change, the code uses `httpx.AsyncClient.stream` (async context manager). Update the mocks.
+
+- [ ] **Step 1: Rewrite the mock helper and patch targets**
+
+Replace the `_mock_stream_response` method and update all test methods:
+
+```python
+"""Tests for AI message streaming functionality."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.ai.models import AIMessage, AISession
+
+User = get_user_model()
+
+
+def _create_user(username, email, password="testpass123"):
+    """Helper: create a test user."""
+    return User.objects.create_user(
+        username=username, email=email, password=password,
+    )
+
+
+def _mock_async_stream(thread_id: str):
+    """Build mock for httpx.AsyncClient.stream (async context manager)."""
+    lines = [
+        f'data: {{"type":"run_started","thread_id":"{thread_id}"}}\n\n',
+        'data: {"type":"agent_message_delta","content":"Hello"}\n\n',
+        'data: {"type":"usage_report","input_tokens":10,"output_tokens":5,"cost_cents":1}\n\n',
+        'data: {"type":"done"}\n\n',
+    ]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    async def aiter_bytes():
+        for line in lines:
+            yield line.encode("utf-8")
+
+    mock_response.aiter_bytes = aiter_bytes
+
+    # async context manager for client.stream()
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__.return_value = mock_response
+    stream_cm.__aexit__.return_value = None
+
+    # async context manager for AsyncClient()
+    mock_client = MagicMock()
+    mock_client.stream.return_value = stream_cm
+
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = mock_client
+    client_cm.__aexit__.return_value = None
+
+    return client_cm
+
+
+def _mock_async_stream_error():
+    """Build mock for httpx.AsyncClient returning 500."""
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+    mock_response.aread = AsyncMock(return_value=b"Internal Server Error")
+
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__.return_value = mock_response
+    stream_cm.__aexit__.return_value = None
+
+    mock_client = MagicMock()
+    mock_client.stream.return_value = stream_cm
+
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = mock_client
+    client_cm.__aexit__.return_value = None
+
+    return client_cm
+
+
+class MessageStreamingTestCase(TestCase):
+    """Test message streaming endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = _create_user("testuser", "test@example.com")
+        self.other_user = _create_user("otheruser", "other@example.com")
+        self.session = AISession.objects.create(
+            session_id="44444444-4444-4444-4444-444444444444",
+            user=self.user,
+            context={"title": "existing"},
+        )
+        self.other_session = AISession.objects.create(
+            session_id="55555555-5555-5555-5555-555555555555",
+            user=self.other_user,
+            context={"title": "other"},
+        )
+
+    def test_send_message_stream_to_own_session(self):
+        self.client.force_authenticate(user=self.user)
+        with patch(
+            "apps.ai.services.session_runtime.build_ai_service_headers",
+            return_value={"X-AI-Internal-Token": "test"},
+        ), patch(
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream(self.session.session_id),
+        ):
+            response = self.client.post(
+                f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
+                {"content": "Hello"},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            _ = b"".join(response.streaming_content)
+
+    def test_send_message_stream_to_other_user_session_returns_404(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            f"/api/v1/ai/sessions/{self.other_session.session_id}/send_message_stream/",
+            {"content": "Hello"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_message_saved_after_streaming(self):
+        self.client.force_authenticate(user=self.user)
+
+        with patch(
+            "apps.ai.services.session_runtime.build_ai_service_headers",
+            return_value={"X-AI-Internal-Token": "test"},
+        ), patch(
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream(self.session.session_id),
+        ):
+            response = self.client.post(
+                f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
+                {"content": "User question"},
+                format="json",
+            )
+            _ = b"".join(response.streaming_content)
+
+            user_messages = AIMessage.objects.filter(
+                session=self.session,
+                role=AIMessage.Role.USER,
+                content="User question",
+            )
+            assistant_messages = AIMessage.objects.filter(
+                session=self.session,
+                role=AIMessage.Role.ASSISTANT,
+            )
+            self.assertEqual(user_messages.count(), 1)
+            self.assertGreaterEqual(assistant_messages.count(), 1)
+
+    def test_non_existent_session_id_treated_as_new_backend_session(self):
+        self.client.force_authenticate(user=self.user)
+        backend_session_id = "66666666-6666-6666-6666-666666666666"
+        ai_thread_id = "77777777-7777-7777-7777-777777777777"
+
+        with patch(
+            "apps.ai.services.session_runtime.build_ai_service_headers",
+            return_value={"X-AI-Internal-Token": "test"},
+        ), patch(
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream(ai_thread_id),
+        ):
+            response = self.client.post(
+                f"/api/v1/ai/sessions/{backend_session_id}/send_message_stream/",
+                {"content": "Hello"},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            _ = b"".join(response.streaming_content)
+
+        self.assertTrue(
+            AISession.objects.filter(session_id=ai_thread_id, user=self.user).exists()
+        )
+
+    def test_ai_service_error_handling(self):
+        self.client.force_authenticate(user=self.user)
+
+        with patch(
+            "apps.ai.services.session_runtime.build_ai_service_headers",
+            return_value={"X-AI-Internal-Token": "test"},
+        ), patch(
+            "apps.ai.services.session_runtime.httpx.AsyncClient",
+            return_value=_mock_async_stream_error(),
+        ):
+            response = self.client.post(
+                f"/api/v1/ai/sessions/{self.session.session_id}/send_message_stream/",
+                {"content": "Hello"},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            payload = b"".join(response.streaming_content).decode("utf-8", errors="ignore")
+            self.assertIn('"type": "error"', payload)
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T backend python -m pytest apps/ai/tests/test_message_streaming.py -v --no-cov
+```
+
+Expected: All 5 tests pass (plus the 2 persistence tests which don't touch streaming).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/apps/ai/tests/test_message_streaming.py
+git commit -m "test(ai): update streaming tests for async httpx mocks"
+```
+
+---
+
+### Task 5: End-to-end streaming verification
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Restart backend with uvicorn**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --no-deps --build backend
+docker compose -f docker-compose.dev.yml logs backend --since=10s
+```
+
+Expected: `INFO: Uvicorn running on http://0.0.0.0:8000`
+
+- [ ] **Step 2: Verify SSE streams incrementally via curl**
+
+Generate a fresh CSRF token and JWT, then:
+
+```bash
+curl -N --no-buffer --max-time 60 -X POST \
+  "http://localhost:8000/api/v1/ai/sessions/<SESSION_ID>/send_message_stream/" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: <CSRF>" \
+  -H "X-QJudge-Agent-Contract: v2" \
+  -H "Cookie: access_token=<JWT>; csrftoken=<CSRF>" \
+  -d '{"content": "你好"}' 2>&1 | while IFS= read -r line; do
+    [ -n "$line" ] && echo "[$(date +%H:%M:%S)] $line"
+  done
+```
+
+Expected: Events arrive at **different timestamps** — `init` immediately, `run_started` within 1s, then `agent_message_delta` tokens spread across seconds. This is the key success criterion.
+
+- [ ] **Step 3: Verify in browser**
+
+Open the chatbot in the browser and send a message. Verify:
+- Reasoning panel opens and shows thinking content incrementally
+- Chain of Thought steps appear one by one with spinners
+- Text response streams character by character
+- "Response stopped" no longer appears for normal completions
+
+- [ ] **Step 4: Verify non-SSE endpoints unaffected**
+
+Spot-check a few REST endpoints:
+- `GET /api/v1/ai/sessions/` — list sessions
+- `POST /api/v1/ai/sessions/new_session/` — create session
+- `GET /api/v1/auth/me` — user info
+
+Expected: All return correct JSON responses as before.
+
+- [ ] **Step 5: Commit (if any adjustments were needed)**
+
+```bash
+git add -A
+git commit -m "fix(ai): verified async SSE streaming works end-to-end"
+```
+
+---
+
+### Task 6: Fix production Nginx SSE config
+
+**Files:**
+- Modify: `frontend/nginx/default.conf:9-15`
+
+The production Nginx config lacks SSE-specific headers. While the backend sets `X-Accel-Buffering: no` (which Nginx respects), adding explicit SSE configuration is defensive and handles edge cases.
+
+- [ ] **Step 1: Add SSE proxy settings to `/api/` location**
+
+Replace lines 9-15 in `frontend/nginx/default.conf`:
+
+```nginx
+# Backend API proxy
+location /api/ {
+    proxy_pass http://backend:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+
+    # SSE streaming support
+    proxy_http_version 1.1;
+    proxy_set_header Connection '';
+    proxy_buffering off;
+    proxy_cache off;
+}
+```
+
+Key additions:
+- `proxy_http_version 1.1` — required for chunked transfer encoding
+- `proxy_set_header Connection ''` — prevents hop-by-hop Connection header issues
+- `proxy_buffering off` — belt-and-suspenders with `X-Accel-Buffering: no`
+- `proxy_cache off` — no caching of SSE responses
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/nginx/default.conf
+git commit -m "fix(nginx): add SSE streaming proxy headers for production"
+```

--- a/docs/superpowers/specs/2026-04-16-ai-exam-preview-card-design.md
+++ b/docs/superpowers/specs/2026-04-16-ai-exam-preview-card-design.md
@@ -1,0 +1,210 @@
+# AI Exam Preview Card — Design Spec
+
+## 目標
+
+AI chatbot 透過 `qjudge_exam` tool 建立筆試題目後，在聊天訊息中渲染 preview card，讓使用者直覺看到建立結果。
+
+## 範圍
+
+- 僅處理 `qjudge_exam` tool（create / batch_create）
+- Card 為純展示，不帶導頁
+- 多題時每題一張 card，垂直排列
+- 失敗不渲染 card（由 AI 文字說明）
+
+## 現有 Pipeline（不改動）
+
+```
+MCP tool (qjudge_exam) → tool result
+  → ai-service SSE: tool_call_finished { tool_call_id, result, is_error }
+  → backend proxy（透傳 + persist 到 metadata.tools_executed）
+  → 前端 ChatbotWidget.handleEvent()
+```
+
+Tool result 已包含所有需要的欄位，不需要在 MCP 或後端層額外組裝。
+
+## Exam Tool Result 格式
+
+### create（單題）
+
+```json
+{
+  "id": "uuid",
+  "question_type": "single_choice",
+  "prompt": "以下哪個是正確的...",
+  "score": 10,
+  "options": ["A. ...", "B. ...", "C. ...", "D. ..."],
+  "correct_answer": "A",
+  "explanation": "因為..."
+}
+```
+
+### batch_create（多題）
+
+```json
+{
+  "created": [
+    { "id": "uuid", "question_type": "single_choice", "prompt": "...", "score": 10, "options": [...] },
+    { "id": "uuid", "question_type": "true_false", "prompt": "...", "score": 5, "options": [...] }
+  ],
+  "deleted_count": 0
+}
+```
+
+## 前端變更
+
+### 1. 新增元件：`AIExamQuestionCard`
+
+**位置**：`frontend/src/features/chatbot/components/AIExamQuestionCard.tsx`
+
+**Props**：
+
+```typescript
+interface AIExamQuestionCardProps {
+  questionType: ExamQuestionType;  // single_choice | multiple_choice | true_false | short_answer | essay
+  prompt: string;
+  score?: number;
+  optionCount?: number;            // options.length（選擇題 / 是非題）
+}
+```
+
+**視覺結構**（參考 `QuestionBankPreviewCard` 風格，簡化版）：
+
+```
+┌──────────────────────────────────┐
+│  [RadioIcon] 單選題        10 分 │
+│                                  │
+│  以下哪個是正確的 TCP 三次       │
+│  握手流程...                     │
+│                                  │
+│  4 個選項                        │
+└──────────────────────────────────┘
+```
+
+- 頂部：題型 icon（複用 `EXAM_QUESTION_TYPE_ICON`）+ 題型 label（複用 `getQuestionTypeLabel`）+ 分數
+- 中間：prompt 截斷顯示（2 行 clamp）
+- 底部：選項數量（僅選擇題/是非題有 options 時顯示）
+- 整體使用 Carbon design tokens 保持視覺一致（`--cds-layer-01` 背景等）
+- 無 click handler
+
+### 2. 修改：`ChatbotWidget.handleEvent()`
+
+**檔案**：`frontend/src/features/chatbot/components/ChatbotWidget.tsx`
+
+在 `handleEvent` 函式中：
+
+#### 2a. 新增暫存陣列
+
+在 streaming 開始時（與 `cotSteps` 同層）新增：
+
+```typescript
+const pendingCards: AIExamQuestionCardProps[] = [];
+```
+
+#### 2b. 擴充 `tool_call_finished` case
+
+在現有 CoT 更新邏輯之後，加入 card 收集：
+
+```typescript
+case "tool_call_finished": {
+  // ... 現有 CoT step 更新邏輯（不動） ...
+
+  // 收集 exam card data
+  if (
+    e.tool_name === "qjudge_exam" &&
+    !e.is_error &&
+    e.result &&
+    typeof e.result === "object"
+  ) {
+    const result = e.result as Record<string, unknown>;
+
+    if (result.id && result.question_type) {
+      // create — 單題
+      pendingCards.push(extractExamCardProps(result));
+    } else if (Array.isArray(result.created)) {
+      // batch_create — 多題
+      for (const item of result.created) {
+        if (item && typeof item === "object" && item.id) {
+          pendingCards.push(extractExamCardProps(item));
+        }
+      }
+    }
+  }
+  break;
+}
+```
+
+#### 2c. 擴充 `run_completed` case
+
+在 `sendFinal` 之後、`onProblemUpdated` 之前，注入 cards：
+
+```typescript
+case "run_completed": {
+  sendFinal(false);
+
+  if (pendingCards.length > 0) {
+    const cardItems = pendingCards.map(props => ({
+      response_type: "user_defined" as const,
+      user_defined: {
+        type: "ai-exam-question-card",
+        ...props,
+      },
+    }));
+    inst.messaging.addMessage({
+      output: { generic: cardItems },
+    });
+  }
+
+  onProblemUpdated?.();
+  break;
+}
+```
+
+### 3. 新增 helper：`extractExamCardProps`
+
+**位置**：同檔或獨立 util（視複雜度決定）
+
+```typescript
+function extractExamCardProps(result: Record<string, unknown>): AIExamQuestionCardProps {
+  const options = Array.isArray(result.options) ? result.options : [];
+  return {
+    questionType: (result.question_type as ExamQuestionType) || "single_choice",
+    prompt: typeof result.prompt === "string" ? result.prompt : "",
+    score: typeof result.score === "number" ? result.score : undefined,
+    optionCount: options.length > 0 ? options.length : undefined,
+  };
+}
+```
+
+### 4. Carbon `user_defined` 渲染註冊
+
+需要在 `ChatCustomElement` 的設定中註冊 `ai-exam-question-card` 的 renderer，使用 React portal 將 `AIExamQuestionCard` 渲染到 Carbon Web Component 的 slot 中。
+
+具體做法依 `@carbon/ai-chat` 的 `user_defined` rendering API：
+- 監聽 `BusEventType.MESSAGE_ITEM_USER_DEFINED`（或等效事件）
+- 根據 `user_defined.type === "ai-exam-question-card"` 渲染對應 React 元件
+
+## 複用的現有資源
+
+| 資源 | 來源 | 用途 |
+|------|------|------|
+| `EXAM_QUESTION_TYPE_ICON` | `shared/ui/examQuestionTypeVisual.ts` | 題型 icon |
+| `getQuestionTypeLabel()` | `features/contest/constants/examLabels.ts` | 題型中文 label |
+| `ExamQuestionType` | `core/entities/contest.entity.ts` | TypeScript 型別 |
+| Carbon design tokens | `@carbon/react` | 樣式一致性 |
+
+## 不做的事
+
+- 不改 MCP tool 回傳格式
+- 不改 ai-service SSE event 格式
+- 不改後端 persist 邏輯
+- 不做導頁功能
+- 不處理 `qjudge_coding` tool（後續擴充）
+- 不處理 exam 的 `update` / `delete` / `import_from_bank` action
+
+## 產出檔案
+
+| 檔案 | 動作 |
+|------|------|
+| `frontend/src/features/chatbot/components/AIExamQuestionCard.tsx` | 新增 |
+| `frontend/src/features/chatbot/components/AIExamQuestionCard.module.scss` | 新增 |
+| `frontend/src/features/chatbot/components/ChatbotWidget.tsx` | 修改 |

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -12,6 +12,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
+
+        # SSE streaming support
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
     }
 
     # OAuth 2.1 well-known metadata (used by MCP clients for discovery)

--- a/frontend/src/features/chatbot/components/AIExamQuestionCard.module.scss
+++ b/frontend/src/features/chatbot/components/AIExamQuestionCard.module.scss
@@ -1,0 +1,53 @@
+@use "@carbon/layout";
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-03;
+  padding: layout.$spacing-04;
+  border: 1px solid var(--cds-border-subtle);
+  border-radius: 4px;
+  background-color: var(--cds-layer-01, var(--cds-layer));
+}
+
+.topRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: layout.$spacing-03;
+}
+
+.typeInfo {
+  display: inline-flex;
+  align-items: center;
+  gap: layout.$spacing-02;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--cds-icon-secondary);
+}
+
+.typeLabel {
+  color: var(--cds-text-secondary);
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.prompt {
+  margin: 0;
+  color: var(--cds-text-primary);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.meta {
+  color: var(--cds-text-secondary);
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+}

--- a/frontend/src/features/chatbot/components/AIExamQuestionCard.tsx
+++ b/frontend/src/features/chatbot/components/AIExamQuestionCard.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Tag } from "@carbon/react";
+import { useTranslation } from "react-i18next";
+import type { ExamQuestionType } from "@/core/entities/contest.entity";
+import { EXAM_QUESTION_TYPE_ICON } from "@/shared/ui/examQuestionTypeVisual";
+import { getQuestionTypeLabel } from "@/features/contest/constants/examLabels";
+import styles from "./AIExamQuestionCard.module.scss";
+
+export interface AIExamQuestionCardProps {
+  questionType: ExamQuestionType;
+  prompt: string;
+  score?: number;
+  optionCount?: number;
+}
+
+export const AIExamQuestionCard: React.FC<AIExamQuestionCardProps> = ({
+  questionType,
+  prompt,
+  score,
+  optionCount,
+}) => {
+  const { t } = useTranslation("common");
+  const Icon = EXAM_QUESTION_TYPE_ICON[questionType];
+  const typeLabel = getQuestionTypeLabel(questionType);
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.topRow}>
+        <div className={styles.typeInfo}>
+          <span className={styles.icon}>
+            <Icon size={16} />
+          </span>
+          <span className={styles.typeLabel}>{typeLabel}</span>
+        </div>
+        {score != null && (
+          <Tag size="sm" type="gray">
+            {t("aiCard.score", "{{score}} 分", { score })}
+          </Tag>
+        )}
+      </div>
+
+      <p className={styles.prompt} title={prompt}>
+        {prompt}
+      </p>
+
+      {optionCount != null && optionCount > 0 && (
+        <span className={styles.meta}>
+          {t("aiCard.optionCount", "{{count}} 個選項", { count: optionCount })}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/chatbot/components/ChatFullPage.tsx
+++ b/frontend/src/features/chatbot/components/ChatFullPage.tsx
@@ -102,8 +102,25 @@ export default function ChatFullPage() {
           case "run_started": if (e.thread_id) { backendSessionIdRef.current = e.thread_id; currentSessionIdRef.current = e.thread_id; } break;
           case "thinking_delta": if (e.content) { accThinking += e.content; inst.messaging.addMessageChunk({ partial_item: { response_type: MessageResponseTypes.TEXT, text: "", streaming_metadata: { id: textItemId, cancellable: true } }, partial_response: { message_options: { reasoning: { content: accThinking } } }, streaming_metadata: { response_id: responseId } } as StreamChunk); } break;
           case "agent_message_delta": if (e.content) sendPartial(e.content); break;
-          case "tool_call_started": if (e.tool_name) { cotSteps.push({ title: e.tool_name, tool_name: e.tool_name, status: ChainOfThoughtStepStatus.PROCESSING, request: e.input_data ? { args: e.input_data } : undefined }); sendPartial(); } break;
-          case "tool_call_finished": { let i = cotSteps.length - 1; for (; i >= 0; i--) if (cotSteps[i].status === ChainOfThoughtStepStatus.PROCESSING) break; if (i >= 0) cotSteps[i] = { ...cotSteps[i], status: e.is_error ? ChainOfThoughtStepStatus.FAILURE : ChainOfThoughtStepStatus.SUCCESS, response: e.result ? { content: typeof e.result === "string" ? e.result : JSON.stringify(e.result, null, 2) } : undefined }; sendPartial(); break; }
+          case "tool_call_started":
+            if (e.tool_name) {
+              cotSteps.push({
+                title: e.tool_name,
+                tool_name: e.tool_call_id || `${e.tool_name}-${cotSteps.length}`,
+                status: ChainOfThoughtStepStatus.PROCESSING,
+                request: e.input_data ? { args: e.input_data } : undefined,
+              });
+              sendPartial();
+            }
+            break;
+          case "tool_call_finished": {
+            const idx = e.tool_call_id
+              ? cotSteps.findIndex(s => s.tool_name === e.tool_call_id)
+              : cotSteps.findLastIndex(s => s.status === ChainOfThoughtStepStatus.PROCESSING);
+            if (idx >= 0) cotSteps[idx] = { ...cotSteps[idx], status: e.is_error ? ChainOfThoughtStepStatus.FAILURE : ChainOfThoughtStepStatus.SUCCESS, response: e.result ? { content: typeof e.result === "string" ? e.result : JSON.stringify(e.result, null, 2) } : undefined };
+            sendPartial();
+            break;
+          }
           case "run_completed": sendFinal(false); break;
           case "run_failed": console.error("[ChatFullPage] Agent error:", e.message); break;
         }

--- a/frontend/src/features/chatbot/components/ChatFullPage.tsx
+++ b/frontend/src/features/chatbot/components/ChatFullPage.tsx
@@ -96,7 +96,7 @@ export default function ChatFullPage() {
         inst.messaging.addMessageChunk({ final_response: { id: responseId, output: { generic: [item] }, ...(mo ? { message_options: mo } : {}) } } as StreamChunk);
       };
 
-      const handleEvent = (e: { type: string; thread_id?: string; content?: string; tool_name?: string; input_data?: Record<string, unknown>; result?: string | Record<string, unknown>; is_error?: boolean; message?: string }) => {
+      const handleEvent = (e: { type: string; thread_id?: string; content?: string; tool_name?: string; tool_call_id?: string; input_data?: Record<string, unknown>; result?: string | Record<string, unknown>; is_error?: boolean; message?: string }) => {
         if (isCanceled) return;
         switch (e.type) {
           case "run_started": if (e.thread_id) { backendSessionIdRef.current = e.thread_id; currentSessionIdRef.current = e.thread_id; } break;
@@ -114,9 +114,10 @@ export default function ChatFullPage() {
             }
             break;
           case "tool_call_finished": {
+            const lastProcessingIdx = (() => { for (let i = cotSteps.length - 1; i >= 0; i--) { if (cotSteps[i].status === ChainOfThoughtStepStatus.PROCESSING) return i; } return -1; })();
             const idx = e.tool_call_id
               ? cotSteps.findIndex(s => s.tool_name === e.tool_call_id)
-              : cotSteps.findLastIndex(s => s.status === ChainOfThoughtStepStatus.PROCESSING);
+              : lastProcessingIdx;
             if (idx >= 0) cotSteps[idx] = { ...cotSteps[idx], status: e.is_error ? ChainOfThoughtStepStatus.FAILURE : ChainOfThoughtStepStatus.SUCCESS, response: e.result ? { content: typeof e.result === "string" ? e.result : JSON.stringify(e.result, null, 2) } : undefined };
             sendPartial();
             break;

--- a/frontend/src/features/chatbot/components/ChatFullPage.tsx
+++ b/frontend/src/features/chatbot/components/ChatFullPage.tsx
@@ -180,7 +180,7 @@ export default function ChatFullPage() {
     } catch { return []; }
   }, []);
 
-  const config = useRef<PublicConfig>({
+  const config = useMemo<PublicConfig>(() => ({
     messaging: { customSendMessage, showStopButtonImmediately: true, messageTimeoutSecs: 120, customLoadHistory },
     history: { isOn: true },
     header: { isOn: false },
@@ -192,7 +192,7 @@ export default function ChatFullPage() {
     },
     openChatByDefault: true,
     assistantName: "QJudge AI",
-  }).current;
+  }), [customSendMessage, customLoadHistory]);
 
   const handleSessionSelect = useCallback((sessionId: string) => {
     backendSessionIdRef.current = sessionId;
@@ -209,6 +209,7 @@ export default function ChatFullPage() {
     if (!instance) return {};
     return {
       [WriteableElementName.HISTORY_PANEL_ELEMENT]: (
+        // eslint-disable-next-line react-hooks/refs
         <ChatHistory instance={instance} currentSessionId={currentSessionIdRef.current} onSessionSelect={handleSessionSelect} onNewChat={handleNewChat} showHeader={false} />
       ),
     };

--- a/frontend/src/features/chatbot/components/ChatFullPage.tsx
+++ b/frontend/src/features/chatbot/components/ChatFullPage.tsx
@@ -132,7 +132,15 @@ export default function ChatFullPage() {
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
           const lines = buffer.split("\n"); buffer = lines.pop() ?? "";
-          for (const raw of lines) { const l = raw.trimEnd(); if (l.startsWith("data: ")) { try { handleEvent(JSON.parse(l.slice(6))); } catch { /* */ } } }
+          for (const raw of lines) {
+            const l = raw.trimEnd();
+            if (l.startsWith("data: ")) {
+              try {
+                handleEvent(JSON.parse(l.slice(6)));
+                await new Promise(r => setTimeout(r, 0));
+              } catch { /* */ }
+            }
+          }
         }
         if (buffer.trim().startsWith("data: ")) { try { handleEvent(JSON.parse(buffer.trim().slice(6))); } catch { /* */ } }
       })().catch((err) => {

--- a/frontend/src/features/chatbot/components/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget.tsx
@@ -24,10 +24,12 @@ import {
   type ButtonItem,
   type CardItem,
   type ChatInstance,
+  type GenericItem,
   type HistoryItem,
   type ChainOfThoughtStep,
   type CustomSendMessageOptions,
   type MessageRequest,
+  type RenderUserDefinedResponse,
   type StreamChunk,
   type PublicConfig,
   type BusEventViewChange,
@@ -39,6 +41,8 @@ import { chatbotRepository } from "@/infrastructure/api/repositories";
 import { httpClient } from "@/infrastructure/api/http.client";
 import { useAuth } from "@/features/auth/contexts/AuthContext";
 import { ChatHistory } from "./ChatHistory";
+import { AIExamQuestionCard, type AIExamQuestionCardProps } from "./AIExamQuestionCard";
+import { extractExamCards } from "./extractExamCards";
 import type { ChatSession } from "@/core/types/chatbot.types";
 import styles from "./ChatbotSidePanel.module.scss";
 
@@ -110,6 +114,10 @@ export const ChatbotWidget = ({
   const instanceRef = useRef<ChatInstance | null>(null);
   // Prevent double-firing when multiple HITL buttons exist in chat history
   const approvalInProgressRef = useRef(false);
+  // Block Enter for 1 s after compositionend so the composition-ending keystroke
+  // cannot immediately trigger a submit (IME double-Enter protection).
+  const blockEnterUntilRef = useRef<number>(0);
+  const inputElRef = useRef<HTMLElement | null>(null);
 
   const isTeacherOrAdmin = user?.role === "teacher" || user?.role === "admin";
 
@@ -140,6 +148,9 @@ export const ChatbotWidget = ({
       let accText = "";
       let accThinking = "";
       const cotSteps: ChainOfThoughtStep[] = [];
+      const pendingCards: AIExamQuestionCardProps[] = [];
+      // Map tool_call_id → { tool_name, action } for card extraction on tool_call_finished
+      const toolCallMeta = new Map<string, { toolName: string; action?: string }>();
       let isCanceled = false;
 
       const abortHandler = () => { isCanceled = true; };
@@ -190,9 +201,13 @@ export const ChatbotWidget = ({
             break;
           case "tool_call_started":
             if (e.tool_name) {
+              const callId = e.tool_call_id || `${e.tool_name}-${cotSteps.length}`;
+              toolCallMeta.set(callId, { toolName: e.tool_name, action: e.input_data?.action as string | undefined });
+              const action = e.input_data?.action as string | undefined;
+              const stepTitle = action ? `${e.tool_name}.${action}` : e.tool_name;
               cotSteps.push({
-                title: e.tool_name,
-                tool_name: e.tool_call_id || `${e.tool_name}-${cotSteps.length}`,
+                title: `${stepTitle} #${cotSteps.length + 1}`,
+                tool_name: callId,
                 status: ChainOfThoughtStepStatus.PROCESSING,
                 request: e.input_data ? { args: e.input_data } : undefined,
               });
@@ -200,17 +215,47 @@ export const ChatbotWidget = ({
             }
             break;
           case "tool_call_finished": {
-            const idx = e.tool_call_id
-              ? cotSteps.findIndex(s => s.tool_name === e.tool_call_id)
+            const callId = e.tool_call_id;
+            const idx = callId
+              ? cotSteps.findIndex(s => s.tool_name === callId)
               : cotSteps.findLastIndex(s => s.status === ChainOfThoughtStepStatus.PROCESSING);
             if (idx >= 0) cotSteps[idx] = { ...cotSteps[idx], status: e.is_error ? ChainOfThoughtStepStatus.FAILURE : ChainOfThoughtStepStatus.SUCCESS, response: e.result ? { content: typeof e.result === "string" ? e.result : JSON.stringify(e.result, null, 2) } : undefined };
+
+            // Collect exam cards from successful qjudge_exam create/batch_create
+            const meta = callId ? toolCallMeta.get(callId) : undefined;
+            if (meta?.toolName === "qjudge_exam" && !e.is_error && e.result) {
+              let parsed: Record<string, unknown> | null = null;
+              if (typeof e.result === "object") {
+                parsed = e.result as Record<string, unknown>;
+              } else if (typeof e.result === "string") {
+                try { parsed = JSON.parse(e.result) as Record<string, unknown>; } catch { /* not JSON */ }
+              }
+              console.log("[ChatbotWidget] exam tool result parsed:", parsed, "action:", meta.action);
+              if (parsed && !parsed.error) {
+                pendingCards.push(...extractExamCards(parsed, meta.action));
+                console.log("[ChatbotWidget] pendingCards after extract:", [...pendingCards]);
+              }
+            }
+
             sendPartial();
             break;
           }
-          case "run_completed":
+          case "run_completed": {
             sendFinal(false);
+
+            console.log("[ChatbotWidget] run_completed, pendingCards:", pendingCards.length, pendingCards);
+            if (pendingCards.length > 0) {
+              const cardItems: GenericItem[] = pendingCards.map((props) => ({
+                response_type: MessageResponseTypes.USER_DEFINED,
+                user_defined: { type: "ai-exam-question-card" as const, ...props },
+              }));
+              console.log("[ChatbotWidget] injecting user_defined cards:", cardItems);
+              inst.messaging.addMessage({ output: { generic: cardItems } });
+            }
+
             onProblemUpdated?.();
             break;
+          }
           case "run_failed":
             console.error("[ChatbotWidget] Agent error:", e.message);
             sendFinal(true);
@@ -426,6 +471,22 @@ export const ChatbotWidget = ({
     }
   }, [onProblemUpdated]);
 
+  const renderUserDefinedResponse: RenderUserDefinedResponse = useCallback((state) => {
+    console.log("[ChatbotWidget] renderUserDefinedResponse called:", state);
+    const ud = state.messageItem?.user_defined as Record<string, unknown> | undefined;
+    if (ud?.type === "ai-exam-question-card") {
+      return (
+        <AIExamQuestionCard
+          questionType={ud.questionType as AIExamQuestionCardProps["questionType"]}
+          prompt={ud.prompt as string}
+          score={ud.score as number | undefined}
+          optionCount={ud.optionCount as number | undefined}
+        />
+      );
+    }
+    return null;
+  }, []);
+
   const renderWriteableElements = useMemo(() => {
     if (!instance) return {};
     return {
@@ -449,13 +510,81 @@ export const ChatbotWidget = ({
     setInstance(inst);
     instanceRef.current = inst;
 
+    // Carbon 的 input 元素在 onBeforeRender 時可能還沒掛上 DOM，用 MutationObserver
+    // 等它出現再綁事件。
+    const bindCompositionListeners = (el: HTMLElement) => {
+      if (inputElRef.current === el) return; // already bound
+      inputElRef.current = el;
+      // After compositionend (1st Enter in IME), block Enter for 1 s so the
+      // composition-ending keystroke cannot immediately trigger a submit.
+      el.addEventListener('compositionend', () => {
+        blockEnterUntilRef.current = Date.now() + 1000;
+      });
+      // Intercept keydown in capture phase — before Carbon's handler — and
+      // swallow Enter while the 1-second block window is active.
+      el.addEventListener('keydown', (e) => {
+        if ((e as KeyboardEvent).key === 'Enter' && Date.now() < blockEnterUntilRef.current) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }, true);
+    };
+
+    const findAndBindInput = () => {
+      const el = document.querySelector('[data-testid="input_field"]') as HTMLElement | null;
+      if (el) bindCompositionListeners(el);
+      return el;
+    };
+
+    if (!findAndBindInput()) {
+      const observer = new MutationObserver(() => {
+        if (findAndBindInput()) {
+          // We keep observing because Carbon might re-render the input element later
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    } else {
+      // Even if found, keep observing for future re-renders
+      const observer = new MutationObserver(() => {
+        findAndBindInput();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+
     inst.on({ type: BusEventType.SEND, handler: () => {
       try { if (backendSessionIdRef.current) localStorage.setItem("chatbot_last_session_id", backendSessionIdRef.current); } catch { /* */ }
-      // 同步清空 contenteditable innerHTML，須在 input 事件 fire 前執行：
-      // emitChangeFromDom() 讀 DOM 若拿到舊文字，會把 state 寫回舊值，
-      // 再加上 skipNextDomSync=true 導致 useLayoutEffect 跳過 DOM 更新。
-      const inputEl = document.querySelector('[data-testid="input_field"]') as HTMLElement | null;
-      if (inputEl) inputEl.innerHTML = '';
+      
+      const forceClear = () => {
+        const inputEl = document.querySelector('[data-testid="input_field"]') as HTMLElement | null;
+        if (!inputEl) return;
+        
+        // 1. 同步清空
+        inputEl.innerHTML = '';
+        inputEl.textContent = '';
+        while (inputEl.firstChild) {
+          inputEl.removeChild(inputEl.firstChild);
+        }
+        
+        // 2. 觸發事件確保 Carbon 內部狀態同步
+        inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+        
+        // 3. 強制 blur/focus 以重設 IME 狀態與游標
+        const isFocused = document.activeElement === inputEl;
+        if (isFocused) {
+          inputEl.blur();
+          setTimeout(() => {
+            if (document.querySelector('[data-testid="input_field"]') === inputEl) {
+              inputEl.focus();
+            }
+          }, 10);
+        }
+      };
+
+      forceClear();
+      // 在多個時間點嘗試清空，捕捉可能發生的 IME 延遲 commit 或 React 非同步更新
+      requestAnimationFrame(forceClear);
+      setTimeout(forceClear, 50);
+      setTimeout(forceClear, 150);
     }});
 
     // HITL: listen for approve/reject button clicks from CardItem footers
@@ -523,6 +652,7 @@ export const ChatbotWidget = ({
           onViewChange={onViewChange}
           onViewPreChange={onViewPreChange}
           renderWriteableElements={renderWriteableElements}
+          renderUserDefinedResponse={renderUserDefinedResponse}
         />
       </div>
     </>

--- a/frontend/src/features/chatbot/components/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget.tsx
@@ -190,7 +190,9 @@ export const ChatbotWidget = ({
             break;
           case "tool_call_started":
             if (e.tool_name) {
-              cotSteps.push({ title: e.tool_name, tool_name: e.tool_name, status: ChainOfThoughtStepStatus.PROCESSING, request: e.input_data ? { args: e.input_data } : undefined });
+              const occurrences = cotSteps.filter(s => s.title === e.tool_name || s.title?.startsWith(e.tool_name + " (")).length;
+              const uniqueTitle = occurrences > 0 ? `${e.tool_name} (${occurrences + 1})` : e.tool_name;
+              cotSteps.push({ title: uniqueTitle, tool_name: e.tool_name, status: ChainOfThoughtStepStatus.PROCESSING, request: e.input_data ? { args: e.input_data } : undefined });
               sendPartial();
             }
             break;
@@ -287,7 +289,12 @@ export const ChatbotWidget = ({
           for (const raw of lines) {
             const l = raw.trimEnd();
             if (l.startsWith("data: ")) {
-              try { handleEvent(JSON.parse(l.slice(6))); } catch { /* parse error */ }
+              try {
+                handleEvent(JSON.parse(l.slice(6)));
+                // Yield to browser so Carbon can render intermediate states
+                // (e.g. tool PROCESSING before SUCCESS when both arrive in one chunk)
+                await new Promise(r => setTimeout(r, 0));
+              } catch { /* parse error */ }
             }
           }
         }
@@ -319,12 +326,22 @@ export const ChatbotWidget = ({
 
   // ── Carbon config (stable refs) ────────────────────────────────────────
   const config = useRef<PublicConfig>({
-    messaging: { customSendMessage, showStopButtonImmediately: true, messageTimeoutSecs: 120, customLoadHistory },
+    messaging: { customSendMessage, messageTimeoutSecs: 120, customLoadHistory },
     history: { isOn: true },
     header: { title: "QJudge AI 助教" },
     layout: { corners: CornersType.SQUARE },
     openChatByDefault: true,
     assistantName: "QJudge AI",
+    strings: {
+      chainOfThought_explainabilityLabel: "推理步驟",
+      chainOfThought_stepTitle: "步驟",
+      chainOfThought_inputLabel: "輸入",
+      chainOfThought_outputLabel: "輸出",
+      chainOfThought_toolLabel: "工具",
+      chainOfThought_statusSucceededLabel: "成功",
+      chainOfThought_statusFailedLabel: "失敗",
+      chainOfThought_statusProcessingLabel: "處理中",
+    },
   }).current;
 
   // Session management for ChatHistory
@@ -430,6 +447,12 @@ export const ChatbotWidget = ({
 
     inst.on({ type: BusEventType.SEND, handler: () => {
       try { if (backendSessionIdRef.current) localStorage.setItem("chatbot_last_session_id", backendSessionIdRef.current); } catch { /* */ }
+      // Carbon Enter 鍵路徑已先清空 store (rawValue="")，導致 updateRawValue 是 no-op
+      // 直接操作 contenteditable DOM 確保視覺清空，對 Enter 和 button 都有效
+      setTimeout(() => {
+        const inputEl = document.querySelector('[data-testid="input_field"]') as HTMLElement | null;
+        if (inputEl) inputEl.textContent = '';
+      }, 0);
     }});
 
     // HITL: listen for approve/reject button clicks from CardItem footers

--- a/frontend/src/features/chatbot/components/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget.tsx
@@ -451,12 +451,11 @@ export const ChatbotWidget = ({
 
     inst.on({ type: BusEventType.SEND, handler: () => {
       try { if (backendSessionIdRef.current) localStorage.setItem("chatbot_last_session_id", backendSessionIdRef.current); } catch { /* */ }
-      // Carbon Enter 鍵路徑已先清空 store (rawValue="")，導致 updateRawValue 是 no-op
-      // 直接操作 contenteditable DOM 確保視覺清空，對 Enter 和 button 都有效
-      setTimeout(() => {
-        const inputEl = document.querySelector('[data-testid="input_field"]') as HTMLElement | null;
-        if (inputEl) inputEl.textContent = '';
-      }, 0);
+      // 同步清空 contenteditable innerHTML，須在 input 事件 fire 前執行：
+      // emitChangeFromDom() 讀 DOM 若拿到舊文字，會把 state 寫回舊值，
+      // 再加上 skipNextDomSync=true 導致 useLayoutEffect 跳過 DOM 更新。
+      const inputEl = document.querySelector('[data-testid="input_field"]') as HTMLElement | null;
+      if (inputEl) inputEl.innerHTML = '';
     }});
 
     // HITL: listen for approve/reject button clicks from CardItem footers

--- a/frontend/src/features/chatbot/components/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget.tsx
@@ -216,9 +216,10 @@ export const ChatbotWidget = ({
             break;
           case "tool_call_finished": {
             const callId = e.tool_call_id;
+            const lastProcessingIdx = (() => { for (let i = cotSteps.length - 1; i >= 0; i--) { if (cotSteps[i].status === ChainOfThoughtStepStatus.PROCESSING) return i; } return -1; })();
             const idx = callId
               ? cotSteps.findIndex(s => s.tool_name === callId)
-              : cotSteps.findLastIndex(s => s.status === ChainOfThoughtStepStatus.PROCESSING);
+              : lastProcessingIdx;
             if (idx >= 0) cotSteps[idx] = { ...cotSteps[idx], status: e.is_error ? ChainOfThoughtStepStatus.FAILURE : ChainOfThoughtStepStatus.SUCCESS, response: e.result ? { content: typeof e.result === "string" ? e.result : JSON.stringify(e.result, null, 2) } : undefined };
 
             // Collect exam cards from successful qjudge_exam create/batch_create

--- a/frontend/src/features/chatbot/components/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget.tsx
@@ -190,16 +190,20 @@ export const ChatbotWidget = ({
             break;
           case "tool_call_started":
             if (e.tool_name) {
-              const occurrences = cotSteps.filter(s => s.title === e.tool_name || s.title?.startsWith(e.tool_name + " (")).length;
-              const uniqueTitle = occurrences > 0 ? `${e.tool_name} (${occurrences + 1})` : e.tool_name;
-              cotSteps.push({ title: uniqueTitle, tool_name: e.tool_name, status: ChainOfThoughtStepStatus.PROCESSING, request: e.input_data ? { args: e.input_data } : undefined });
+              cotSteps.push({
+                title: e.tool_name,
+                tool_name: e.tool_call_id || `${e.tool_name}-${cotSteps.length}`,
+                status: ChainOfThoughtStepStatus.PROCESSING,
+                request: e.input_data ? { args: e.input_data } : undefined,
+              });
               sendPartial();
             }
             break;
           case "tool_call_finished": {
-            let i = cotSteps.length - 1;
-            for (; i >= 0; i--) if (cotSteps[i].status === ChainOfThoughtStepStatus.PROCESSING) break;
-            if (i >= 0) cotSteps[i] = { ...cotSteps[i], status: e.is_error ? ChainOfThoughtStepStatus.FAILURE : ChainOfThoughtStepStatus.SUCCESS, response: e.result ? { content: typeof e.result === "string" ? e.result : JSON.stringify(e.result, null, 2) } : undefined };
+            const idx = e.tool_call_id
+              ? cotSteps.findIndex(s => s.tool_name === e.tool_call_id)
+              : cotSteps.findLastIndex(s => s.status === ChainOfThoughtStepStatus.PROCESSING);
+            if (idx >= 0) cotSteps[idx] = { ...cotSteps[idx], status: e.is_error ? ChainOfThoughtStepStatus.FAILURE : ChainOfThoughtStepStatus.SUCCESS, response: e.result ? { content: typeof e.result === "string" ? e.result : JSON.stringify(e.result, null, 2) } : undefined };
             sendPartial();
             break;
           }

--- a/frontend/src/features/chatbot/components/extractExamCards.ts
+++ b/frontend/src/features/chatbot/components/extractExamCards.ts
@@ -1,0 +1,40 @@
+import type { ExamQuestionType } from "@/core/entities/contest.entity";
+import type { AIExamQuestionCardProps } from "./AIExamQuestionCard";
+
+/**
+ * Extract card props from a qjudge_exam tool result.
+ * Handles both single create (result has `id`) and batch_create (result has `created` array).
+ */
+export function extractExamCards(
+  result: Record<string, unknown>,
+  action?: string,
+): AIExamQuestionCardProps[] {
+  // Single create — result is the question object itself
+  if (action === "create" && result.id && result.question_type) {
+    return [mapOne(result)];
+  }
+
+  // batch_create — result has { created: [...] }
+  if (action === "batch_create" && Array.isArray(result.created)) {
+    return (result.created as Record<string, unknown>[])
+      .filter((item) => item && typeof item === "object" && item.id)
+      .map(mapOne);
+  }
+
+  // Fallback: if action is unknown but result looks like a single question
+  if (result.id && result.question_type) {
+    return [mapOne(result)];
+  }
+
+  return [];
+}
+
+function mapOne(item: Record<string, unknown>): AIExamQuestionCardProps {
+  const options = Array.isArray(item.options) ? item.options : [];
+  return {
+    questionType: (item.question_type as ExamQuestionType) || "single_choice",
+    prompt: typeof item.prompt === "string" ? item.prompt : "",
+    score: typeof item.score === "number" ? item.score : undefined,
+    optionCount: options.length > 0 ? options.length : undefined,
+  };
+}

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -54,6 +54,19 @@ echo "[deploy] fetch and checkout ${GIT_REF}"
 git fetch --all --tags --prune
 git checkout --force "${GIT_REF}"
 
+echo "[deploy] pull judge image from GHCR"
+if docker pull ghcr.io/quan0715/qjudge/judge:latest; then
+  docker tag ghcr.io/quan0715/qjudge/judge:latest oj-judge:latest
+  echo "[deploy] judge image updated from GHCR"
+else
+  echo "[deploy] GHCR pull failed — checking local fallback"
+  if ! docker image inspect oj-judge:latest >/dev/null 2>&1; then
+    echo "[deploy] no local judge image, building from Dockerfile" >&2
+    docker build -t oj-judge:latest \
+      -f backend/judge/Dockerfile.judge backend/judge
+  fi
+fi
+
 echo "[deploy] build images"
 docker compose "${COMPOSE_FILES[@]}" build
 


### PR DESCRIPTION
## Summary

- **fix(nginx):** add `proxy_buffering off` / `proxy_http_version 1.1` / `proxy_cache off` for SSE streaming in production
- **feat(ai):** convert backend SSE proxy to async (`httpx.AsyncClient`) for true ASGI streaming under uvicorn/daphne
- **fix(ai):** patch `SummarizationMiddleware` tool_call pair-splitting bug (langchain#34282) — prevents 400 errors on long sessions
- **fix(ai):** delete corrupt LangGraph checkpoint when `_repair_dangling_tool_calls` finds nothing to fix (prevents sticky AGENT_ERROR on bad `_summarization_event` state)
- **fix(ai):** emit `summarization_started` SSE event, fix summarization trigger threshold
- **feat(chatbot):** render AI exam question cards inline from assistant messages
- **fix(chatbot):** multiple CoT/streaming/layout fixes (tool_call_id keying, contenteditable sync, viewport, HITL flow)
- **fix(auth/csrf):** ASGI-compatible CSRF cookie, Cloudflare Tunnel CSRF origins

## Test plan

- [ ] `docker compose pull && docker compose up -d --build` on remote, verify `oj_backend` and `oj_frontend` are healthy
- [ ] Send a chat message via AI assistant, verify SSE events arrive incrementally (not all at once after delay)
- [ ] Verify AI assistant completes a multi-tool session without AGENT_ERROR
- [ ] Verify long sessions (> ~50 messages) don't produce 400 errors after summarization

🤖 Generated with [Claude Code](https://claude.com/claude-code)