### PR TITLE
feat(chatbot): Notion 風格 SideMenu + Chat Session URL Routing

### DIFF
--- a/ai-service/services/event_adapter.py
+++ b/ai-service/services/event_adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass, field
-from typing import Any, Union
+from typing import Any, Iterable, Union
 
 logger = logging.getLogger(__name__)
 
@@ -144,13 +144,20 @@ def adapt_langgraph_event(event: dict[str, Any]) -> list[InternalEvent] | None:
         chunk = data.get("chunk")
         if chunk is None:
             return None
-            
+
         results: list[InternalEvent] = []
 
-        if hasattr(chunk, "additional_kwargs") and "reasoning_content" in chunk.additional_kwargs:
-            rc = chunk.additional_kwargs.get("reasoning_content")
-            if rc:
-                results.append(ThinkingDelta(content=rc))
+        additional_kwargs = (
+            getattr(chunk, "additional_kwargs", None)
+            if hasattr(chunk, "additional_kwargs")
+            else None
+        )
+        if isinstance(additional_kwargs, dict):
+            thinking_from_kwargs = _extract_reasoning_from_additional_kwargs(
+                additional_kwargs
+            )
+            if thinking_from_kwargs:
+                results.append(ThinkingDelta(content=thinking_from_kwargs))
 
         content = getattr(chunk, "content", "")
         if isinstance(content, list):
@@ -158,10 +165,21 @@ def adapt_langgraph_event(event: dict[str, Any]) -> list[InternalEvent] | None:
             thinking_parts: list[str] = []
             for block in content:
                 if isinstance(block, dict):
-                    if block.get("type") == "thinking":
-                        thinking_parts.append(block.get("thinking", ""))
-                    elif block.get("type") == "text":
-                        text_parts.append(block.get("text", ""))
+                    block_type = block.get("type")
+                    if block_type in {"thinking", "reasoning"}:
+                        thinking_parts.extend(
+                            _extract_text_fragments(
+                                block,
+                                preferred_keys=("thinking", "reasoning", "text"),
+                            )
+                        )
+                    elif block_type == "text":
+                        text_parts.extend(
+                            _extract_text_fragments(
+                                block,
+                                preferred_keys=("text",),
+                            )
+                        )
                 elif isinstance(block, str):
                     text_parts.append(block)
             # Emit both thinking and text when both are present in the same chunk
@@ -219,6 +237,72 @@ def adapt_langgraph_event(event: dict[str, Any]) -> list[InternalEvent] | None:
     # avoiding duplicate run_started events.
 
     return None
+
+
+def _extract_reasoning_from_additional_kwargs(
+    additional_kwargs: dict[str, Any],
+) -> str:
+    parts: list[str] = []
+
+    # Common fields observed across providers / wrappers.
+    candidate_keys = (
+        "reasoning_content",
+        "reasoning",
+        "reasoning_text",
+        "thinking",
+    )
+    for key in candidate_keys:
+        if key not in additional_kwargs:
+            continue
+        parts.extend(
+            _extract_text_fragments(
+                additional_kwargs[key],
+                preferred_keys=("text", "content", "reasoning", "thinking"),
+            )
+        )
+
+    # OpenAI-compatible chunks may carry content blocks under additional_kwargs.
+    # Example shapes:
+    # - {"reasoning": {"content": [...]}}
+    # - {"reasoning": [{"type": "reasoning", "text": "..."}]}
+    return "".join(parts)
+
+
+def _extract_text_fragments(
+    value: Any,
+    *,
+    preferred_keys: Iterable[str],
+) -> list[str]:
+    if value is None:
+        return []
+
+    if isinstance(value, str):
+        return [value]
+
+    if isinstance(value, (int, float, bool)):
+        return [str(value)]
+
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key in preferred_keys:
+            if key in value:
+                parts.extend(
+                    _extract_text_fragments(
+                        value[key],
+                        preferred_keys=preferred_keys,
+                    )
+                )
+        return parts
+
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            parts.extend(
+                _extract_text_fragments(item, preferred_keys=preferred_keys)
+            )
+        return parts
+
+    return []
 
 
 # ---------------------------------------------------------------------------

--- a/ai-service/tests/test_event_adapter.py
+++ b/ai-service/tests/test_event_adapter.py
@@ -1,0 +1,82 @@
+"""Unit tests for LangGraph -> internal event adaptation."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+_deepseek_stub = types.ModuleType("langchain_deepseek")
+_openai_stub = types.ModuleType("langchain_openai")
+
+
+class _ChatDeepSeekStub:  # pragma: no cover - import stub only
+    pass
+
+
+class _ChatOpenAIStub:  # pragma: no cover - import stub only
+    pass
+
+
+_deepseek_stub.ChatDeepSeek = _ChatDeepSeekStub
+_openai_stub.ChatOpenAI = _ChatOpenAIStub
+sys.modules.setdefault("langchain_deepseek", _deepseek_stub)
+sys.modules.setdefault("langchain_openai", _openai_stub)
+
+from services.event_adapter import (
+    AgentMessageDelta,
+    ThinkingDelta,
+    adapt_langgraph_event,
+)
+
+
+class _Chunk:
+    def __init__(self, content, additional_kwargs=None):
+        self.content = content
+        self.additional_kwargs = additional_kwargs or {}
+
+
+def _stream_event(chunk: _Chunk) -> dict:
+    return {"event": "on_chat_model_stream", "data": {"chunk": chunk}}
+
+
+def test_adapt_openai_reasoning_text_in_additional_kwargs():
+    chunk = _Chunk(
+        content="final answer",
+        additional_kwargs={"reasoning": {"text": "step-by-step"}},
+    )
+
+    events = adapt_langgraph_event(_stream_event(chunk))
+
+    assert events is not None
+    assert isinstance(events[0], ThinkingDelta)
+    assert events[0].content == "step-by-step"
+    assert isinstance(events[1], AgentMessageDelta)
+    assert events[1].content == "final answer"
+
+
+def test_adapt_reasoning_content_blocks_and_text_blocks():
+    chunk = _Chunk(
+        content=[
+            {"type": "reasoning", "text": "think-a"},
+            {"type": "text", "text": "answer-a"},
+        ]
+    )
+
+    events = adapt_langgraph_event(_stream_event(chunk))
+
+    assert events is not None
+    assert isinstance(events[0], ThinkingDelta)
+    assert events[0].content == "think-a"
+    assert isinstance(events[1], AgentMessageDelta)
+    assert events[1].content == "answer-a"
+
+
+def test_adapt_legacy_thinking_block_still_supported():
+    chunk = _Chunk(content=[{"type": "thinking", "thinking": "old-think"}])
+
+    events = adapt_langgraph_event(_stream_event(chunk))
+
+    assert events is not None
+    assert len(events) == 1
+    assert isinstance(events[0], ThinkingDelta)
+    assert events[0].content == "old-think"

--- a/backend/apps/ai/services/run_runtime.py
+++ b/backend/apps/ai/services/run_runtime.py
@@ -35,10 +35,19 @@ TERMINAL_STATUSES = [
 ]
 PAUSED_STATUSES = [AIChatRun.Status.AWAITING_APPROVAL]
 
-# Poll interval for tailing new SSE events. HITL runs can idle for arbitrary
-# time waiting on human input, so we also short-circuit on PAUSED_STATUSES to
-# free the underlying DB connection back to pgbouncer.
-_SSE_POLL_INTERVAL_SECONDS = 1.5
+# Poll intervals for tailing new SSE events.
+#
+# We use adaptive backoff so the typewriter effect stays smooth during token
+# bursts while idle / HITL waits don't hammer the DB:
+#   - When events arrive, reset to MIN so the next chunk lands within ~50ms.
+#   - When the queue is empty, exponentially back off up to MAX.
+#
+# HITL runs can idle for arbitrary time waiting on human input, so we also
+# short-circuit on PAUSED_STATUSES to free the underlying DB connection back
+# to pgbouncer.
+_SSE_POLL_MIN_INTERVAL_SECONDS = 0.05
+_SSE_POLL_MAX_INTERVAL_SECONDS = 1.5
+_SSE_POLL_BACKOFF_FACTOR = 1.5
 
 
 def ensure_session_for_run(*, user, session_id: str) -> AISession:
@@ -183,6 +192,7 @@ async def run_events_as_sse(*, run: AIChatRun, after: int = 0) -> AsyncGenerator
     decision via ``POST /runs/{id}/approval/``.
     """
     last_seq = max(after, 0)
+    interval = _SSE_POLL_MIN_INTERVAL_SECONDS
     try:
         while True:
             emitted = False
@@ -205,8 +215,14 @@ async def run_events_as_sse(*, run: AIChatRun, after: int = 0) -> AsyncGenerator
                 return
             if run_status in PAUSED_STATUSES and not emitted:
                 return
-            if not emitted:
-                await asyncio.sleep(_SSE_POLL_INTERVAL_SECONDS)
+            if emitted:
+                interval = _SSE_POLL_MIN_INTERVAL_SECONDS
+            else:
+                await asyncio.sleep(interval)
+                interval = min(
+                    interval * _SSE_POLL_BACKOFF_FACTOR,
+                    _SSE_POLL_MAX_INTERVAL_SECONDS,
+                )
     finally:
         # Release any DB connections held by the sync_to_async worker
         # threads so they return to the pgbouncer pool immediately.

--- a/backend/apps/question_bank/views.py
+++ b/backend/apps/question_bank/views.py
@@ -10,7 +10,7 @@ from django.http import Http404
 from django.db.models import Count, Q
 from django.urls import reverse
 from django.utils import timezone
-from rest_framework import mixins, permissions, status, viewsets
+from rest_framework import filters, mixins, permissions, status, viewsets
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError as DRFValidationError
 from rest_framework.decorators import action
 from rest_framework.parsers import FormParser, MultiPartParser
@@ -84,6 +84,10 @@ class QuestionBankViewSet(viewsets.ModelViewSet):
     serializer_class = QuestionBankSerializer
     pagination_class = None
     lookup_field = "uuid"
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['name']
+    ordering_fields = ['created_at', 'name']
+    ordering = ['-created_at']
     COVER_SUPPORTED_FORMATS = {
         "PNG": ("png", "image/png"),
         "JPEG": ("jpg", "image/jpeg"),

--- a/docs/superpowers/plans/2026-04-19-notion-style-sidemenu-chat.md
+++ b/docs/superpowers/plans/2026-04-19-notion-style-sidemenu-chat.md
@@ -1,0 +1,1688 @@
+# Notion 風格 SideMenu + Chat Session URL Routing 實作計劃
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 將 ChatHistoryPanel 整合進全域 SideMenu（三 tab：教室/題庫/Chat），重設計 ChatTopBar（full-page），並加上 `/chat/:sessionId` URL routing。
+
+**Architecture:** 新增 `ChatSessionContext` 作為 session 清單的共享 source of truth（僅清單，不含 streaming 狀態）；SideMenu 的 Chat tab 和 ChatContainer full-page 均消費此 context。`useChatbot` 在 CRUD 後呼叫 `context.refreshSessions()`，並透過 `externalSessionId` prop 與 URL 同步。
+
+**Tech Stack:** React 18, Carbon Design System (`@carbon/react`), React Router v6, Vitest, SCSS Modules, TypeScript
+
+---
+
+## 檔案地圖
+
+| 檔案 | 動作 |
+|---|---|
+| `frontend/src/features/chatbot/contexts/ChatSessionContext.tsx` | **新建** — session 清單 context + provider |
+| `frontend/src/features/chatbot/hooks/useChatbot.ts` | **修改** — 加 `externalSessionId` 同步 + CRUD 後 refreshSessions |
+| `frontend/src/App.tsx` | **修改** — 加 `/chat/:sessionId` route，加 `ChatSessionProvider` |
+| `frontend/src/features/chatbot/components/ChatStandalonePage.tsx` | **修改** — 讀 URL params，傳 sessionId + 導航 callbacks |
+| `frontend/src/features/chatbot/components/ChatFullPage.tsx` | **修改** — 接收 sessionId prop |
+| `frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx` | **修改** — 移除 history panels，接收 sessionId prop |
+| `frontend/src/features/chatbot/components/chat-ui/ChatContainer.module.scss` | **修改** — 移除 historyColumn/Overlay 樣式 |
+| `frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx` | **修改** — 重設計 full-page header |
+| `frontend/src/features/chatbot/components/chat-ui/ChatTopBar.module.scss` | **修改** — 新增 titleBtn, dropdown 等樣式 |
+| `frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx` | **修改** — 移除搜尋，加 icon + 時間，可選底部 new chat |
+| `frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.module.scss` | **修改** — 加 itemIcon, itemTime, footer 樣式 |
+| `frontend/src/features/app/components/SideMenu.tsx` | **修改** — 加 tab bar，整合 Chat tab |
+| `frontend/src/features/app/components/SideMenu.scss` | **修改** — 加 tab bar 樣式 |
+
+---
+
+## Task 1: 建立 `ChatSessionContext`
+
+**Files:**
+- Create: `frontend/src/features/chatbot/contexts/ChatSessionContext.tsx`
+
+- [ ] **Step 1: 建立 context 檔案**
+
+```tsx
+// frontend/src/features/chatbot/contexts/ChatSessionContext.tsx
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import type { ChatSession } from "@/core/types/chatbot.types";
+import { chatbotRepository } from "@/infrastructure/api/repositories";
+import { useAuth } from "@/features/auth/contexts/AuthContext";
+
+interface ChatSessionContextValue {
+  sessions: ChatSession[];
+  isLoadingSessions: boolean;
+  refreshSessions: () => Promise<void>;
+}
+
+const ChatSessionContext = createContext<ChatSessionContextValue>({
+  sessions: [],
+  isLoadingSessions: false,
+  refreshSessions: async () => {},
+});
+
+export function ChatSessionProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const isTeacherOrAdmin = user?.role === "teacher" || user?.role === "admin";
+
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(false);
+
+  const refreshSessions = useCallback(async () => {
+    if (!isTeacherOrAdmin) return;
+    setIsLoadingSessions(true);
+    try {
+      const result = await chatbotRepository.getSessions();
+      setSessions(result);
+    } catch {
+      // silently fail — SideMenu will show empty list
+    } finally {
+      setIsLoadingSessions(false);
+    }
+  }, [isTeacherOrAdmin]);
+
+  useEffect(() => {
+    if (isTeacherOrAdmin) {
+      void refreshSessions();
+    }
+  }, [isTeacherOrAdmin, refreshSessions]);
+
+  return (
+    <ChatSessionContext.Provider value={{ sessions, isLoadingSessions, refreshSessions }}>
+      {children}
+    </ChatSessionContext.Provider>
+  );
+}
+
+export function useChatSessionContext() {
+  return useContext(ChatSessionContext);
+}
+```
+
+- [ ] **Step 2: 加入 index export**
+
+在 `frontend/src/features/chatbot/index.ts` 加入（或確認有 export）：
+
+```ts
+export { ChatSessionProvider, useChatSessionContext } from "./contexts/ChatSessionContext";
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/chatbot/contexts/ChatSessionContext.tsx frontend/src/features/chatbot/index.ts
+git commit -m "feat(chatbot): add ChatSessionContext for shared session list"
+```
+
+---
+
+## Task 2: 在 `App.tsx` 加入 `ChatSessionProvider` 與 `/chat/:sessionId` route
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: 加入 import**
+
+在 `App.tsx` 現有 import 區段，加入：
+
+```ts
+import { ChatSessionProvider } from "@/features/chatbot/contexts/ChatSessionContext";
+```
+
+- [ ] **Step 2: 將 `ChatSessionProvider` 包在 `AIWorkspaceProvider` 內層**
+
+找到：
+```tsx
+<AIWorkspaceProvider>
+  <PageHeaderActionsProvider>
+```
+改為：
+```tsx
+<AIWorkspaceProvider>
+  <ChatSessionProvider>
+  <PageHeaderActionsProvider>
+```
+並在對應的 `</PageHeaderActionsProvider>` 後加上 `</ChatSessionProvider>`。
+
+- [ ] **Step 3: 加入 `/chat/:sessionId` route**
+
+找到：
+```tsx
+<Route
+  path="/chat"
+  element={
+    <Suspense fallback={null}>
+      <ChatStandalonePage />
+    </Suspense>
+  }
+/>
+```
+改為：
+```tsx
+<Route
+  path="/chat"
+  element={
+    <Suspense fallback={null}>
+      <ChatStandalonePage />
+    </Suspense>
+  }
+/>
+<Route
+  path="/chat/:sessionId"
+  element={
+    <Suspense fallback={null}>
+      <ChatStandalonePage />
+    </Suspense>
+  }
+/>
+```
+
+- [ ] **Step 4: 確認 dev server 啟動無型別錯誤**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+```
+Expected: 無 TypeScript error（警告可忽略）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/App.tsx
+git commit -m "feat(chatbot): add /chat/:sessionId route and ChatSessionProvider"
+```
+
+---
+
+## Task 3: `ChatStandalonePage` 讀 URL params 並傳遞 sessionId
+
+**Files:**
+- Modify: `frontend/src/features/chatbot/components/ChatStandalonePage.tsx`
+- Modify: `frontend/src/features/chatbot/components/ChatFullPage.tsx`
+
+- [ ] **Step 1: 更新 `ChatStandalonePage.tsx`**
+
+```tsx
+// frontend/src/features/chatbot/components/ChatStandalonePage.tsx
+import { useNavigate, useParams } from "react-router-dom";
+import { GlobalHeader } from "@/features/app/components/GlobalHeader";
+import ChatFullPage from "./ChatFullPage";
+import styles from "./ChatStandalonePage.module.scss";
+
+export default function ChatStandalonePage() {
+  const { sessionId } = useParams<{ sessionId?: string }>();
+  const navigate = useNavigate();
+
+  const handleSessionChange = (newId: string) => {
+    navigate(`/chat/${newId}`, { replace: false });
+  };
+
+  const handleSessionDeleted = (fallbackId: string | null) => {
+    if (fallbackId) {
+      navigate(`/chat/${fallbackId}`, { replace: true });
+    } else {
+      navigate("/chat", { replace: true });
+    }
+  };
+
+  return (
+    <div className={styles.pageRoot}>
+      <GlobalHeader />
+      <main className={styles.main}>
+        <ChatFullPage
+          sessionId={sessionId ?? null}
+          onSessionChange={handleSessionChange}
+          onSessionDeleted={handleSessionDeleted}
+        />
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 更新 `ChatFullPage.tsx`**
+
+```tsx
+// frontend/src/features/chatbot/components/ChatFullPage.tsx
+import { ChatContainer } from "./chat-ui/ChatContainer";
+import styles from "./ChatFullPage.module.scss";
+
+interface ChatFullPageProps {
+  sessionId?: string | null;
+  onSessionChange?: (newId: string) => void;
+  onSessionDeleted?: (fallbackId: string | null) => void;
+}
+
+export default function ChatFullPage({ sessionId, onSessionChange, onSessionDeleted }: ChatFullPageProps) {
+  return (
+    <ChatContainer
+      mode="full"
+      className={styles.fullPage}
+      externalSessionId={sessionId ?? undefined}
+      onSessionChange={onSessionChange}
+      onSessionDeleted={onSessionDeleted}
+    />
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/chatbot/components/ChatStandalonePage.tsx \
+        frontend/src/features/chatbot/components/ChatFullPage.tsx
+git commit -m "feat(chatbot): pass URL sessionId into ChatFullPage"
+```
+
+---
+
+## Task 4: 修改 `useChatbot` — 加 `externalSessionId` 同步 + context refreshSessions
+
+**Files:**
+- Modify: `frontend/src/features/chatbot/hooks/useChatbot.ts`
+
+- [ ] **Step 1: 在 `UseChatbotOptions` 加新欄位**
+
+找到 `interface UseChatbotOptions` 定義，加入：
+
+```ts
+interface UseChatbotOptions {
+  enabled?: boolean;
+  backgroundInfo?: BackgroundInformation | null;
+  context?: ChatContext | null;
+  onProblemUpdated?: () => void;
+  /** 從 URL 傳入的 session ID，useChatbot 會在初始化後切換到此 session */
+  externalSessionId?: string;
+  /** 當 session 被建立/刪除/改名時的回調（用於 URL navigation） */
+  onSessionChange?: (newId: string) => void;
+  onSessionDeleted?: (fallbackId: string | null) => void;
+}
+```
+
+- [ ] **Step 2: 在 `useChatbot` 函式頂端加入 context 消費**
+
+在 `export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {` 之後的解構行，加入 `externalSessionId` 和 callbacks：
+
+```ts
+const {
+  enabled = true,
+  backgroundInfo = null,
+  context = null,
+  onProblemUpdated: _onProblemUpdated,
+  externalSessionId,
+  onSessionChange,
+  onSessionDeleted,
+} = options;
+```
+
+在 state 宣告之後，加入 context 消費：
+
+```ts
+// ChatSessionContext — notify SideMenu when session list changes
+const chatSessionCtx = useChatSessionContext();
+```
+
+需要在頂部加入 import：
+```ts
+import { useChatSessionContext } from "../contexts/ChatSessionContext";
+```
+
+- [ ] **Step 3: 加入 `externalSessionId` 同步 effect**
+
+在 `useEffect(() => { init(); }, [...]);` 之後加入：
+
+```ts
+// Sync to URL-provided session ID after init
+useEffect(() => {
+  if (!externalSessionId || isInitializing) return;
+  if (currentSessionId !== externalSessionId) {
+    void switchSession(externalSessionId);
+  }
+}, [externalSessionId, isInitializing, currentSessionId, switchSession]);
+```
+
+- [ ] **Step 4: 在 `createSession` 加入 context refresh + 導航**
+
+找到 `createSession` 的 `return newSession.id;` 之前，加入：
+
+```ts
+void chatSessionCtx.refreshSessions();
+onSessionChange?.(newSession.id);
+```
+
+- [ ] **Step 5: 在 `deleteSession` 加入 context refresh**
+
+找到 `deleteSession` 的 `setSessions((prev) => {` 後的邏輯，改為：
+
+```ts
+setSessions((prev) => {
+  const filtered = prev.filter((session) => session.id !== sessionId);
+
+  if (sessionId === currentSessionId) {
+    const fallback = filtered[0]?.id ?? null;
+    if (filtered.length > 0) {
+      setCurrentSessionId(filtered[0].id);
+    } else {
+      void createSession();
+    }
+    onSessionDeleted?.(fallback);
+  } else if (filtered.length === 0) {
+    void createSession();
+    onSessionDeleted?.(null);
+  }
+
+  return filtered;
+});
+void chatSessionCtx.refreshSessions();
+```
+
+- [ ] **Step 6: 在 `renameSession` 加入 context refresh**
+
+找到 `renameSession` 成功後的 `setSessions(...)` 之後加入：
+
+```ts
+void chatSessionCtx.refreshSessions();
+```
+
+- [ ] **Step 7: 型別檢查**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -E "error TS" | head -20
+```
+
+Expected: 0 errors（或只有 pre-existing errors）
+
+- [ ] **Step 8: 現有測試通過**
+
+```bash
+cd frontend && npx vitest run src/features/chatbot/hooks/useChatbot.test.ts
+```
+
+Expected: All tests pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/features/chatbot/hooks/useChatbot.ts
+git commit -m "feat(chatbot): sync useChatbot with URL sessionId and refresh ChatSessionContext on CRUD"
+```
+
+---
+
+## Task 5: `ChatContainer` full-page — 移除歷史面板，接收 sessionId props
+
+**Files:**
+- Modify: `frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx`
+- Modify: `frontend/src/features/chatbot/components/chat-ui/ChatContainer.module.scss`
+
+- [ ] **Step 1: 更新 `ChatContainerProps`**
+
+找到 `interface ChatContainerProps`，加入：
+
+```ts
+interface ChatContainerProps {
+  mode: "full" | "sidebar";
+  context?: ChatContext | null;
+  onProblemUpdated?: () => void;
+  onClose?: () => void;
+  className?: string;
+  /** full-page 模式：當前 URL session ID */
+  externalSessionId?: string;
+  /** full-page 模式：session 建立/切換後的導航回調 */
+  onSessionChange?: (newId: string) => void;
+  /** full-page 模式：session 刪除後的導航回調 */
+  onSessionDeleted?: (fallbackId: string | null) => void;
+}
+```
+
+- [ ] **Step 2: 將新 props 傳入 `useChatbot`**
+
+在 `useChatbot({...})` 呼叫中加入：
+
+```ts
+const { ..., } = useChatbot({
+  enabled: true,
+  context,
+  onProblemUpdated,
+  externalSessionId: mode === "full" ? externalSessionId : undefined,
+  onSessionChange: mode === "full" ? onSessionChange : undefined,
+  onSessionDeleted: mode === "full" ? onSessionDeleted : undefined,
+});
+```
+
+- [ ] **Step 3: 移除 historyOpen state 和 history 相關 JSX（full mode）**
+
+找到：
+```ts
+const [historyOpen, setHistoryOpen] = useState(mode === "full" && !isMobile);
+```
+改為：
+```ts
+const [historyOpen, setHistoryOpen] = useState(mode === "sidebar");
+```
+
+移除以下 JSX 區塊（full mode 的 historyColumn 和 historyOverlay for full mode）：
+
+刪除：
+```tsx
+{/* Desktop full-page: history as side column */}
+{mode === "full" && !isMobile && (
+  <div className={`${styles.historyColumn} ${showDesktopHistory ? "" : styles.historyCollapsed}`}>
+    <ChatHistoryPanel
+      sessions={sessions}
+      currentSessionId={currentSessionId}
+      onSelectSession={handleSelectSession}
+      onDeleteSession={deleteSession}
+      onRenameSession={renameSession}
+    />
+  </div>
+)}
+```
+
+- [ ] **Step 4: 更新 `ChatTopBar` for full mode 傳入 sessions**
+
+找到 full mode 的 ChatTopBar：
+```tsx
+{mode === "full" && (
+  <ChatTopBar
+    title={sessionTitle}
+    historyOpen={historyOpen}
+    onToggleHistory={() => setHistoryOpen((v) => !v)}
+    onNewChat={handleNewChat}
+  />
+)}
+```
+改為：
+```tsx
+{mode === "full" && (
+  <ChatTopBar
+    mode="full"
+    title={sessionTitle}
+    sessions={sessions}
+    currentSessionId={currentSessionId}
+    onSelectSession={handleSelectSession}
+    onNewChat={handleNewChat}
+    onRenameSession={renameSession}
+    onDeleteSession={deleteSession}
+  />
+)}
+```
+
+- [ ] **Step 5: 保留 sidebar mode ChatTopBar 不變**
+
+確認 sidebar mode 的 ChatTopBar 仍使用原有 props（title、historyOpen、onToggleHistory、onNewChat、onClose）。
+
+- [ ] **Step 6: 清理 ChatContainer.module.scss**
+
+移除 `.historyColumn`、`.historyCollapsed`、`.historyOverlay`、`.historyOverlayOpen` 樣式區塊。
+
+- [ ] **Step 7: 型別檢查**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -E "error TS" | head -20
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx \
+        frontend/src/features/chatbot/components/chat-ui/ChatContainer.module.scss
+git commit -m "feat(chatbot): remove history panel from full-page mode, wire session props"
+```
+
+---
+
+## Task 6: 重設計 `ChatTopBar`（full-page 模式）
+
+**Files:**
+- Modify: `frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx`
+- Modify: `frontend/src/features/chatbot/components/chat-ui/ChatTopBar.module.scss`
+
+- [ ] **Step 1: 更新 `ChatTopBarProps`**
+
+```tsx
+// 完整更新 ChatTopBar.tsx
+import { useState, useRef, useEffect, useCallback } from "react";
+import { IconButton, OverflowMenu, OverflowMenuItem } from "@carbon/react";
+import { Add, Close, ChevronDown, Chat as ChatIcon } from "@carbon/icons-react";
+import { useTranslation } from "react-i18next";
+import type { ChatSession } from "@/core/types/chatbot.types";
+import styles from "./ChatTopBar.module.scss";
+
+// 相對時間工具（不依賴外部套件）
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) {
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    if (diffHours === 0) return "Just now";
+    return `${diffHours}h`;
+  }
+  if (diffDays === 1) return "1d";
+  if (diffDays < 7) return `${diffDays}d`;
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 5) return `${diffWeeks}w`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+interface ChatTopBarFullProps {
+  mode: "full";
+  title?: string;
+  sessions: ChatSession[];
+  currentSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onNewChat: () => void;
+  onRenameSession: (id: string, title: string) => void;
+  onDeleteSession: (id: string) => void;
+}
+
+interface ChatTopBarSidebarProps {
+  mode?: "sidebar";
+  title?: string;
+  historyOpen?: boolean;
+  onToggleHistory?: () => void;
+  onNewChat: () => void;
+  onClose?: () => void;
+}
+
+type ChatTopBarProps = ChatTopBarFullProps | ChatTopBarSidebarProps;
+
+export function ChatTopBar(props: ChatTopBarProps) {
+  const { t } = useTranslation("chatbot");
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const closeDropdown = useCallback(() => setDropdownOpen(false), []);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (!dropdownRef.current?.contains(e.target as Node)) {
+        closeDropdown();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [dropdownOpen, closeDropdown]);
+
+  // ── Sidebar mode ──────────────────────────────────────────────
+  if (!props.mode || props.mode === "sidebar") {
+    const { title, historyOpen = false, onToggleHistory, onNewChat, onClose } = props as ChatTopBarSidebarProps;
+    const displayTitle = title || t("ui.chatbotTitle");
+    const { RecentlyViewed } = require("@carbon/icons-react");
+    return (
+      <div className={styles.bar}>
+        <div className={styles.left}>
+          {onToggleHistory && (
+            <IconButton kind="ghost" label={historyOpen ? t("ui.collapse") : t("ui.history")} onClick={onToggleHistory}>
+              {historyOpen ? <Close size={20} /> : <RecentlyViewed size={20} />}
+            </IconButton>
+          )}
+        </div>
+        <span className={styles.title}>{displayTitle}</span>
+        <div className={styles.right}>
+          <IconButton kind="ghost" label={t("ui.newChat")} onClick={onNewChat}>
+            <Add size={20} />
+          </IconButton>
+          {onClose && (
+            <IconButton kind="ghost" label={t("ui.close")} onClick={onClose}>
+              <Close size={20} />
+            </IconButton>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Full-page mode ────────────────────────────────────────────
+  const { title, sessions, currentSessionId, onSelectSession, onNewChat, onRenameSession, onDeleteSession } = props as ChatTopBarFullProps;
+  const displayTitle = title || t("ui.newChat");
+
+  const startRename = (session: ChatSession) => {
+    setRenamingId(session.id);
+    setRenameValue(session.title || "");
+    setDropdownOpen(false);
+  };
+
+  const commitRename = () => {
+    if (renamingId && renameValue.trim()) {
+      onRenameSession(renamingId, renameValue.trim());
+    }
+    setRenamingId(null);
+    setRenameValue("");
+  };
+
+  return (
+    <div className={styles.bar}>
+      {/* Left: title dropdown */}
+      <div className={styles.left} ref={dropdownRef}>
+        {renamingId === currentSessionId ? (
+          <input
+            className={styles.renameInput}
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitRename();
+              if (e.key === "Escape") { setRenamingId(null); setRenameValue(""); }
+            }}
+            autoFocus
+          />
+        ) : (
+          <button
+            type="button"
+            className={styles.titleBtn}
+            onClick={() => setDropdownOpen((v) => !v)}
+            aria-haspopup="listbox"
+            aria-expanded={dropdownOpen}
+          >
+            <span className={styles.titleText}>{displayTitle}</span>
+            <ChevronDown size={16} className={`${styles.titleChevron} ${dropdownOpen ? styles.open : ""}`} />
+          </button>
+        )}
+
+        {dropdownOpen && (
+          <div className={styles.dropdown} role="listbox">
+            {sessions.slice(0, 15).map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                role="option"
+                aria-selected={s.id === currentSessionId}
+                className={`${styles.dropdownItem} ${s.id === currentSessionId ? styles.dropdownItemActive : ""}`}
+                onClick={() => { onSelectSession(s.id); setDropdownOpen(false); }}
+              >
+                <ChatIcon size={14} className={styles.dropdownItemIcon} />
+                <span className={styles.dropdownItemTitle}>
+                  {s.title || t("ui.newChat")}
+                </span>
+                <span className={styles.dropdownItemTime}>
+                  {formatRelativeTime(s.updatedAt)}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Right: actions */}
+      <div className={styles.right}>
+        <IconButton kind="ghost" label={t("ui.newChat")} onClick={onNewChat}>
+          <Add size={20} />
+        </IconButton>
+        {currentSessionId && (
+          <OverflowMenu size="sm" flipped>
+            <OverflowMenuItem
+              itemText={t("ui.rename")}
+              onClick={() => {
+                const session = sessions.find((s) => s.id === currentSessionId);
+                if (session) startRename(session);
+              }}
+            />
+            <OverflowMenuItem
+              itemText={t("ui.delete")}
+              isDelete
+              hasDivider
+              onClick={() => currentSessionId && onDeleteSession(currentSessionId)}
+            />
+          </OverflowMenu>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+> **注意**：`RecentlyViewed` 改用靜態 import，將上方的 `require(...)` 改成在 import 區：
+> ```ts
+> import { Add, Close, ChevronDown, Chat as ChatIcon, RecentlyViewed } from "@carbon/icons-react";
+> ```
+> 並移除 `const { RecentlyViewed } = require(...)` 行。
+
+- [ ] **Step 2: 更新 `ChatTopBar.module.scss`**
+
+```scss
+@use "./variables" as *;
+
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+  max-width: $chat-content-max-width;
+  width: 100%;
+  margin: 0 auto;
+  background: transparent;
+  flex-shrink: 0;
+  z-index: 5;
+  position: relative;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  min-width: 0;
+  flex: 1;
+  position: relative;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: 400;
+  color: var(--cds-text-secondary, #525252);
+}
+
+// Full-page: title dropdown button
+.titleBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: 500;
+  max-width: 28rem;
+  min-width: 0;
+  transition: background 150ms ease;
+
+  &:hover {
+    background: var(--cds-layer-hover, #e8e8e8);
+  }
+}
+
+.titleText {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.titleChevron {
+  flex-shrink: 0;
+  color: var(--cds-icon-secondary, #525252);
+  transition: transform 150ms ease;
+
+  &.open {
+    transform: rotate(180deg);
+  }
+}
+
+.renameInput {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: 500;
+  border: 1px solid var(--cds-focus, #0f62fe);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  background: var(--cds-field-01, #fff);
+  color: var(--cds-text-primary, #161616);
+  outline: none;
+  width: 20rem;
+  max-width: 100%;
+}
+
+// Dropdown panel
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 16rem;
+  max-width: 24rem;
+  max-height: 20rem;
+  overflow-y: auto;
+  background: var(--cds-layer-01, #f4f4f4);
+  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  border-radius: 4px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  z-index: 200;
+  padding: 0.25rem 0;
+}
+
+.dropdownItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--cds-text-primary, #161616);
+  transition: background 100ms ease;
+
+  &:hover {
+    background: var(--cds-layer-hover-01, #e8e8e8);
+  }
+}
+
+.dropdownItemActive {
+  background: var(--cds-layer-selected-01, #e0e0e0);
+
+  &:hover {
+    background: var(--cds-layer-selected-hover-01, #d1d1d1);
+  }
+}
+
+.dropdownItemIcon {
+  flex-shrink: 0;
+  color: var(--cds-icon-secondary, #525252);
+}
+
+.dropdownItemTitle {
+  flex: 1;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.dropdownItemTime {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--cds-text-secondary, #525252);
+}
+```
+
+- [ ] **Step 3: 確認 stories 不 break（可選）**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep ChatTopBar | head -10
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx \
+        frontend/src/features/chatbot/components/chat-ui/ChatTopBar.module.scss
+git commit -m "feat(chatbot): redesign ChatTopBar full-page with title dropdown and actions"
+```
+
+---
+
+## Task 7: 重設計 `ChatHistoryPanel`（Notion 風格，Carbon style）
+
+**Files:**
+- Modify: `frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx`
+- Modify: `frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.module.scss`
+
+- [ ] **Step 1: 更新 `ChatHistoryPanel.tsx`**
+
+```tsx
+// frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx
+import { useState, useMemo, useCallback } from "react";
+import { OverflowMenu, OverflowMenuItem } from "@carbon/react";
+import { Chat as ChatIcon, Add } from "@carbon/icons-react";
+import { useTranslation } from "react-i18next";
+import type { ChatSession } from "@/core/types/chatbot.types";
+import styles from "./ChatHistoryPanel.module.scss";
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) {
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    return diffHours === 0 ? "Just now" : `${diffHours}h`;
+  }
+  if (diffDays === 1) return "1d";
+  if (diffDays < 7) return `${diffDays}d`;
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 5) return `${diffWeeks}w`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+interface ChatHistoryPanelProps {
+  sessions: ChatSession[];
+  currentSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (id: string) => void;
+  onRenameSession: (id: string, name: string) => void;
+  onClose?: () => void;
+  /** 顯示底部「新增對話」按鈕 */
+  showNewChatButton?: boolean;
+  onNewChat?: () => void;
+}
+
+interface HistoryGroup {
+  key: "today" | "yesterday" | "lastWeek" | "older";
+  sessions: ChatSession[];
+}
+
+function groupSessions(sessions: ChatSession[]): HistoryGroup[] {
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const yesterdayStart = todayStart - 86_400_000;
+  const weekStart = todayStart - 7 * 86_400_000;
+
+  const groups: Record<string, ChatSession[]> = {
+    today: [], yesterday: [], lastWeek: [], older: [],
+  };
+
+  for (const s of sessions) {
+    const ts = s.updatedAt.getTime();
+    if (ts >= todayStart) groups["today"].push(s);
+    else if (ts >= yesterdayStart) groups["yesterday"].push(s);
+    else if (ts >= weekStart) groups["lastWeek"].push(s);
+    else groups["older"].push(s);
+  }
+
+  return Object.entries(groups)
+    .filter(([, list]) => list.length > 0)
+    .map(([key, list]) => ({ key: key as HistoryGroup["key"], sessions: list }));
+}
+
+export function ChatHistoryPanel({
+  sessions,
+  currentSessionId,
+  onSelectSession,
+  onDeleteSession,
+  onRenameSession,
+  onClose: _onClose,
+  showNewChatButton = false,
+  onNewChat,
+}: ChatHistoryPanelProps) {
+  const { t } = useTranslation("chatbot");
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+
+  const groups = useMemo(() => groupSessions(sessions), [sessions]);
+
+  const groupLabels = useMemo(() => ({
+    today: t("ui.groupToday"),
+    yesterday: t("ui.groupYesterday"),
+    lastWeek: t("ui.groupLast7Days"),
+    older: t("ui.groupOlder"),
+  }), [t]);
+
+  const startRename = useCallback((session: ChatSession) => {
+    setRenamingId(session.id);
+    setRenameValue(session.title || "");
+  }, []);
+
+  const commitRename = useCallback(() => {
+    if (renamingId && renameValue.trim()) {
+      onRenameSession(renamingId, renameValue.trim());
+    }
+    setRenamingId(null);
+    setRenameValue("");
+  }, [renamingId, renameValue, onRenameSession]);
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.list}>
+        {groups.length === 0 && (
+          <div className={styles.empty}>{t("ui.noHistory")}</div>
+        )}
+
+        {groups.map((group) => (
+          <div key={group.key} className={styles.group}>
+            <div className={styles.groupLabel}>{groupLabels[group.key]}</div>
+            {group.sessions.map((session) => (
+              <div
+                key={session.id}
+                className={`${styles.item} ${session.id === currentSessionId ? styles.active : ""}`}
+                onClick={() => onSelectSession(session.id)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelectSession(session.id);
+                  }
+                }}
+              >
+                <ChatIcon size={16} className={styles.itemIcon} />
+
+                {renamingId === session.id ? (
+                  <input
+                    className={styles.renameInput}
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commitRename();
+                      if (e.key === "Escape") { setRenamingId(null); setRenameValue(""); }
+                    }}
+                    autoFocus
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  <>
+                    <span className={styles.itemName}>
+                      {session.title || t("ui.defaultSessionTitle", { id: session.id.slice(0, 8) })}
+                    </span>
+                    <span className={styles.itemTime}>
+                      {formatRelativeTime(session.updatedAt)}
+                    </span>
+                  </>
+                )}
+
+                <OverflowMenu
+                  size="sm"
+                  flipped
+                  className={styles.overflow}
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                >
+                  <OverflowMenuItem
+                    itemText={t("ui.rename")}
+                    onClick={() => startRename(session)}
+                  />
+                  <OverflowMenuItem
+                    itemText={t("ui.delete")}
+                    isDelete
+                    hasDivider
+                    onClick={() => onDeleteSession(session.id)}
+                  />
+                </OverflowMenu>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {showNewChatButton && onNewChat && (
+        <div className={styles.footer}>
+          <button type="button" className={styles.newChatBtn} onClick={onNewChat}>
+            <Add size={16} />
+            <span>{t("ui.newChat")}</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 更新 `ChatHistoryPanel.module.scss`**
+
+```scss
+.panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--cds-layer-01, #f4f4f4);
+}
+
+.list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+}
+
+.empty {
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: var(--cds-text-secondary, #525252);
+}
+
+.group {
+  margin-bottom: 0.25rem;
+}
+
+.groupLabel {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--cds-text-secondary, #525252);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.5rem 1rem 0.25rem;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem 0.375rem 0.75rem;
+  cursor: pointer;
+  transition: background 100ms ease;
+  border-radius: 4px;
+  margin: 0 0.25rem;
+
+  &:hover {
+    background: var(--cds-layer-hover-01, #e8e8e8);
+
+    .overflow {
+      opacity: 1;
+    }
+
+    .itemTime {
+      display: none;
+    }
+  }
+}
+
+.active {
+  background: var(--cds-layer-selected-01, #e0e0e0);
+
+  &:hover {
+    background: var(--cds-layer-selected-hover-01, #d1d1d1);
+  }
+}
+
+.itemIcon {
+  flex-shrink: 0;
+  color: var(--cds-icon-secondary, #525252);
+}
+
+.itemName {
+  flex: 1;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  color: var(--cds-text-primary, #161616);
+}
+
+.itemTime {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--cds-text-secondary, #525252);
+  white-space: nowrap;
+}
+
+.overflow {
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.renameInput {
+  flex: 1;
+  font-size: 0.8125rem;
+  border: 1px solid var(--cds-focus, #0f62fe);
+  border-radius: 2px;
+  padding: 0.125rem 0.25rem;
+  background: var(--cds-field-01, #fff);
+  outline: none;
+}
+
+// Footer: new chat button
+.footer {
+  padding: 0.5rem;
+  border-top: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  flex-shrink: 0;
+}
+
+.newChatBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem;
+  background: transparent;
+  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--cds-text-secondary, #525252);
+  font-size: 0.875rem;
+  transition: background 100ms ease, color 100ms ease;
+
+  &:hover {
+    background: var(--cds-layer-hover-01, #e8e8e8);
+    color: var(--cds-text-primary, #161616);
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx \
+        frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.module.scss
+git commit -m "feat(chatbot): redesign ChatHistoryPanel in Notion style with Carbon tokens"
+```
+
+---
+
+## Task 8: `SideMenu` 升級 — tab bar + Chat tab
+
+**Files:**
+- Modify: `frontend/src/features/app/components/SideMenu.tsx`
+- Modify: `frontend/src/features/app/components/SideMenu.scss`
+
+- [ ] **Step 1: 更新 `SideMenu.tsx` — 加入 tab 邏輯與 Chat tab**
+
+```tsx
+// frontend/src/features/app/components/SideMenu.tsx
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+  Dashboard, Education, Book, Checkmark, Globe, Chat as ChatIcon, Add,
+} from "@carbon/icons-react";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@/features/auth/contexts/AuthContext";
+import { getClassrooms } from "@/infrastructure/api/repositories/classroom.repository";
+import { getQuestionBanks as listMyBanks } from "@/infrastructure/api/repositories/questionBank.repository";
+import { getClassroomIcon } from "@/features/classroom/constants/classroomIcons";
+import type { Classroom } from "@/core/entities/classroom.entity";
+import type { QuestionBank } from "@/core/entities/question-bank.entity";
+import { useChatSessionContext } from "@/features/chatbot/contexts/ChatSessionContext";
+import { chatbotRepository } from "@/infrastructure/api/repositories";
+import { ChatHistoryPanel } from "@/features/chatbot/components/chat-ui/ChatHistoryPanel";
+import "./SideMenu.scss";
+
+type TabKey = "classrooms" | "banks" | "chat";
+
+function getDefaultTab(pathname: string): TabKey {
+  if (pathname.startsWith("/classrooms")) return "classrooms";
+  if (pathname.startsWith("/question-banks")) return "banks";
+  if (pathname.startsWith("/chat")) return "chat";
+  return "classrooms";
+}
+
+interface SideMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation("common");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useAuth();
+  const drawerRef = useRef<HTMLElement | null>(null);
+  const [, startTransition] = useTransition();
+
+  const isTeacherOrAdmin = user?.role === "teacher" || user?.role === "admin";
+
+  const [activeTab, setActiveTab] = useState<TabKey>(() => getDefaultTab(location.pathname));
+  const [classrooms, setClassrooms] = useState<Classroom[]>([]);
+  const [banks, setBanks] = useState<QuestionBank[]>([]);
+  const [fetched, setFetched] = useState(false);
+
+  // Chat sessions from shared context
+  const { sessions, refreshSessions } = useChatSessionContext();
+  const currentSessionId = useMemo(() => {
+    const match = location.pathname.match(/^\/chat\/([^/]+)/);
+    return match?.[1] ?? null;
+  }, [location.pathname]);
+
+  // Update active tab when route changes
+  useEffect(() => {
+    setActiveTab(getDefaultTab(location.pathname));
+  }, [location.pathname]);
+
+  // Refresh chat sessions when Chat tab becomes visible
+  useEffect(() => {
+    if (isOpen && activeTab === "chat" && isTeacherOrAdmin) {
+      void refreshSessions();
+    }
+  }, [isOpen, activeTab, isTeacherOrAdmin, refreshSessions]);
+
+  const classroomId = useMemo(() => {
+    const match = location.pathname.match(/^\/classrooms\/([^/]+)/);
+    return match?.[1];
+  }, [location.pathname]);
+
+  const bankId = useMemo(() => {
+    const match = location.pathname.match(/^\/question-banks\/([^/]+)/);
+    return match?.[1];
+  }, [location.pathname]);
+
+  const fetchData = useCallback(async () => {
+    if (!user) return;
+    try {
+      const classroomRows = await getClassrooms();
+      let bankRows: QuestionBank[] = [];
+      if (isTeacherOrAdmin) bankRows = await listMyBanks();
+      startTransition(() => {
+        setClassrooms(classroomRows);
+        setBanks(bankRows);
+        setFetched(true);
+      });
+    } catch {
+      startTransition(() => { setFetched(true); });
+    }
+  }, [user, isTeacherOrAdmin]);
+
+  useEffect(() => {
+    if (isOpen && !fetched) void fetchData();
+  }, [isOpen, fetched, fetchData]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (drawerRef.current?.contains(target)) return;
+      const toggle = document.querySelector(`[data-side-menu-toggle]`);
+      if (toggle?.contains(target)) return;
+      onClose();
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen, onClose]);
+
+  const go = (path: string) => { onClose(); navigate(path); };
+  const isActive = (prefix: string) => location.pathname.startsWith(prefix);
+
+  const handleNewChat = async () => {
+    try {
+      const newSession = await chatbotRepository.createSession();
+      void refreshSessions();
+      onClose();
+      navigate(`/chat/${newSession.id}`);
+    } catch {
+      onClose();
+      navigate("/chat");
+    }
+  };
+
+  const handleSelectSession = (id: string) => {
+    onClose();
+    navigate(`/chat/${id}`);
+  };
+
+  const handleDeleteSession = async (id: string) => {
+    try {
+      await chatbotRepository.deleteSession(id);
+      void refreshSessions();
+      if (id === currentSessionId) {
+        const remaining = sessions.filter((s) => s.id !== id);
+        if (remaining.length > 0) {
+          navigate(`/chat/${remaining[0].id}`, { replace: true });
+        } else {
+          navigate("/chat", { replace: true });
+        }
+      }
+    } catch {
+      // silently ignore
+    }
+  };
+
+  const handleRenameSession = async (id: string, title: string) => {
+    try {
+      await chatbotRepository.renameSession(id, title);
+      void refreshSessions();
+    } catch {
+      // silently ignore
+    }
+  };
+
+  const tabs: { key: TabKey; label: string; show: boolean }[] = [
+    { key: "classrooms", label: t("nav.classrooms"), show: true },
+    { key: "banks", label: t("nav.questionBanks"), show: isTeacherOrAdmin },
+    { key: "chat", label: t("nav.chat", "Chat"), show: isTeacherOrAdmin },
+  ].filter((tab) => tab.show);
+
+  return (
+    <>
+      <div className={`side-menu-backdrop${isOpen ? " side-menu-backdrop--visible" : ""}`} aria-hidden="true" />
+      <nav
+        ref={drawerRef}
+        className={`side-menu${isOpen ? " side-menu--open" : ""}`}
+        aria-label={t("header.sideNav", "Side navigation")}
+      >
+        {/* Tab bar */}
+        <div className="side-menu__tabs" role="tablist">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.key}
+              className={`side-menu__tab${activeTab === tab.key ? " side-menu__tab--active" : ""}`}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        {activeTab === "classrooms" && (
+          <>
+            {/* Quick links */}
+            <div className="side-menu__section">
+              <button
+                type="button"
+                className={`side-menu__link${isActive("/dashboard") ? " side-menu__link--active" : ""}`}
+                onClick={() => go("/dashboard")}
+              >
+                <Dashboard size={16} />
+                <span>{t("nav.dashboard")}</span>
+              </button>
+              {isTeacherOrAdmin && (
+                <button
+                  type="button"
+                  className={`side-menu__link${isActive("/marketplace") ? " side-menu__link--active" : ""}`}
+                  onClick={() => go("/marketplace")}
+                >
+                  <Globe size={16} />
+                  <span>{t("nav.marketplace", "Marketplace")}</span>
+                </button>
+              )}
+            </div>
+            {classrooms.length > 0 && (
+              <>
+                <div className="side-menu__divider" />
+                <div className="side-menu__section">
+                  <div className="side-menu__section-header">
+                    <Education size={16} />
+                    <span>{t("nav.classrooms")}</span>
+                  </div>
+                  <div className="side-menu__classroom-list">
+                    {classrooms.map((c) => {
+                      const isCurrent = c.id === classroomId;
+                      const Icon = getClassroomIcon(c.icon);
+                      return (
+                        <button
+                          key={c.id}
+                          type="button"
+                          className={`side-menu__classroom${isCurrent ? " side-menu__classroom--active" : ""}`}
+                          onClick={() => go(`/classrooms/${c.id}`)}
+                        >
+                          <Icon size={16} />
+                          <span className="side-menu__classroom-name">{c.name}</span>
+                          {isCurrent && <Checkmark size={16} className="side-menu__classroom-check" />}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </>
+            )}
+          </>
+        )}
+
+        {activeTab === "banks" && banks.length > 0 && (
+          <div className="side-menu__section">
+            <div className="side-menu__section-header">
+              <Book size={16} />
+              <span>{t("nav.questionBanks")}</span>
+            </div>
+            <div className="side-menu__bank-list">
+              {banks.map((b) => {
+                const isCurrent = b.id === bankId;
+                return (
+                  <button
+                    key={b.id}
+                    type="button"
+                    className={`side-menu__bank${isCurrent ? " side-menu__bank--active" : ""}`}
+                    onClick={() => go(`/question-banks/${b.id}`)}
+                  >
+                    <span className="side-menu__bank-name">{b.name}</span>
+                    <span className="side-menu__bank-meta">
+                      {b.category === "coding" ? "Coding" : "Exam"} · {b.questionCount}
+                    </span>
+                    {isCurrent && <Checkmark size={14} className="side-menu__bank-check" />}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {activeTab === "chat" && (
+          <div className="side-menu__chat-tab">
+            <ChatHistoryPanel
+              sessions={sessions}
+              currentSessionId={currentSessionId}
+              onSelectSession={handleSelectSession}
+              onDeleteSession={handleDeleteSession}
+              onRenameSession={handleRenameSession}
+              showNewChatButton
+              onNewChat={handleNewChat}
+            />
+          </div>
+        )}
+      </nav>
+    </>
+  );
+};
+
+export default SideMenu;
+```
+
+- [ ] **Step 2: 在 `SideMenu.scss` 加入 tab bar 樣式**
+
+在現有 `.side-menu` 樣式定義後，追加：
+
+```scss
+// ── Tab bar ──
+
+.side-menu__tabs {
+  display: flex;
+  border-bottom: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  background: var(--cds-layer-01, #f4f4f4);
+  flex-shrink: 0;
+}
+
+.side-menu__tab {
+  flex: 1;
+  padding: 0.625rem 0.25rem;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--cds-text-secondary, #525252);
+  transition: color 150ms ease, border-color 150ms ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    color: var(--cds-text-primary, #161616);
+    background: var(--cds-layer-hover-01, #e8e8e8);
+  }
+}
+
+.side-menu__tab--active {
+  color: var(--cds-text-primary, #161616);
+  border-bottom-color: var(--cds-interactive, #0f62fe);
+  font-weight: 500;
+}
+
+// ── Chat tab ──
+
+.side-menu__chat-tab {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+```
+
+同時確認現有 `.side-menu` 有 `display: flex; flex-direction: column;`（若沒有則加入）。
+
+- [ ] **Step 3: 型別檢查 + lint**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -E "error TS" | head -20
+```
+
+Expected: 0 errors
+
+- [ ] **Step 4: 確認 `nav.chat` i18n key 已存在或加入**
+
+在 `frontend/src/locales/zh-TW/common.json`（或對應 locale 檔案）確認有：
+```json
+"nav": {
+  "chat": "Chat"
+}
+```
+若不存在則加入。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/app/components/SideMenu.tsx \
+        frontend/src/features/app/components/SideMenu.scss
+git commit -m "feat(app): upgrade SideMenu with tab bar and Notion-style Chat tab"
+```
+
+---
+
+## Task 9: 整合驗證與手動測試
+
+- [ ] **Step 1: 啟動開發環境**
+
+```bash
+bash .codex/skills/qjudge-env-compose-owner/scripts/qjudge-dc.sh dev up -d
+```
+
+- [ ] **Step 2: 完整型別檢查**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -E "error TS"
+```
+Expected: 0 errors
+
+- [ ] **Step 3: 執行單元測試**
+
+```bash
+cd frontend && npx vitest run src/features/chatbot/
+```
+Expected: All pass
+
+- [ ] **Step 4: 手動測試 — URL routing**
+
+- 瀏覽 `/chat` → 應該 redirect 或顯示最後一個 session
+- 複製 URL（應為 `/chat/:sessionId`）→ 重新開啟 → 應進入同一 session
+- 刪除目前 session → URL 應自動更新到下一個 session
+
+- [ ] **Step 5: 手動測試 — SideMenu Chat tab**
+
+- 點漢堡選單 → 看到三個 tab（教室 / 題庫 / Chat）
+- 點 Chat tab → 看到 session 列表（Notion 風格：chat icon + 標題 + 時間）
+- 點某 session → SideMenu 關閉，URL 更新，ChatContainer 顯示對應 session
+- 點「新增對話」→ 建立新 session，URL 更新
+- Hover session → 出現 `...` overflow（rename、delete）
+
+- [ ] **Step 6: 手動測試 — ChatTopBar（full-page）**
+
+- 點 session 標題 → 展開下拉清單（有 chat icon + 時間）
+- 點清單中的 session → URL 更新，ChatContainer 切換
+- 點 `+` → 建立新 session
+- 點 `...` → Rename（inline 編輯）/ Delete（URL 更新）
+
+- [ ] **Step 7: 手動測試 — sidebar mode 不受影響**
+
+- 在習題頁或考試頁開啟 chat sidebar → 功能正常，有歷史 toggle
+
+- [ ] **Step 8: Final commit（若有 polish 修改）**
+
+```bash
+git add -p
+git commit -m "fix(chatbot): integration polish after manual testing"
+```

--- a/docs/superpowers/specs/2026-04-19-notion-style-sidemenu-chat-design.md
+++ b/docs/superpowers/specs/2026-04-19-notion-style-sidemenu-chat-design.md
@@ -1,0 +1,146 @@
+# Notion 風格 SideMenu + Chat Session URL Routing
+
+## 目標
+
+將 ChatHistoryPanel 整合進全域 SideMenu，改成 Notion AI 側邊欄風格，並加上 tab 切換（教室 / 題庫 / Chat）。同時讓 `/chat/:sessionId` 承載 session 狀態，使 URL 可分享與書籤化。
+
+---
+
+## 一、路由變更（App.tsx）
+
+- 現有：`/chat`
+- 新增：`/chat/:sessionId`
+- 行為：
+  - 進入 `/chat` → 自動 redirect 到最後一個 session（localStorage `chatbot_last_session_id`），或 redirect 到新建 session 的 URL
+  - `ChatStandalonePage` 讀取 `useParams()` 取得 `sessionId`，傳入 `ChatContainer`
+  - 切換 session → `navigate('/chat/:newId')`，不 push 同一個 session
+  - 刪除目前 session → redirect 到最近的其他 session，或 `/chat`（自動新建）
+
+---
+
+## 二、狀態提升：`useChatSessions` + `ChatSessionProvider`
+
+### 問題
+目前 session 清單與 CRUD 邏輯都埋在 `useChatbot` 裡，SideMenu 無法取得。
+
+### 解法
+將 session 管理拆出為獨立 hook：
+
+**`useChatSessions`**（新建）
+```ts
+{
+  sessions: ChatSession[];
+  isInitializing: boolean;
+  createSession: () => Promise<string | null>;   // 回傳新 sessionId
+  deleteSession: (id: string) => Promise<void>;
+  switchSession: (id: string) => void;           // 更新 currentSessionId
+  renameSession: (id: string, title: string) => Promise<void>;
+  refreshSessions: () => Promise<void>;
+  currentSessionId: string | null;
+  setCurrentSessionId: (id: string | null) => void;
+}
+```
+
+**`ChatSessionProvider`**（新建，在 App.tsx 包住 protected routes）
+- 使用 `useChatSessions`
+- 僅在已登入時初始化（`enabled: !!user`）
+- 暴露 context 給 SideMenu 和 full-page ChatContainer 消費
+
+**`useChatbot` 變更**
+- full-page 模式：接收外部 `ChatSessionContext`（不再自建 session state）
+- sidebar 模式（WorkspaceShell 內）：維持原有行為，使用獨立 session（不共用 context）
+
+---
+
+## 三、SideMenu 重設計
+
+### Tab bar（頂部）
+- 三個 tab：`教室 | 題庫 | Chat`
+- 依目前路由自動 active：
+  - `/classrooms/*` → 教室
+  - `/question-banks/*` → 題庫
+  - `/chat/*` → Chat
+- Tab 儲存於 SideMenu 內部 state，點擊可切換
+
+### 教室 tab
+與現有內容相同（classroom list）。
+
+### 題庫 tab
+與現有內容相同（question bank list）。
+
+### Chat tab（Notion 風格）
+- 無搜尋欄
+- 依時間分組（今天 / 昨天 / 過去一週 / 更早）
+- 每個 session item：
+  - 左：`<Chat size={16} />` icon（灰色）
+  - 中：標題（truncate，1 行）
+  - 右：相對時間（`1d`、`Apr 16` 等）
+  - hover → 顯示 `...` OverflowMenu（rename、delete）
+- Active session（目前 URL sessionId）高亮
+- 點擊 session → `navigate('/chat/:id')`
+- 底部固定：「新增對話」全寬 ghost button → `navigate('/chat')` + createSession
+
+---
+
+## 四、ChatContainer full-page 模式變更
+
+### 移除
+- `historyColumn`（左側歷史欄）
+- `historyOverlay`（mobile 覆蓋層）
+- `historyOpen` state 和 toggle 邏輯
+- ChatTopBar 的 history toggle 按鈕
+
+### ChatTopBar 重設計（full mode）
+```
+[ <sessionTitle> ▾ ]  ←→  [ + ] [ ⋯ ]
+```
+- **左側**：`<Button kind="ghost">` 顯示目前 session 標題 + `<ChevronDown>` icon
+  - 點擊展開 dropdown，列出最近 sessions（最多 15 筆）
+  - 每項：標題 + 相對時間，點擊 → `navigate('/chat/:id')`
+- **右側**：
+  - `+`（Add icon）→ create new session → navigate
+  - `...`（OverflowMenu）→ Rename（inline 編輯）/ Delete（confirm + redirect）
+
+### sidebar mode ChatTopBar
+維持不變（有 close button）。
+
+---
+
+## 五、ChatHistoryPanel 重設計
+
+（用於 SideMenu Chat tab 和未來其他地方）
+
+- 移除 `<Search>` 元件
+- 移除 header 的 close button（由 SideMenu 管理開關）
+- 每個 item 加上 `<Chat size={16} />` 前綴 icon
+- 每個 item 右側加上相對時間（`formatDistanceToNow` from date-fns 或自製）
+- OverflowMenu 改為 hover 才顯示（CSS `opacity: 0 → 1 on :hover`）
+- 整體樣式：更乾淨，無邊框，`--cds-layer-01` 背景，`8px` border-radius hover
+
+---
+
+## 六、影響範圍
+
+| 檔案 | 改動類型 |
+|---|---|
+| `frontend/src/App.tsx` | 新增 `/chat/:sessionId` route + `ChatSessionProvider` |
+| `frontend/src/features/chatbot/hooks/useChatbot.ts` | 拆出 `useChatSessions`，支援外部 context |
+| `frontend/src/features/chatbot/contexts/ChatSessionContext.tsx` | 新建 |
+| `frontend/src/features/chatbot/hooks/useChatSessions.ts` | 新建 |
+| `frontend/src/features/chatbot/components/ChatStandalonePage.tsx` | 讀 URL params，傳 sessionId |
+| `frontend/src/features/chatbot/components/ChatFullPage.tsx` | 傳 sessionId 給 ChatContainer |
+| `frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx` | 移除 history panel，接受外部 sessionId |
+| `frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx` | 重設計 full-page header |
+| `frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx` | 移除搜尋，Notion 樣式 |
+| `frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.module.scss` | 重設計 |
+| `frontend/src/features/app/components/SideMenu.tsx` | 加 tab bar，整合 Chat tab |
+| `frontend/src/features/app/components/SideMenu.scss` | 加 tab + chat item 樣式 |
+
+---
+
+## 七、不在本次範圍
+
+- Agent 頭像列（目前只有一個 AI 助教）
+- SideMenu 搜尋功能
+- sidebar 模式的 ChatContainer（維持現有行為）
+- Mobile 響應式細節（維持現有 breakpoint 邏輯）

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ const ChatStandalonePage = lazy(() => import("@/features/chatbot/components/Chat
 import { ApiErrorProvider, ToastProvider, ContentLanguageProvider } from "@/shared/contexts";
 import { PageHeaderActionsProvider } from "@/features/app/contexts/PageHeaderActionsContext";
 import { AIWorkspaceProvider } from "@/features/chatbot/components/workspace/AIWorkspaceProvider";
+import { ChatSessionProvider } from "@/features/chatbot/contexts/ChatSessionContext";
 import { ThemeProvider } from "@/shared/ui/theme/ThemeContext";
 import {
   MarkdownImageUploadProvider,
@@ -96,6 +97,7 @@ function App() {
                     <RecurProviderBridge>
                     <BrowserRouter>
                       <AIWorkspaceProvider>
+                      <ChatSessionProvider>
                       <PageHeaderActionsProvider>
                       <ApiErrorProvider>
                       <Routes>
@@ -178,6 +180,14 @@ function App() {
                                 </Suspense>
                               }
                             />
+                            <Route
+                              path="/chat/:sessionId"
+                              element={
+                                <Suspense fallback={null}>
+                                  <ChatStandalonePage />
+                                </Suspense>
+                              }
+                            />
 
                             {/* Question Bank Detail - Standalone with breadcrumb header */}
                             {questionBankDetailRoute}
@@ -208,6 +218,7 @@ function App() {
                       </Routes>
                       </ApiErrorProvider>
                       </PageHeaderActionsProvider>
+                      </ChatSessionProvider>
                       </AIWorkspaceProvider>
                     </BrowserRouter>
                     <SettingsDialog />

--- a/frontend/src/features/app/components/SideMenu.scss
+++ b/frontend/src/features/app/components/SideMenu.scss
@@ -54,8 +54,7 @@
   flex-direction: column;
   transform: translateX(-100%);
   transition: transform 200ms cubic-bezier(0.2, 0, 0.38, 0.9);
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .side-menu--open {

--- a/frontend/src/features/app/components/SideMenu.scss
+++ b/frontend/src/features/app/components/SideMenu.scss
@@ -55,6 +55,7 @@
   transform: translateX(-100%);
   transition: transform 200ms cubic-bezier(0.2, 0, 0.38, 0.9);
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .side-menu--open {
@@ -230,4 +231,49 @@
   .side-menu {
     width: 100%;
   }
+}
+
+// ── Tab bar ──
+
+.side-menu__tabs {
+  display: flex;
+  border-bottom: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  background: var(--cds-layer-01, #f4f4f4);
+  flex-shrink: 0;
+}
+
+.side-menu__tab {
+  flex: 1;
+  padding: 0.625rem 0.25rem;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--cds-text-secondary, #525252);
+  transition: color 150ms ease, border-color 150ms ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    color: var(--cds-text-primary, #161616);
+    background: var(--cds-layer-hover-01, #e8e8e8);
+  }
+}
+
+.side-menu__tab--active {
+  color: var(--cds-text-primary, #161616);
+  border-bottom-color: var(--cds-interactive, #0f62fe);
+  font-weight: 500;
+}
+
+// ── Chat tab content ──
+
+.side-menu__chat-tab {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }

--- a/frontend/src/features/app/components/SideMenu.tsx
+++ b/frontend/src/features/app/components/SideMenu.tsx
@@ -14,7 +14,19 @@ import { getQuestionBanks as listMyBanks } from "@/infrastructure/api/repositori
 import { getClassroomIcon } from "@/features/classroom/constants/classroomIcons";
 import type { Classroom } from "@/core/entities/classroom.entity";
 import type { QuestionBank } from "@/core/entities/question-bank.entity";
+import { useChatSessionContext } from "@/features/chatbot/contexts/ChatSessionContext";
+import { chatbotRepository } from "@/infrastructure/api/repositories";
+import { ChatHistoryPanel } from "@/features/chatbot/components/chat-ui/ChatHistoryPanel";
 import "./SideMenu.scss";
+
+type TabKey = "classrooms" | "banks" | "chat";
+
+function getDefaultTab(pathname: string): TabKey {
+  if (pathname.startsWith("/classrooms")) return "classrooms";
+  if (pathname.startsWith("/question-banks")) return "banks";
+  if (pathname.startsWith("/chat")) return "chat";
+  return "classrooms";
+}
 
 interface SideMenuProps {
   isOpen: boolean;
@@ -29,7 +41,30 @@ export const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose }) => {
   const drawerRef = useRef<HTMLElement | null>(null);
   const [, startTransition] = useTransition();
 
-  // Extract IDs from URL since this component lives outside route context
+  const isTeacherOrAdmin = user?.role === "teacher" || user?.role === "admin";
+
+  const [activeTab, setActiveTab] = useState<TabKey>(() => getDefaultTab(location.pathname));
+  const [classrooms, setClassrooms] = useState<Classroom[]>([]);
+  const [banks, setBanks] = useState<QuestionBank[]>([]);
+  const [fetched, setFetched] = useState(false);
+
+  const { sessions, refreshSessions } = useChatSessionContext();
+
+  const currentSessionId = useMemo(() => {
+    const match = location.pathname.match(/^\/chat\/([^/]+)/);
+    return match?.[1] ?? null;
+  }, [location.pathname]);
+
+  useEffect(() => {
+    setActiveTab(getDefaultTab(location.pathname));
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (isOpen && activeTab === "chat" && isTeacherOrAdmin) {
+      void refreshSessions();
+    }
+  }, [isOpen, activeTab, isTeacherOrAdmin, refreshSessions]);
+
   const classroomId = useMemo(() => {
     const match = location.pathname.match(/^\/classrooms\/([^/]+)/);
     return match?.[1];
@@ -40,43 +75,28 @@ export const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose }) => {
     return match?.[1];
   }, [location.pathname]);
 
-  const isTeacherOrAdmin =
-    user?.role === "teacher" || user?.role === "admin";
-
-  const [classrooms, setClassrooms] = useState<Classroom[]>([]);
-  const [banks, setBanks] = useState<QuestionBank[]>([]);
-  const [fetched, setFetched] = useState(false);
-
   const fetchData = useCallback(async () => {
     if (!user) return;
     try {
       const classroomRows = await getClassrooms();
       let bankRows: QuestionBank[] = [];
-      if (isTeacherOrAdmin) {
-        bankRows = await listMyBanks();
-      }
-      
+      if (isTeacherOrAdmin) bankRows = await listMyBanks();
       startTransition(() => {
         setClassrooms(classroomRows);
         setBanks(bankRows);
         setFetched(true);
       });
     } catch {
-      startTransition(() => {
-        setFetched(true);
-      });
+      startTransition(() => { setFetched(true); });
     }
   }, [user, isTeacherOrAdmin]);
 
   useEffect(() => {
-    if (isOpen && !fetched) {
-      void fetchData();
-    }
+    if (isOpen && !fetched) void fetchData();
   }, [isOpen, fetched, fetchData]);
 
   useEffect(() => {
     if (!isOpen) return;
-
     const handlePointerDown = (event: MouseEvent) => {
       const target = event.target as Node;
       if (drawerRef.current?.contains(target)) return;
@@ -84,11 +104,9 @@ export const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose }) => {
       if (toggle?.contains(target)) return;
       onClose();
     };
-
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
-
     document.addEventListener("mousedown", handlePointerDown);
     document.addEventListener("keydown", handleEscape);
     return () => {
@@ -97,12 +115,58 @@ export const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose }) => {
     };
   }, [isOpen, onClose]);
 
-  const go = (path: string) => {
-    onClose();
-    navigate(path);
-  };
+  const go = useCallback((path: string) => { onClose(); navigate(path); }, [onClose, navigate]);
 
   const isActive = (prefix: string) => location.pathname.startsWith(prefix);
+
+  const handleNewChat = useCallback(async () => {
+    try {
+      const newSession = await chatbotRepository.createSession();
+      void refreshSessions();
+      onClose();
+      navigate(`/chat/${newSession.id}`);
+    } catch {
+      onClose();
+      navigate("/chat");
+    }
+  }, [refreshSessions, onClose, navigate]);
+
+  const handleSelectSession = useCallback((id: string) => {
+    onClose();
+    navigate(`/chat/${id}`);
+  }, [onClose, navigate]);
+
+  const handleDeleteSession = useCallback(async (id: string) => {
+    try {
+      await chatbotRepository.deleteSession(id);
+      void refreshSessions();
+      if (id === currentSessionId) {
+        const remaining = sessions.filter((s) => s.id !== id);
+        if (remaining.length > 0) {
+          navigate(`/chat/${remaining[0].id}`, { replace: true });
+        } else {
+          navigate("/chat", { replace: true });
+        }
+      }
+    } catch {
+      // silently ignore
+    }
+  }, [currentSessionId, sessions, refreshSessions, navigate]);
+
+  const handleRenameSession = useCallback(async (id: string, title: string) => {
+    try {
+      await chatbotRepository.renameSession(id, title);
+      void refreshSessions();
+    } catch {
+      // silently ignore
+    }
+  }, [refreshSessions]);
+
+  const tabs: { key: TabKey; label: string; show: boolean }[] = [
+    { key: "classrooms", label: t("nav.classrooms"), show: true },
+    { key: "banks", label: t("nav.questionBanks"), show: isTeacherOrAdmin },
+    { key: "chat", label: t("nav.chat", "Chat"), show: isTeacherOrAdmin },
+  ].filter((tab) => tab.show);
 
   return (
     <>
@@ -115,94 +179,119 @@ export const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose }) => {
         className={`side-menu${isOpen ? " side-menu--open" : ""}`}
         aria-label={t("header.sideNav", "Side navigation")}
       >
-        {/* Quick Links */}
-        <div className="side-menu__section">
-          <button
-            type="button"
-            className={`side-menu__link${isActive("/dashboard") ? " side-menu__link--active" : ""}`}
-            onClick={() => go("/dashboard")}
-          >
-            <Dashboard size={16} />
-            <span>{t("nav.dashboard")}</span>
-          </button>
-
-          {isTeacherOrAdmin && (
+        {/* Tab bar */}
+        <div className="side-menu__tabs" role="tablist">
+          {tabs.map((tab) => (
             <button
+              key={tab.key}
               type="button"
-              className={`side-menu__link${isActive("/marketplace") ? " side-menu__link--active" : ""}`}
-              onClick={() => go("/marketplace")}
+              role="tab"
+              aria-selected={activeTab === tab.key}
+              className={`side-menu__tab${activeTab === tab.key ? " side-menu__tab--active" : ""}`}
+              onClick={() => setActiveTab(tab.key)}
             >
-              <Globe size={16} />
-              <span>{t("nav.marketplace", "Marketplace")}</span>
+              {tab.label}
             </button>
-          )}
+          ))}
         </div>
 
-        {/* Classroom List */}
-        {classrooms.length > 0 && (
+        {/* Classrooms tab */}
+        {activeTab === "classrooms" && (
           <>
-            <div className="side-menu__divider" />
             <div className="side-menu__section">
-              <div className="side-menu__section-header">
-                <Education size={16} />
-                <span>{t("nav.classrooms")}</span>
-              </div>
-              <div className="side-menu__classroom-list">
-                {classrooms.map((c) => {
-                  const isCurrent = c.id === classroomId;
-                  const Icon = getClassroomIcon(c.icon);
-                  return (
-                    <button
-                      key={c.id}
-                      type="button"
-                      className={`side-menu__classroom${isCurrent ? " side-menu__classroom--active" : ""}`}
-                      onClick={() => go(`/classrooms/${c.id}`)}
-                    >
-                      <Icon size={16} />
-                      <span className="side-menu__classroom-name">{c.name}</span>
-                      {isCurrent && (
-                        <Checkmark size={16} className="side-menu__classroom-check" />
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
+              <button
+                type="button"
+                className={`side-menu__link${isActive("/dashboard") ? " side-menu__link--active" : ""}`}
+                onClick={() => go("/dashboard")}
+              >
+                <Dashboard size={16} />
+                <span>{t("nav.dashboard")}</span>
+              </button>
+              {isTeacherOrAdmin && (
+                <button
+                  type="button"
+                  className={`side-menu__link${isActive("/marketplace") ? " side-menu__link--active" : ""}`}
+                  onClick={() => go("/marketplace")}
+                >
+                  <Globe size={16} />
+                  <span>{t("nav.marketplace", "Marketplace")}</span>
+                </button>
+              )}
             </div>
+            {classrooms.length > 0 && (
+              <>
+                <div className="side-menu__divider" />
+                <div className="side-menu__section">
+                  <div className="side-menu__section-header">
+                    <Education size={16} />
+                    <span>{t("nav.classrooms")}</span>
+                  </div>
+                  <div className="side-menu__classroom-list">
+                    {classrooms.map((c) => {
+                      const isCurrent = c.id === classroomId;
+                      const Icon = getClassroomIcon(c.icon);
+                      return (
+                        <button
+                          key={c.id}
+                          type="button"
+                          className={`side-menu__classroom${isCurrent ? " side-menu__classroom--active" : ""}`}
+                          onClick={() => go(`/classrooms/${c.id}`)}
+                        >
+                          <Icon size={16} />
+                          <span className="side-menu__classroom-name">{c.name}</span>
+                          {isCurrent && <Checkmark size={16} className="side-menu__classroom-check" />}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </>
+            )}
           </>
         )}
 
-        {/* Question Bank List */}
-        {banks.length > 0 && (
-          <>
-            <div className="side-menu__divider" />
-            <div className="side-menu__section">
-              <div className="side-menu__section-header">
-                <Book size={16} />
-                <span>{t("nav.questionBanks")}</span>
-              </div>
-              <div className="side-menu__bank-list">
-                {banks.map((b) => {
-                  const isCurrent = b.id === bankId;
-                  return (
-                    <button
-                      key={b.id}
-                      type="button"
-                      className={`side-menu__bank${isCurrent ? " side-menu__bank--active" : ""}`}
-                      onClick={() => go(`/question-banks/${b.id}`)}
-                    >
-                      <span className="side-menu__bank-name">{b.name}</span>
-                      <span className="side-menu__bank-meta">
-                        {b.category === "coding" ? "Coding" : "Exam"} · {b.questionCount}
-                      </span>
-                      {isCurrent && (
-                        <Checkmark size={14} className="side-menu__bank-check" />
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
+        {/* Question banks tab */}
+        {activeTab === "banks" && banks.length > 0 && (
+          <div className="side-menu__section">
+            <div className="side-menu__section-header">
+              <Book size={16} />
+              <span>{t("nav.questionBanks")}</span>
             </div>
-          </>
+            <div className="side-menu__bank-list">
+              {banks.map((b) => {
+                const isCurrent = b.id === bankId;
+                return (
+                  <button
+                    key={b.id}
+                    type="button"
+                    className={`side-menu__bank${isCurrent ? " side-menu__bank--active" : ""}`}
+                    onClick={() => go(`/question-banks/${b.id}`)}
+                  >
+                    <span className="side-menu__bank-name">{b.name}</span>
+                    <span className="side-menu__bank-meta">
+                      {b.category === "coding" ? "Coding" : "Exam"} · {b.questionCount}
+                    </span>
+                    {isCurrent && <Checkmark size={14} className="side-menu__bank-check" />}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Chat tab */}
+        {activeTab === "chat" && (
+          <div className="side-menu__chat-tab">
+            <ChatHistoryPanel
+              sessions={sessions}
+              currentSessionId={currentSessionId}
+              onSelectSession={handleSelectSession}
+              onDeleteSession={handleDeleteSession}
+              onRenameSession={handleRenameSession}
+              showNewChatButton
+              onNewChat={handleNewChat}
+            />
+          </div>
         )}
       </nav>
     </>

--- a/frontend/src/features/app/components/SideMenu.tsx
+++ b/frontend/src/features/app/components/SideMenu.tsx
@@ -162,11 +162,15 @@ export const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose }) => {
     }
   }, [refreshSessions]);
 
-  const tabs: { key: TabKey; label: string; show: boolean }[] = [
-    { key: "classrooms", label: t("nav.classrooms"), show: true },
-    { key: "banks", label: t("nav.questionBanks"), show: isTeacherOrAdmin },
-    { key: "chat", label: t("nav.chat", "Chat"), show: isTeacherOrAdmin },
-  ].filter((tab) => tab.show);
+  const tabs = useMemo(
+    () =>
+      [
+        { key: "classrooms" as TabKey, label: t("nav.classrooms"), show: true },
+        { key: "banks" as TabKey, label: t("nav.questionBanks"), show: isTeacherOrAdmin },
+        { key: "chat" as TabKey, label: t("nav.chat"), show: isTeacherOrAdmin },
+      ].filter((tab) => tab.show),
+    [t, isTeacherOrAdmin],
+  );
 
   return (
     <>

--- a/frontend/src/features/chatbot/components/ChatFullPage.tsx
+++ b/frontend/src/features/chatbot/components/ChatFullPage.tsx
@@ -2,8 +2,20 @@
 import { ChatContainer } from "./chat-ui/ChatContainer";
 import styles from "./ChatFullPage.module.scss";
 
-export default function ChatFullPage() {
+interface ChatFullPageProps {
+  sessionId?: string | null;
+  onSessionChange?: (newId: string) => void;
+  onSessionDeleted?: (fallbackId: string | null) => void;
+}
+
+export default function ChatFullPage({ sessionId, onSessionChange, onSessionDeleted }: ChatFullPageProps) {
   return (
-    <ChatContainer mode="full" className={styles.fullPage} />
+    <ChatContainer
+      mode="full"
+      className={styles.fullPage}
+      externalSessionId={sessionId ?? undefined}
+      onSessionChange={onSessionChange}
+      onSessionDeleted={onSessionDeleted}
+    />
   );
 }

--- a/frontend/src/features/chatbot/components/ChatStandalonePage.tsx
+++ b/frontend/src/features/chatbot/components/ChatStandalonePage.tsx
@@ -1,24 +1,24 @@
-// frontend/src/features/chatbot/components/ChatStandalonePage.tsx
+import { useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { GlobalHeader } from "@/features/app/components/GlobalHeader";
 import ChatFullPage from "./ChatFullPage";
 import styles from "./ChatStandalonePage.module.scss";
 
 export default function ChatStandalonePage() {
-  const { sessionId } = useParams<{ sessionId?: string }>();
+  const { sessionId } = useParams<{ sessionId: string }>();
   const navigate = useNavigate();
 
-  const handleSessionChange = (newId: string) => {
+  const handleSessionChange = useCallback((newId: string) => {
     navigate(`/chat/${newId}`, { replace: false });
-  };
+  }, [navigate]);
 
-  const handleSessionDeleted = (fallbackId: string | null) => {
+  const handleSessionDeleted = useCallback((fallbackId: string | null) => {
     if (fallbackId) {
       navigate(`/chat/${fallbackId}`, { replace: true });
     } else {
       navigate("/chat", { replace: true });
     }
-  };
+  }, [navigate]);
 
   return (
     <div className={styles.pageRoot}>

--- a/frontend/src/features/chatbot/components/ChatStandalonePage.tsx
+++ b/frontend/src/features/chatbot/components/ChatStandalonePage.tsx
@@ -1,13 +1,34 @@
+// frontend/src/features/chatbot/components/ChatStandalonePage.tsx
+import { useNavigate, useParams } from "react-router-dom";
 import { GlobalHeader } from "@/features/app/components/GlobalHeader";
 import ChatFullPage from "./ChatFullPage";
 import styles from "./ChatStandalonePage.module.scss";
 
 export default function ChatStandalonePage() {
+  const { sessionId } = useParams<{ sessionId?: string }>();
+  const navigate = useNavigate();
+
+  const handleSessionChange = (newId: string) => {
+    navigate(`/chat/${newId}`, { replace: false });
+  };
+
+  const handleSessionDeleted = (fallbackId: string | null) => {
+    if (fallbackId) {
+      navigate(`/chat/${fallbackId}`, { replace: true });
+    } else {
+      navigate("/chat", { replace: true });
+    }
+  };
+
   return (
     <div className={styles.pageRoot}>
       <GlobalHeader />
       <main className={styles.main}>
-        <ChatFullPage />
+        <ChatFullPage
+          sessionId={sessionId ?? null}
+          onSessionChange={handleSessionChange}
+          onSessionDeleted={handleSessionDeleted}
+        />
       </main>
     </div>
   );

--- a/frontend/src/features/chatbot/components/chat-ui/ChatContainer.module.scss
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatContainer.module.scss
@@ -49,17 +49,6 @@
     var(--cds-background, #161616);
 }
 
-.historyColumn {
-  width: $chat-history-width;
-  flex-shrink: 0;
-  transition: width $chat-motion-duration $chat-motion-easing;
-  overflow: hidden;
-}
-
-.historyCollapsed {
-  width: 0;
-}
-
 .main {
   flex: 1;
   display: flex;

--- a/frontend/src/features/chatbot/components/chat-ui/ChatContainer.module.scss
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatContainer.module.scss
@@ -88,38 +88,3 @@
   width: 100%;
 }
 
-// History overlay (mobile + sidebar) — slide in from left
-.historyOverlay {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: $chat-history-width;
-  z-index: 100;
-  background: var(--cds-layer-01, #f4f4f4);
-  border-right: 1px solid var(--cds-border-subtle-01, #e0e0e0);
-  transform: translateX(-100%);
-  opacity: 0;
-  visibility: hidden;
-  transition:
-    transform $chat-motion-duration $chat-motion-easing,
-    opacity $chat-motion-duration $chat-motion-easing,
-    visibility 0s $chat-motion-duration;
-}
-
-.historyOverlayOpen {
-  transform: translateX(0);
-  opacity: 1;
-  visibility: visible;
-  transition:
-    transform $chat-motion-duration $chat-motion-easing,
-    opacity $chat-motion-duration $chat-motion-easing,
-    visibility 0s 0s;
-}
-
-// Mobile: overlay takes full width
-@media (max-width: $chat-mobile-breakpoint) {
-  .historyOverlay {
-    width: 100%;
-  }
-}

--- a/frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx
@@ -1,27 +1,12 @@
-import { useState, useCallback, useSyncExternalStore } from "react";
+import { useCallback } from "react";
 import { Loading } from "@carbon/react";
 import { useTranslation } from "react-i18next";
 import { useChatbot } from "../../hooks/useChatbot";
 import type { ChatContext } from "@/core/types/chatbot.types";
 import { MessageList } from "./MessageList";
 import { ComposerBar } from "./ComposerBar";
-import { ChatHistoryPanel } from "./ChatHistoryPanel";
 import { ChatTopBar } from "./ChatTopBar";
 import styles from "./ChatContainer.module.scss";
-
-// Reactive mobile detection — sync with $chat-mobile-breakpoint in _variables.scss
-const MOBILE_QUERY = "(max-width: 768px)";
-const subscribe = (cb: () => void) => {
-  const mql = window.matchMedia(MOBILE_QUERY);
-  mql.addEventListener("change", cb);
-  return () => mql.removeEventListener("change", cb);
-};
-const getSnapshot = () => window.matchMedia(MOBILE_QUERY).matches;
-const getServerSnapshot = () => false;
-
-function useIsMobile() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-}
 
 interface ChatContainerProps {
   mode: "full" | "sidebar";
@@ -67,20 +52,15 @@ export function ChatContainer({ mode, context, onProblemUpdated, onClose, classN
     onSessionDeleted: mode === "full" ? onSessionDeleted : undefined,
   });
 
-  const isMobile = useIsMobile();
-  const [historyOpen, setHistoryOpen] = useState(mode === "sidebar");
-
   const handleNewChat = useCallback(() => {
     createSession();
-    if (isMobile) setHistoryOpen(false);
-  }, [createSession, isMobile]);
+  }, [createSession]);
 
   const handleSelectSession = useCallback(
     (id: string) => {
       switchSession(id);
-      if (isMobile || mode === "sidebar") setHistoryOpen(false);
     },
-    [switchSession, isMobile, mode],
+    [switchSession],
   );
 
   const handleApproval = useCallback(
@@ -102,54 +82,23 @@ export function ChatContainer({ mode, context, onProblemUpdated, onClose, classN
     );
   }
 
-  // Mobile full-page or sidebar: history as overlay
-  const showHistoryOverlay = mode === "sidebar" && historyOpen;
-
   const sessionTitle = currentSession?.title || t("ui.newChat");
 
   return (
     <div className={`${styles.container} ${styles[mode]} ${className ?? ""}`}>
-      {/* Sidebar: history as overlay with slide animation */}
-      {mode === "sidebar" && (
-        <div className={`${styles.historyOverlay} ${showHistoryOverlay ? styles.historyOverlayOpen : ""}`}>
-          <ChatHistoryPanel
-            sessions={sessions}
-            currentSessionId={currentSessionId}
-            onSelectSession={handleSelectSession}
-            onDeleteSession={deleteSession}
-            onRenameSession={renameSession}
-            onClose={() => setHistoryOpen(false)}
-          />
-        </div>
-      )}
-
       {/* Main chat area */}
       <div className={styles.main}>
-        {/* Unified top bar for full mode (desktop + mobile) */}
-        {mode === "full" && (
-          <ChatTopBar
-            mode="full"
-            title={sessionTitle}
-            sessions={sessions}
-            currentSessionId={currentSessionId}
-            onSelectSession={handleSelectSession}
-            onNewChat={handleNewChat}
-            onRenameSession={renameSession}
-            onDeleteSession={deleteSession}
-          />
-        )}
-
-        {/* Sidebar header with history toggle + close */}
-        {mode === "sidebar" && (
-          <ChatTopBar
-            mode="sidebar"
-            title={t("ui.chatbotTitle")}
-            historyOpen={historyOpen}
-            onToggleHistory={() => setHistoryOpen((v) => !v)}
-            onNewChat={handleNewChat}
-            onClose={onClose}
-          />
-        )}
+        <ChatTopBar
+          mode="full"
+          title={sessionTitle}
+          sessions={sessions}
+          currentSessionId={currentSessionId}
+          onSelectSession={handleSelectSession}
+          onNewChat={handleNewChat}
+          onRenameSession={renameSession}
+          onDeleteSession={deleteSession}
+          onClose={onClose}
+        />
 
         <div className={styles.chatBody}>
           <div className={styles.messagesArea}>

--- a/frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx
@@ -29,9 +29,15 @@ interface ChatContainerProps {
   onProblemUpdated?: () => void;
   onClose?: () => void;
   className?: string;
+  /** full-page 模式：當前 URL session ID */
+  externalSessionId?: string;
+  /** full-page 模式：session 建立/切換後的導航回調 */
+  onSessionChange?: (newId: string) => void;
+  /** full-page 模式：session 刪除後的導航回調 */
+  onSessionDeleted?: (fallbackId: string | null) => void;
 }
 
-export function ChatContainer({ mode, context, onProblemUpdated, onClose, className }: ChatContainerProps) {
+export function ChatContainer({ mode, context, onProblemUpdated, onClose, className, externalSessionId, onSessionChange, onSessionDeleted }: ChatContainerProps) {
   const { t } = useTranslation("chatbot");
   const {
     sessions,
@@ -56,10 +62,13 @@ export function ChatContainer({ mode, context, onProblemUpdated, onClose, classN
     enabled: true,
     context,
     onProblemUpdated,
+    externalSessionId: mode === "full" ? externalSessionId : undefined,
+    onSessionChange: mode === "full" ? onSessionChange : undefined,
+    onSessionDeleted: mode === "full" ? onSessionDeleted : undefined,
   });
 
   const isMobile = useIsMobile();
-  const [historyOpen, setHistoryOpen] = useState(mode === "full" && !isMobile);
+  const [historyOpen, setHistoryOpen] = useState(mode === "sidebar");
 
   const handleNewChat = useCallback(() => {
     createSession();
@@ -93,7 +102,6 @@ export function ChatContainer({ mode, context, onProblemUpdated, onClose, classN
     );
   }
 
-  const showDesktopHistory = mode === "full" && !isMobile && historyOpen;
   // Mobile full-page or sidebar: history as overlay
   const showHistoryOverlay = (isMobile || mode === "sidebar") && historyOpen;
 
@@ -101,19 +109,6 @@ export function ChatContainer({ mode, context, onProblemUpdated, onClose, classN
 
   return (
     <div className={`${styles.container} ${styles[mode]} ${className ?? ""}`}>
-      {/* Desktop full-page: history as side column */}
-      {mode === "full" && !isMobile && (
-        <div className={`${styles.historyColumn} ${showDesktopHistory ? "" : styles.historyCollapsed}`}>
-          <ChatHistoryPanel
-            sessions={sessions}
-            currentSessionId={currentSessionId}
-            onSelectSession={handleSelectSession}
-            onDeleteSession={deleteSession}
-            onRenameSession={renameSession}
-          />
-        </div>
-      )}
-
       {/* Mobile / sidebar: history as overlay with slide animation */}
       <div className={`${styles.historyOverlay} ${showHistoryOverlay ? styles.historyOverlayOpen : ""}`}>
         <ChatHistoryPanel
@@ -131,16 +126,21 @@ export function ChatContainer({ mode, context, onProblemUpdated, onClose, classN
         {/* Unified top bar for full mode (desktop + mobile) */}
         {mode === "full" && (
           <ChatTopBar
+            mode="full"
             title={sessionTitle}
-            historyOpen={historyOpen}
-            onToggleHistory={() => setHistoryOpen((v) => !v)}
+            sessions={sessions}
+            currentSessionId={currentSessionId}
+            onSelectSession={handleSelectSession}
             onNewChat={handleNewChat}
+            onRenameSession={renameSession}
+            onDeleteSession={deleteSession}
           />
         )}
 
         {/* Sidebar header with history toggle + close */}
         {mode === "sidebar" && (
           <ChatTopBar
+            mode="sidebar"
             title={t("ui.chatbotTitle")}
             historyOpen={historyOpen}
             onToggleHistory={() => setHistoryOpen((v) => !v)}

--- a/frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatContainer.tsx
@@ -103,23 +103,25 @@ export function ChatContainer({ mode, context, onProblemUpdated, onClose, classN
   }
 
   // Mobile full-page or sidebar: history as overlay
-  const showHistoryOverlay = (isMobile || mode === "sidebar") && historyOpen;
+  const showHistoryOverlay = mode === "sidebar" && historyOpen;
 
   const sessionTitle = currentSession?.title || t("ui.newChat");
 
   return (
     <div className={`${styles.container} ${styles[mode]} ${className ?? ""}`}>
-      {/* Mobile / sidebar: history as overlay with slide animation */}
-      <div className={`${styles.historyOverlay} ${showHistoryOverlay ? styles.historyOverlayOpen : ""}`}>
-        <ChatHistoryPanel
-          sessions={sessions}
-          currentSessionId={currentSessionId}
-          onSelectSession={handleSelectSession}
-          onDeleteSession={deleteSession}
-          onRenameSession={renameSession}
-          onClose={() => setHistoryOpen(false)}
-        />
-      </div>
+      {/* Sidebar: history as overlay with slide animation */}
+      {mode === "sidebar" && (
+        <div className={`${styles.historyOverlay} ${showHistoryOverlay ? styles.historyOverlayOpen : ""}`}>
+          <ChatHistoryPanel
+            sessions={sessions}
+            currentSessionId={currentSessionId}
+            onSelectSession={handleSelectSession}
+            onDeleteSession={deleteSession}
+            onRenameSession={renameSession}
+            onClose={() => setHistoryOpen(false)}
+          />
+        </div>
+      )}
 
       {/* Main chat area */}
       <div className={styles.main}>

--- a/frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.module.scss
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.module.scss
@@ -3,30 +3,12 @@
   flex-direction: column;
   height: 100%;
   background: var(--cds-layer-01, #f4f4f4);
-  border-right: 1px solid var(--cds-border-subtle-01, #e0e0e0);
-}
-
-.header {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.5rem;
-  border-bottom: 1px solid var(--cds-border-subtle-01, #e0e0e0);
-}
-
-.search {
-  flex: 1;
-  min-width: 0;
-}
-
-.closeBtn {
-  flex-shrink: 0;
 }
 
 .list {
   flex: 1;
   overflow-y: auto;
-  padding: 0.5rem 0;
+  padding: 0.25rem 0;
 }
 
 .empty {
@@ -36,7 +18,7 @@
 }
 
 .group {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .groupLabel {
@@ -51,13 +33,23 @@
 .item {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.5rem 0.5rem 0.5rem 1rem;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem 0.375rem 0.75rem;
   cursor: pointer;
-  transition: background 150ms ease;
+  transition: background 100ms ease;
+  border-radius: 4px;
+  margin: 0 0.25rem;
 
   &:hover {
     background: var(--cds-layer-hover-01, #e8e8e8);
+
+    .overflow {
+      opacity: 1;
+    }
+
+    .itemTime {
+      display: none;
+    }
   }
 }
 
@@ -69,6 +61,11 @@
   }
 }
 
+.itemIcon {
+  flex-shrink: 0;
+  color: var(--cds-icon-secondary, #525252);
+}
+
 .itemName {
   flex: 1;
   font-size: 0.8125rem;
@@ -76,16 +73,20 @@
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  color: var(--cds-text-primary, #161616);
+}
+
+.itemTime {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--cds-text-secondary, #525252);
+  white-space: nowrap;
 }
 
 .overflow {
   flex-shrink: 0;
   opacity: 0;
   transition: opacity 150ms ease;
-
-  .item:hover & {
-    opacity: 1;
-  }
 }
 
 .renameInput {
@@ -96,4 +97,31 @@
   padding: 0.125rem 0.25rem;
   background: var(--cds-field-01, #fff);
   outline: none;
+}
+
+.footer {
+  padding: 0.5rem;
+  border-top: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  flex-shrink: 0;
+}
+
+.newChatBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem;
+  background: transparent;
+  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--cds-text-secondary, #525252);
+  font-size: 0.875rem;
+  transition: background 100ms ease, color 100ms ease;
+
+  &:hover {
+    background: var(--cds-layer-hover-01, #e8e8e8);
+    color: var(--cds-text-primary, #161616);
+  }
 }

--- a/frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx
@@ -10,12 +10,12 @@ interface ChatHistoryPanelProps {
   sessions: ChatSession[];
   currentSessionId: string | null;
   onSelectSession: (id: string) => void;
-  onDeleteSession: (id: string) => void;
-  onRenameSession: (id: string, name: string) => void;
+  onDeleteSession: (id: string) => void | Promise<void>;
+  onRenameSession: (id: string, name: string) => void | Promise<void>;
   onClose?: () => void;
   /** Show "新增對話" button at bottom */
   showNewChatButton?: boolean;
-  onNewChat?: () => void;
+  onNewChat?: () => void | Promise<void>;
 }
 
 interface HistoryGroup {

--- a/frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatHistoryPanel.tsx
@@ -1,8 +1,9 @@
 import { useState, useMemo, useCallback } from "react";
-import { Search, IconButton, OverflowMenu, OverflowMenuItem } from "@carbon/react";
-import { Close } from "@carbon/icons-react";
+import { OverflowMenu, OverflowMenuItem } from "@carbon/react";
+import { Chat as ChatIcon, Add } from "@carbon/icons-react";
 import { useTranslation } from "react-i18next";
 import type { ChatSession } from "@/core/types/chatbot.types";
+import { formatRelativeTime } from "@/shared/utils/relativeTime";
 import styles from "./ChatHistoryPanel.module.scss";
 
 interface ChatHistoryPanelProps {
@@ -12,6 +13,9 @@ interface ChatHistoryPanelProps {
   onDeleteSession: (id: string) => void;
   onRenameSession: (id: string, name: string) => void;
   onClose?: () => void;
+  /** Show "新增對話" button at bottom */
+  showNewChatButton?: boolean;
+  onNewChat?: () => void;
 }
 
 interface HistoryGroup {
@@ -26,10 +30,7 @@ function groupSessions(sessions: ChatSession[]): HistoryGroup[] {
   const weekStart = todayStart - 7 * 86_400_000;
 
   const groups: Record<string, ChatSession[]> = {
-    today: [],
-    yesterday: [],
-    lastWeek: [],
-    older: [],
+    today: [], yesterday: [], lastWeek: [], older: [],
   };
 
   for (const s of sessions) {
@@ -51,20 +52,15 @@ export function ChatHistoryPanel({
   onSelectSession,
   onDeleteSession,
   onRenameSession,
-  onClose,
+  onClose: _onClose,
+  showNewChatButton = false,
+  onNewChat,
 }: ChatHistoryPanelProps) {
   const { t } = useTranslation("chatbot");
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
-  const [searchQuery, setSearchQuery] = useState("");
 
-  const filteredSessions = useMemo(() => {
-    if (!searchQuery.trim()) return sessions;
-    const q = searchQuery.trim().toLowerCase();
-    return sessions.filter((s) => (s.title ?? "").toLowerCase().includes(q));
-  }, [sessions, searchQuery]);
-
-  const groups = useMemo(() => groupSessions(filteredSessions), [filteredSessions]);
+  const groups = useMemo(() => groupSessions(sessions), [sessions]);
 
   const groupLabels = useMemo(() => ({
     today: t("ui.groupToday"),
@@ -88,23 +84,6 @@ export function ChatHistoryPanel({
 
   return (
     <div className={styles.panel}>
-      <div className={styles.header}>
-        <Search
-          size="sm"
-          placeholder={t("ui.searchPlaceholder")}
-          labelText={t("ui.searchLabel")}
-          value={searchQuery}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
-          closeButtonLabelText={t("ui.clear")}
-          className={styles.search}
-        />
-        {onClose && (
-          <IconButton kind="ghost" size="sm" label={t("ui.close")} onClick={onClose} className={styles.closeBtn}>
-            <Close size={20} />
-          </IconButton>
-        )}
-      </div>
-
       <div className={styles.list}>
         {groups.length === 0 && (
           <div className={styles.empty}>{t("ui.noHistory")}</div>
@@ -116,9 +95,7 @@ export function ChatHistoryPanel({
             {group.sessions.map((session) => (
               <div
                 key={session.id}
-                className={`${styles.item} ${
-                  session.id === currentSessionId ? styles.active : ""
-                }`}
+                className={`${styles.item} ${session.id === currentSessionId ? styles.active : ""}`}
                 onClick={() => onSelectSession(session.id)}
                 role="button"
                 tabIndex={0}
@@ -129,6 +106,8 @@ export function ChatHistoryPanel({
                   }
                 }}
               >
+                <ChatIcon size={16} className={styles.itemIcon} />
+
                 {renamingId === session.id ? (
                   <input
                     className={styles.renameInput}
@@ -146,9 +125,14 @@ export function ChatHistoryPanel({
                     onClick={(e) => e.stopPropagation()}
                   />
                 ) : (
-                  <span className={styles.itemName}>
-                    {session.title || t("ui.defaultSessionTitle", { id: session.id.slice(0, 8) })}
-                  </span>
+                  <>
+                    <span className={styles.itemName}>
+                      {session.title || t("ui.defaultSessionTitle", { id: session.id.slice(0, 8) })}
+                    </span>
+                    <span className={styles.itemTime}>
+                      {formatRelativeTime(session.updatedAt)}
+                    </span>
+                  </>
                 )}
 
                 <OverflowMenu
@@ -173,6 +157,15 @@ export function ChatHistoryPanel({
           </div>
         ))}
       </div>
+
+      {showNewChatButton && onNewChat && (
+        <div className={styles.footer}>
+          <button type="button" className={styles.newChatBtn} onClick={onNewChat}>
+            <Add size={16} />
+            <span>{t("ui.newChat")}</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.module.scss
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.module.scss
@@ -14,15 +14,146 @@
   position: relative;
 }
 
-.left,
-.right {
+// Sidebar mode layout helpers
+.left {
   display: flex;
+  align-items: center;
   gap: 0.125rem;
   min-width: 3rem;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  flex-shrink: 0;
 }
 
 .title {
   font-size: var(--cds-body-compact-01-font-size, 0.875rem);
   font-weight: 400;
+  color: var(--cds-text-secondary, #525252);
+}
+
+// Full-page mode: title area (left side)
+.titleArea {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex: 1;
+  position: relative;
+}
+
+.titleBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: 500;
+  max-width: 28rem;
+  min-width: 0;
+  transition: background 150ms ease;
+
+  &:hover {
+    background: var(--cds-layer-hover, #e8e8e8);
+  }
+}
+
+.titleText {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.titleChevron {
+  flex-shrink: 0;
+  color: var(--cds-icon-secondary, #525252);
+  transition: transform 150ms ease;
+
+  &.open {
+    transform: rotate(180deg);
+  }
+}
+
+.renameInput {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: 500;
+  border: 1px solid var(--cds-focus, #0f62fe);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  background: var(--cds-field-01, #fff);
+  color: var(--cds-text-primary, #161616);
+  outline: none;
+  width: 20rem;
+  max-width: 100%;
+}
+
+// Session dropdown
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 16rem;
+  max-width: 24rem;
+  max-height: 20rem;
+  overflow-y: auto;
+  background: var(--cds-layer-01, #f4f4f4);
+  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  border-radius: 4px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  z-index: 200;
+  padding: 0.25rem 0;
+}
+
+.dropdownItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--cds-text-primary, #161616);
+  transition: background 100ms ease;
+
+  &:hover {
+    background: var(--cds-layer-hover-01, #e8e8e8);
+  }
+}
+
+.dropdownItemActive {
+  background: var(--cds-layer-selected-01, #e0e0e0);
+
+  &:hover {
+    background: var(--cds-layer-selected-hover-01, #d1d1d1);
+  }
+}
+
+.dropdownItemIcon {
+  flex-shrink: 0;
+  color: var(--cds-icon-secondary, #525252);
+}
+
+.dropdownItemTitle {
+  flex: 1;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.dropdownItemTime {
+  flex-shrink: 0;
+  font-size: 0.75rem;
   color: var(--cds-text-secondary, #525252);
 }

--- a/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.module.scss
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.module.scss
@@ -5,9 +5,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.25rem 0.5rem;
-  max-width: $chat-content-max-width;
   width: 100%;
-  margin: 0 auto;
   background: transparent;
   flex-shrink: 0;
   z-index: 5;

--- a/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx
@@ -1,9 +1,38 @@
-import { IconButton } from "@carbon/react";
-import { RecentlyViewed, Add, Close } from "@carbon/icons-react";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { IconButton, OverflowMenu, OverflowMenuItem } from "@carbon/react";
+import { Add, Close, ChevronDown, Chat as ChatIcon, RecentlyViewed } from "@carbon/icons-react";
 import { useTranslation } from "react-i18next";
+import type { ChatSession } from "@/core/types/chatbot.types";
 import styles from "./ChatTopBar.module.scss";
 
-interface ChatTopBarProps {
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) {
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    return diffHours === 0 ? "Just now" : `${diffHours}h`;
+  }
+  if (diffDays === 1) return "1d";
+  if (diffDays < 7) return `${diffDays}d`;
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 5) return `${diffWeeks}w`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+interface ChatTopBarFullProps {
+  mode: "full";
+  title?: string;
+  sessions: ChatSession[];
+  currentSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onNewChat: () => void;
+  onRenameSession: (id: string, title: string) => void;
+  onDeleteSession: (id: string) => void;
+}
+
+interface ChatTopBarSidebarProps {
+  mode?: "sidebar";
   title?: string;
   historyOpen?: boolean;
   onToggleHistory?: () => void;
@@ -11,34 +40,169 @@ interface ChatTopBarProps {
   onClose?: () => void;
 }
 
-export function ChatTopBar({
-  title,
-  historyOpen = false,
-  onToggleHistory,
-  onNewChat,
-  onClose,
-}: ChatTopBarProps) {
+type ChatTopBarProps = ChatTopBarFullProps | ChatTopBarSidebarProps;
+
+export function ChatTopBar(props: ChatTopBarProps) {
   const { t } = useTranslation("chatbot");
-  const displayTitle = title || t("ui.chatbotTitle");
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const closeDropdown = useCallback(() => setDropdownOpen(false), []);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (!dropdownRef.current?.contains(e.target as Node)) {
+        closeDropdown();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [dropdownOpen, closeDropdown]);
+
+  // ── Sidebar mode ──
+  if (!props.mode || props.mode === "sidebar") {
+    const { title, historyOpen = false, onToggleHistory, onNewChat, onClose } = props as ChatTopBarSidebarProps;
+    const displayTitle = title || t("ui.chatbotTitle");
+    return (
+      <div className={styles.bar}>
+        <div className={styles.left}>
+          {onToggleHistory && (
+            <IconButton
+              kind="ghost"
+              label={historyOpen ? t("ui.collapse") : t("ui.history")}
+              onClick={onToggleHistory}
+            >
+              {historyOpen ? <Close size={20} /> : <RecentlyViewed size={20} />}
+            </IconButton>
+          )}
+        </div>
+        <span className={styles.title}>{displayTitle}</span>
+        <div className={styles.right}>
+          <IconButton kind="ghost" label={t("ui.newChat")} onClick={onNewChat}>
+            <Add size={20} />
+          </IconButton>
+          {onClose && (
+            <IconButton kind="ghost" label={t("ui.close")} onClick={onClose}>
+              <Close size={20} />
+            </IconButton>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Full-page mode ──
+  const {
+    title,
+    sessions,
+    currentSessionId,
+    onSelectSession,
+    onNewChat,
+    onRenameSession,
+    onDeleteSession,
+  } = props as ChatTopBarFullProps;
+  const displayTitle = title || t("ui.newChat");
+
+  const startRename = (session: ChatSession) => {
+    setRenamingId(session.id);
+    setRenameValue(session.title || "");
+    setDropdownOpen(false);
+  };
+
+  const commitRename = () => {
+    if (renamingId && renameValue.trim()) {
+      onRenameSession(renamingId, renameValue.trim());
+    }
+    setRenamingId(null);
+    setRenameValue("");
+  };
 
   return (
     <div className={styles.bar}>
-      <div className={styles.left}>
-        {onToggleHistory && (
-          <IconButton kind="ghost" label={historyOpen ? t("ui.collapse") : t("ui.history")} onClick={onToggleHistory}>
-            {historyOpen ? <Close size={20} /> : <RecentlyViewed size={20} />}
-          </IconButton>
+      {/* Left: title dropdown */}
+      <div className={styles.titleArea} ref={dropdownRef}>
+        {renamingId === currentSessionId ? (
+          <input
+            className={styles.renameInput}
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitRename();
+              if (e.key === "Escape") {
+                setRenamingId(null);
+                setRenameValue("");
+              }
+            }}
+            autoFocus
+          />
+        ) : (
+          <button
+            type="button"
+            className={styles.titleBtn}
+            onClick={() => setDropdownOpen((v) => !v)}
+            aria-haspopup="listbox"
+            aria-expanded={dropdownOpen}
+          >
+            <span className={styles.titleText}>{displayTitle}</span>
+            <ChevronDown
+              size={16}
+              className={`${styles.titleChevron} ${dropdownOpen ? styles.open : ""}`}
+            />
+          </button>
+        )}
+
+        {dropdownOpen && (
+          <div className={styles.dropdown} role="listbox">
+            {sessions.slice(0, 15).map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                role="option"
+                aria-selected={s.id === currentSessionId}
+                className={`${styles.dropdownItem} ${s.id === currentSessionId ? styles.dropdownItemActive : ""}`}
+                onClick={() => {
+                  onSelectSession(s.id);
+                  setDropdownOpen(false);
+                }}
+              >
+                <ChatIcon size={14} className={styles.dropdownItemIcon} />
+                <span className={styles.dropdownItemTitle}>
+                  {s.title || t("ui.newChat")}
+                </span>
+                <span className={styles.dropdownItemTime}>
+                  {formatRelativeTime(s.updatedAt)}
+                </span>
+              </button>
+            ))}
+          </div>
         )}
       </div>
-      <span className={styles.title}>{displayTitle}</span>
+
+      {/* Right: actions */}
       <div className={styles.right}>
         <IconButton kind="ghost" label={t("ui.newChat")} onClick={onNewChat}>
           <Add size={20} />
         </IconButton>
-        {onClose && (
-          <IconButton kind="ghost" label={t("ui.close")} onClick={onClose}>
-            <Close size={20} />
-          </IconButton>
+        {currentSessionId && (
+          <OverflowMenu size="sm" flipped>
+            <OverflowMenuItem
+              itemText={t("ui.rename")}
+              onClick={() => {
+                const session = sessions.find((s) => s.id === currentSessionId);
+                if (session) startRename(session);
+              }}
+            />
+            <OverflowMenuItem
+              itemText={t("ui.delete")}
+              isDelete
+              hasDivider
+              onClick={() => onDeleteSession(currentSessionId)}
+            />
+          </OverflowMenu>
         )}
       </div>
     </div>

--- a/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx
@@ -3,22 +3,8 @@ import { IconButton, OverflowMenu, OverflowMenuItem } from "@carbon/react";
 import { Add, Close, ChevronDown, Chat as ChatIcon, RecentlyViewed } from "@carbon/icons-react";
 import { useTranslation } from "react-i18next";
 import type { ChatSession } from "@/core/types/chatbot.types";
+import { formatRelativeTime } from "@/shared/utils/relativeTime";
 import styles from "./ChatTopBar.module.scss";
-
-function formatRelativeTime(date: Date): string {
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) {
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    return diffHours === 0 ? "Just now" : `${diffHours}h`;
-  }
-  if (diffDays === 1) return "1d";
-  if (diffDays < 7) return `${diffDays}d`;
-  const diffWeeks = Math.floor(diffDays / 7);
-  if (diffWeeks < 5) return `${diffWeeks}w`;
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-}
 
 interface ChatTopBarFullProps {
   mode: "full";

--- a/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ChatTopBar.tsx
@@ -15,6 +15,7 @@ interface ChatTopBarFullProps {
   onNewChat: () => void;
   onRenameSession: (id: string, title: string) => void;
   onDeleteSession: (id: string) => void;
+  onClose?: () => void;
 }
 
 interface ChatTopBarSidebarProps {
@@ -89,6 +90,7 @@ export function ChatTopBar(props: ChatTopBarProps) {
     onNewChat,
     onRenameSession,
     onDeleteSession,
+    onClose,
   } = props as ChatTopBarFullProps;
   const displayTitle = title || t("ui.newChat");
 
@@ -189,6 +191,11 @@ export function ChatTopBar(props: ChatTopBarProps) {
               onClick={() => onDeleteSession(currentSessionId)}
             />
           </OverflowMenu>
+        )}
+        {onClose && (
+          <IconButton kind="ghost" label={t("ui.close")} onClick={onClose}>
+            <Close size={20} />
+          </IconButton>
         )}
       </div>
     </div>

--- a/frontend/src/features/chatbot/components/chat-ui/ComposerBar.module.scss
+++ b/frontend/src/features/chatbot/components/chat-ui/ComposerBar.module.scss
@@ -1,3 +1,4 @@
+@use "@carbon/layout";
 @use "./variables" as *;
 
 .bar {
@@ -53,13 +54,88 @@
 .inputWrapper {
   pointer-events: auto;
   display: flex;
-  flex-direction: column;
   gap: 0.5rem;
   border-radius: 16px;
   border: 1px solid var(--cds-border-subtle-01, #525252);
   background: var(--cds-layer-02, #262626);
   box-shadow: none;
   padding: 0.6rem 0.75rem 0.6rem;
+  transition: padding 160ms ease;
+}
+
+// Compact mode: single visible row; everything inline.
+.inputWrapperCompact {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.45rem 0.35rem 0.95rem;
+
+  .input {
+    flex: 1 1 auto;
+    min-height: 1.75rem;
+    padding: 0;
+  }
+
+  .toolbar {
+    flex: 0 0 auto;
+    width: auto;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.4rem;
+  }
+
+  .rightTools {
+    width: auto;
+    flex-wrap: nowrap;
+    gap: 0.4rem;
+  }
+
+  // Slimmer model chip so single row stays balanced
+  .modelSelectWrap {
+    min-width: 0;
+    padding-left: 0.45rem;
+  }
+
+  .modelSelectButton {
+    min-height: 1.75rem;
+    padding-right: 1.1rem;
+    max-width: 8.5rem;
+  }
+
+  .modelText {
+    max-width: 7rem;
+  }
+}
+
+// Expanded mode (auto-grows when text wraps multiple lines):
+// toolbar moves below the textarea with model selector pinned to the left
+// and send button on the right.
+.inputWrapperExpanded {
+  flex-direction: column;
+  align-items: stretch;
+
+  .toolbar {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .rightTools {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .modelSelectWrap {
+    margin-right: auto;
+  }
+
+  // Model is now anchored to the left edge of the bar — open the dropdown
+  // toward the right so it never gets clipped by the viewport on narrow screens.
+  .modelMenu {
+    left: 0;
+    right: auto;
+    max-width: calc(100vw - 2rem);
+  }
 }
 
 .input {
@@ -261,37 +337,68 @@
 
 @media (max-width: $chat-mobile-breakpoint) {
   .bar {
-    padding: 0.6rem 0.75rem 0.9rem;
-  }
-
-  .inputWrapper {
-    border-radius: 14px;
-    padding: 0.5rem 0.6rem;
-    gap: 0.5rem;
+    padding-top: 0.6rem;
+    padding-left: layout.$spacing-05;
+    padding-right: layout.$spacing-05;
+    padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
   }
 
   .input {
     min-height: 1.75rem;
   }
 
-  .toolbar {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.55rem;
-  }
-
-  .rightTools {
-    width: 100%;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-  }
-
-  .modelSelectWrap {
-    min-width: 10rem;
-  }
-
   .sendButton {
     width: 2rem;
     height: 2rem;
+  }
+
+  // Compact mode on mobile: keep one row but shrink the model chip further
+  .inputWrapperCompact {
+    padding: 0.3rem 0.4rem 0.3rem 0.85rem;
+    gap: 0.4rem;
+
+    .modelSelectWrap {
+      min-width: 0;
+    }
+
+    .modelSelectButton {
+      max-width: 6.5rem;
+      padding-right: 0.9rem;
+    }
+
+    .modelText {
+      max-width: 5rem;
+    }
+  }
+
+  // Expanded mode on mobile: model selector on left, send button on right
+  .inputWrapperExpanded {
+    padding: 0.5rem 0.6rem;
+    gap: 0.5rem;
+
+    .toolbar {
+      flex-direction: row;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .rightTools {
+      width: 100%;
+      justify-content: space-between;
+      flex-wrap: nowrap;
+    }
+
+    .modelSelectWrap {
+      min-width: 0;
+      flex: 0 1 auto;
+    }
+
+    .modelSelectButton {
+      max-width: 9rem;
+    }
+
+    .modelText {
+      max-width: 7.5rem;
+    }
   }
 }

--- a/frontend/src/features/chatbot/components/chat-ui/ComposerBar.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/ComposerBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useMemo, useEffect } from "react";
+import { useRef, useState, useCallback, useMemo, useEffect, useLayoutEffect } from "react";
 import { ArrowUp, Checkmark, ChevronDown, InProgress } from "@carbon/icons-react";
 import { useTranslation } from "react-i18next";
 import type { ModelInfo } from "@/core/types/chatbot.types";
@@ -34,6 +34,7 @@ export function ComposerBar({
   
   const [value, setValue] = useState("");
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const composingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const modelMenuRef = useRef<HTMLDivElement>(null);
@@ -64,10 +65,6 @@ export function ComposerBar({
     if (!trimmed || disabled || isStreaming) return;
     onSend(trimmed);
     setValue("");
-    // Reset textarea height
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "auto";
-    }
   }, [value, disabled, isStreaming, onSend]);
 
   const handleKeyDown = useCallback(
@@ -85,11 +82,53 @@ export function ComposerBar({
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
-    // Auto-resize
-    const ta = e.target;
+  }, []);
+
+  // Adjusts textarea height only — never touches isExpanded.
+  // Used by both initial render and ResizeObserver so layout shifts
+  // (e.g. window/sidebar resize) won't toggle mode and cause flicker.
+  const adjustTextareaHeight = useCallback(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
     ta.style.height = "auto";
     ta.style.height = `${Math.min(ta.scrollHeight, TEXTAREA_MAX_HEIGHT)}px`;
   }, []);
+
+  // Single-line height when empty / one line; grows when content wraps.
+  // Mode evaluation is one-way: enter expanded once content wraps, and only
+  // return to compact when the input is fully cleared. This prevents the
+  // compact↔expanded flicker caused by textarea width changing across modes.
+  useLayoutEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    const next = Math.min(ta.scrollHeight, TEXTAREA_MAX_HEIGHT);
+    ta.style.height = `${next}px`;
+
+    if (value.length === 0) {
+      if (isExpanded) setIsExpanded(false);
+      return;
+    }
+    if (isExpanded) return;
+
+    const cs = window.getComputedStyle(ta);
+    const lineHeight = parseFloat(cs.lineHeight) || 22;
+    const paddingY =
+      (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0);
+    if (next - paddingY > lineHeight * 1.5) {
+      setIsExpanded(true);
+    }
+  }, [value, isExpanded]);
+
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      adjustTextareaHeight();
+    });
+    ro.observe(ta);
+    return () => ro.disconnect();
+  }, [adjustTextareaHeight]);
 
   const canSend = value.trim().length > 0 && !disabled && !isStreaming;
   const hasStatusBlock = Boolean(sessionNotice);
@@ -108,7 +147,11 @@ export function ComposerBar({
         </div>
       )}
 
-      <div className={styles.inputWrapper}>
+      <div
+        className={`${styles.inputWrapper} ${
+          isExpanded ? styles.inputWrapperExpanded : styles.inputWrapperCompact
+        }`}
+      >
         <textarea
           ref={textareaRef}
           className={styles.input}

--- a/frontend/src/features/chatbot/components/chat-ui/MessageList.module.scss
+++ b/frontend/src/features/chatbot/components/chat-ui/MessageList.module.scss
@@ -44,7 +44,7 @@
 
 .scrollButton {
   position: absolute;
-  bottom: 7rem; // Keep distance from the composer input.
+  bottom: 8.5rem; // Keep distance from the composer input (desktop).
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;
@@ -71,6 +71,13 @@
   // Carbon icons integration
   svg {
     fill: var(--cds-icon-secondary, #525252);
+  }
+}
+
+// Taller composer on narrow viewports + safe-area — lift button so it does not touch the bar
+@media (max-width: $chat-mobile-breakpoint) {
+  .scrollButton {
+    bottom: calc(12rem + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/frontend/src/features/chatbot/components/chat-ui/MessageList.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/MessageList.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useRef, useEffect, useState, useCallback, useLayoutEffect } from "react";
+import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown } from "@carbon/icons-react";
 import { Button, SkeletonText } from "@carbon/react";
 import type { ChatMessage } from "@/core/types/chatbot.types";
 import type { ApprovalRequest } from "@/core/types/chatbot.types";
+import { useChatScrollToBottom } from "../../hooks/useChatScrollToBottom";
 import { MessageBubble } from "./MessageBubble";
 import { HITLCard } from "./HITLCard";
 import styles from "./MessageList.module.scss";
@@ -24,9 +25,7 @@ export function MessageList({
   onApprovalDecision,
 }: MessageListProps) {
   const { t } = useTranslation("chatbot");
-  const endRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [showScrollButton, setShowScrollButton] = useState(false);
 
   const displayMessages = useMemo(() => {
     if (messages.length === 0) {
@@ -42,66 +41,13 @@ export function MessageList({
     return messages;
   }, [messages, t]);
 
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    container.scrollTo({
-      top: container.scrollHeight,
-      behavior,
-    });
-  }, []);
-
-  const scheduleScrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    requestAnimationFrame(() => {
-      scrollToBottom(behavior);
-      requestAnimationFrame(() => scrollToBottom(behavior));
-    });
-  }, [scrollToBottom]);
-
-  // Handle scroll event to show/hide "Scroll to Bottom" button
-  const handleScroll = useCallback(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    // Show button if user scrolls up more than 300px from the bottom
-    const isFarFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight > 300;
-    setShowScrollButton(isFarFromBottom);
-  }, []);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (container) {
-      container.addEventListener("scroll", handleScroll);
-      return () => container.removeEventListener("scroll", handleScroll);
-    }
-  }, [handleScroll]);
-
-  // Auto-scroll to bottom when session changes
-  useLayoutEffect(() => {
-    scheduleScrollToBottom("auto");
-  }, [currentSessionId, isLoading, scheduleScrollToBottom]);
-
-  // When tool-confirmation (HITL) card becomes visible, always scroll to bottom so the user sees it
-  // immediately, even if they had scrolled up to read earlier messages. (Card is hidden while isLoading.)
-  useLayoutEffect(() => {
-    if (!pendingApproval || isLoading) return;
-    scheduleScrollToBottom("auto");
-  }, [pendingApproval, isLoading, scheduleScrollToBottom]);
-
-  // Auto-scroll to bottom when new messages arrive or content changes (if already near bottom)
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const isNearBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight < 150;
-
-    if (isNearBottom) {
-      scheduleScrollToBottom("smooth");
-    }
-  }, [messages, pendingApproval, scheduleScrollToBottom]);
+  const { scrollToBottom, showScrollButton } = useChatScrollToBottom({
+    containerRef,
+    messages,
+    currentSessionId,
+    isLoading,
+    pendingApproval,
+  });
 
   return (
     <div className={styles.wrapper}>
@@ -117,8 +63,6 @@ export function MessageList({
         {!isLoading && pendingApproval && (
           <HITLCard request={pendingApproval} onDecision={onApprovalDecision} />
         )}
-
-        <div ref={endRef} />
       </div>
 
       {showScrollButton && (

--- a/frontend/src/features/chatbot/components/chat-ui/__stories__/ChatHistoryPanel.stories.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/__stories__/ChatHistoryPanel.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof ChatHistoryPanel> = {
   parameters: {
     docs: {
       description: {
-        component: "歷史對話側邊欄 — 依時間分組（今天/昨天/過去 7 天/更早），支援搜尋、重命名、刪除。可選 close 按鈕。",
+        component: "歷史對話側邊欄 — 依時間分組（今天/昨天/過去 7 天/更早），Notion 風格。支援重命名、刪除、可選底部新增對話按鈕。",
       },
     },
   },
@@ -53,5 +53,13 @@ export const WithCloseButton: Story = {
     sessions: mockSessions,
     currentSessionId: "session-1",
     onClose: () => {},
+  },
+};
+
+export const WithNewChatButton: Story = {
+  args: {
+    ...WithSessions.args,
+    showNewChatButton: true,
+    onNewChat: () => console.log("new chat"),
   },
 };

--- a/frontend/src/features/chatbot/components/chat-ui/__stories__/ChatTopBar.stories.tsx
+++ b/frontend/src/features/chatbot/components/chat-ui/__stories__/ChatTopBar.stories.tsx
@@ -1,24 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
 import { ChatTopBar } from "../ChatTopBar";
+import { mockSessions } from "./chat-ui.mocks";
 
-const meta: Meta<typeof ChatTopBar> = {
+const meta: Meta = {
   title: "features/chatbot/chat-ui/ChatTopBar",
   component: ChatTopBar,
   parameters: {
     docs: {
       description: {
-        component: "統一頂部列 — 左：history toggle / 中：session 標題 / 右：新對話 + (可選) 關閉。桌面、手機、sidebar 共用。",
+        component:
+          "統一頂部列 — 支援 full-page（title dropdown + actions）與 sidebar（history toggle + close）兩種模式。",
       },
     },
-  },
-  args: {
-    onToggleHistory: () => {},
-    onNewChat: () => {},
-  },
-  argTypes: {
-    title: { control: "text" },
-    historyOpen: { control: "boolean" },
   },
   decorators: [
     (Story) => (
@@ -32,28 +25,43 @@ const meta: Meta<typeof ChatTopBar> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const HistoryClosed: Story = {
-  name: "History 關閉",
-  args: { title: "新對話", historyOpen: false },
-};
-
-export const HistoryOpen: Story = {
-  name: "History 開啟",
-  args: { title: "列出我的教室", historyOpen: true },
-};
-
-export const SidebarMode: Story = {
-  name: "Sidebar 模式（含關閉按鈕）",
+export const FullPage: Story = {
+  name: "Full-page mode",
   args: {
+    mode: "full" as const,
+    title: "如何描述 AI 側邊欄效果",
+    sessions: mockSessions,
+    currentSessionId: mockSessions[0].id,
+    onSelectSession: () => {},
+    onNewChat: () => {},
+    onRenameSession: () => {},
+    onDeleteSession: () => {},
+  },
+};
+
+export const FullPageWithClose: Story = {
+  name: "Full-page + close button (sidebar embed)",
+  args: {
+    mode: "full" as const,
     title: "QJudge AI 助教",
+    sessions: mockSessions,
+    currentSessionId: mockSessions[0].id,
+    onSelectSession: () => {},
+    onNewChat: () => {},
+    onRenameSession: () => {},
+    onDeleteSession: () => {},
     onClose: () => {},
   },
 };
 
-export const NoHistoryToggle: Story = {
-  name: "無 History 按鈕",
+export const SidebarMode: Story = {
+  name: "Sidebar mode（含關閉按鈕）",
   args: {
+    mode: "sidebar" as const,
     title: "QJudge AI 助教",
-    onToggleHistory: undefined,
+    historyOpen: false,
+    onToggleHistory: () => {},
+    onNewChat: () => {},
+    onClose: () => {},
   },
 };

--- a/frontend/src/features/chatbot/components/workspace/WorkspaceShell.module.scss
+++ b/frontend/src/features/chatbot/components/workspace/WorkspaceShell.module.scss
@@ -1,33 +1,31 @@
 @use "../chat-ui/variables" as *;
 
 .shell {
+  display: flex;
   flex: 1;
   height: 100%;
   min-height: 0;
   overflow: hidden;
-  position: relative;
 }
 
 .content {
-  width: 100%;
-  height: 100%;
+  flex: 1;
+  min-width: 0;
   min-height: 0;
 }
 
-// Overlay panel — floats over content (same on all screen sizes)
 .panel {
-  position: absolute;
-  top: 0;
-  right: 0;
+  flex-shrink: 0;
   width: 0;
   height: 100%;
   overflow: hidden;
-  z-index: 50;
+  position: relative;
   transition: width $chat-motion-duration $chat-motion-easing;
 }
 
 .panelOpen {
   width: $chat-sidebar-width;
+  display: flex;
 }
 
 .resizeHandle {

--- a/frontend/src/features/chatbot/components/workspace/WorkspaceShell.module.scss
+++ b/frontend/src/features/chatbot/components/workspace/WorkspaceShell.module.scss
@@ -1,31 +1,33 @@
 @use "../chat-ui/variables" as *;
 
 .shell {
-  display: flex;
   flex: 1;
   height: 100%;
   min-height: 0;
   overflow: hidden;
+  position: relative;
 }
 
 .content {
-  flex: 1;
-  min-width: 0;
+  width: 100%;
+  height: 100%;
   min-height: 0;
 }
 
+// Overlay panel — floats over content (same on all screen sizes)
 .panel {
-  flex-shrink: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
   width: 0;
   height: 100%;
   overflow: hidden;
-  position: relative;
+  z-index: 50;
   transition: width $chat-motion-duration $chat-motion-easing;
 }
 
 .panelOpen {
   width: $chat-sidebar-width;
-  display: flex;
 }
 
 .resizeHandle {
@@ -37,10 +39,9 @@
   cursor: col-resize;
   z-index: 10;
   background: transparent;
-  // Visual border centered in the handle
   border-right: 1px solid var(--cds-border-subtle-01, #e0e0e0);
   transition: border-color 150ms ease;
-  touch-action: none; // prevent scroll while dragging on touch
+  touch-action: none;
 
   &:hover,
   &:active {
@@ -48,7 +49,6 @@
     border-right-width: 2px;
   }
 
-  // Wider touch target on touch devices
   @media (pointer: coarse) {
     left: -8px;
     width: 16px;

--- a/frontend/src/features/chatbot/components/workspace/WorkspaceShell.tsx
+++ b/frontend/src/features/chatbot/components/workspace/WorkspaceShell.tsx
@@ -20,9 +20,18 @@ function getSavedWidth(): number {
 }
 
 interface WorkspaceShellProps {
+  /** Main workspace area (left of the chat sidebar). */
   children: React.ReactNode;
 }
 
+/**
+ * Two-column shell: main content + optional chat panel.
+ *
+ * **Chat open state for descendants**
+ * - Any child may call `useWorkspace()` and read `isOpen` / `toggleChat` / etc.
+ * - The main content wrapper also sets `data-chatbot-sidebar-open` for CSS or
+ *   non-React consumers (`[data-chatbot-sidebar-open="true"]`).
+ */
 export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const { isOpen, closeChat } = useWorkspace();
   const panelRef = useRef<HTMLElement>(null);
@@ -80,7 +89,10 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   return (
     <div className={styles.shell}>
-      <div className={styles.content}>
+      <div
+        className={styles.content}
+        data-chatbot-sidebar-open={isOpen ? "true" : "false"}
+      >
         {children}
       </div>
       <aside

--- a/frontend/src/features/chatbot/contexts/ChatSessionContext.tsx
+++ b/frontend/src/features/chatbot/contexts/ChatSessionContext.tsx
@@ -1,5 +1,5 @@
 // frontend/src/features/chatbot/contexts/ChatSessionContext.tsx
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 import type { ChatSession } from "@/core/types/chatbot.types";
 import { chatbotRepository } from "@/infrastructure/api/repositories";
 import { useAuth } from "@/features/auth/contexts/AuthContext";
@@ -10,13 +10,9 @@ interface ChatSessionContextValue {
   refreshSessions: () => Promise<void>;
 }
 
-const ChatSessionContext = createContext<ChatSessionContextValue>({
-  sessions: [],
-  isLoadingSessions: false,
-  refreshSessions: async () => {},
-});
+const ChatSessionContext = createContext<ChatSessionContextValue | undefined>(undefined);
 
-export function ChatSessionProvider({ children }: { children: React.ReactNode }) {
+export function ChatSessionProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
   const isTeacherOrAdmin = user?.role === "teacher" || user?.role === "admin";
 
@@ -50,5 +46,9 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
 }
 
 export function useChatSessionContext() {
-  return useContext(ChatSessionContext);
+  const ctx = useContext(ChatSessionContext);
+  if (ctx === undefined) {
+    throw new Error("useChatSessionContext must be used within ChatSessionProvider");
+  }
+  return ctx;
 }

--- a/frontend/src/features/chatbot/contexts/ChatSessionContext.tsx
+++ b/frontend/src/features/chatbot/contexts/ChatSessionContext.tsx
@@ -1,0 +1,54 @@
+// frontend/src/features/chatbot/contexts/ChatSessionContext.tsx
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import type { ChatSession } from "@/core/types/chatbot.types";
+import { chatbotRepository } from "@/infrastructure/api/repositories";
+import { useAuth } from "@/features/auth/contexts/AuthContext";
+
+interface ChatSessionContextValue {
+  sessions: ChatSession[];
+  isLoadingSessions: boolean;
+  refreshSessions: () => Promise<void>;
+}
+
+const ChatSessionContext = createContext<ChatSessionContextValue>({
+  sessions: [],
+  isLoadingSessions: false,
+  refreshSessions: async () => {},
+});
+
+export function ChatSessionProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const isTeacherOrAdmin = user?.role === "teacher" || user?.role === "admin";
+
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(false);
+
+  const refreshSessions = useCallback(async () => {
+    if (!isTeacherOrAdmin) return;
+    setIsLoadingSessions(true);
+    try {
+      const result = await chatbotRepository.getSessions();
+      setSessions(result);
+    } catch {
+      // silently fail — SideMenu will show empty list
+    } finally {
+      setIsLoadingSessions(false);
+    }
+  }, [isTeacherOrAdmin]);
+
+  useEffect(() => {
+    if (isTeacherOrAdmin) {
+      void refreshSessions();
+    }
+  }, [isTeacherOrAdmin, refreshSessions]);
+
+  return (
+    <ChatSessionContext.Provider value={{ sessions, isLoadingSessions, refreshSessions }}>
+      {children}
+    </ChatSessionContext.Provider>
+  );
+}
+
+export function useChatSessionContext() {
+  return useContext(ChatSessionContext);
+}

--- a/frontend/src/features/chatbot/hooks/useChatScrollToBottom.ts
+++ b/frontend/src/features/chatbot/hooks/useChatScrollToBottom.ts
@@ -1,0 +1,140 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+import type { ApprovalRequest, ChatMessage } from "@/core/types/chatbot.types";
+
+interface UseChatScrollToBottomParams {
+  /** Scrollable container element (the messages list). */
+  containerRef: RefObject<HTMLElement | null>;
+  messages: ChatMessage[];
+  currentSessionId: string | null;
+  isLoading: boolean;
+  pendingApproval: ApprovalRequest | null;
+  /**
+   * Distance from bottom (px) under which we still consider the user as
+   * "following" the conversation, so streaming updates keep auto-scrolling.
+   */
+  nearBottomThreshold?: number;
+  /**
+   * Distance from bottom (px) over which the floating "scroll to latest"
+   * button becomes visible.
+   */
+  showButtonThreshold?: number;
+}
+
+interface UseChatScrollToBottomResult {
+  /** Manually trigger a scroll to the latest message (e.g. button click). */
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+  /** Whether the floating "scroll to latest" button should be visible. */
+  showScrollButton: boolean;
+}
+
+/**
+ * Single source of truth for "scroll to latest message" behavior in the chat.
+ *
+ * Triggers handled internally:
+ *   - Session switch / initial load → instant jump to bottom
+ *   - HITL approval card appears → instant jump
+ *   - User just sent a message → forced smooth scroll, even if scrolled up
+ *   - New / streaming messages → smooth scroll only if user is near bottom
+ *   - Manual button click → smooth scroll via the returned `scrollToBottom`
+ */
+export function useChatScrollToBottom({
+  containerRef,
+  messages,
+  currentSessionId,
+  isLoading,
+  pendingApproval,
+  nearBottomThreshold = 150,
+  showButtonThreshold = 300,
+}: UseChatScrollToBottomParams): UseChatScrollToBottomResult {
+  const [showScrollButton, setShowScrollButton] = useState(false);
+  const lastUserMessageIdRef = useRef<string | null>(null);
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = "smooth") => {
+      const container = containerRef.current;
+      if (!container) return;
+      container.scrollTo({ top: container.scrollHeight, behavior });
+    },
+    [containerRef],
+  );
+
+  // Schedules two RAFs so newly rendered content (incl. async images) is
+  // measured before scrolling.
+  const scheduleScrollToBottom = useCallback(
+    (behavior: ScrollBehavior = "smooth") => {
+      requestAnimationFrame(() => {
+        scrollToBottom(behavior);
+        requestAnimationFrame(() => scrollToBottom(behavior));
+      });
+    },
+    [scrollToBottom],
+  );
+
+  // Toggle the floating button based on scroll position.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const distanceFromBottom =
+        container.scrollHeight - container.scrollTop - container.clientHeight;
+      setShowScrollButton(distanceFromBottom > showButtonThreshold);
+    };
+
+    container.addEventListener("scroll", handleScroll);
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [containerRef, showButtonThreshold]);
+
+  // Session switch / initial load → jump instantly so users land at the latest.
+  useLayoutEffect(() => {
+    scheduleScrollToBottom("auto");
+  }, [currentSessionId, isLoading, scheduleScrollToBottom]);
+
+  // HITL approval card appears → ensure it is visible.
+  useLayoutEffect(() => {
+    if (!pendingApproval || isLoading) return;
+    scheduleScrollToBottom("auto");
+  }, [pendingApproval, isLoading, scheduleScrollToBottom]);
+
+  // Message-driven scroll:
+  //   - If the user just sent a new message → force scroll (UX guarantee).
+  //   - Otherwise (assistant streaming, etc.) → only scroll if near bottom,
+  //     so users reading older history aren't yanked away.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let lastUserMessage: ChatMessage | undefined;
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      if (messages[i].role === "user") {
+        lastUserMessage = messages[i];
+        break;
+      }
+    }
+
+    const userJustSent =
+      !!lastUserMessage && lastUserMessage.id !== lastUserMessageIdRef.current;
+    lastUserMessageIdRef.current = lastUserMessage?.id ?? null;
+
+    if (userJustSent) {
+      scheduleScrollToBottom("smooth");
+      return;
+    }
+
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    if (distanceFromBottom < nearBottomThreshold) {
+      scheduleScrollToBottom("smooth");
+    }
+  }, [messages, pendingApproval, scheduleScrollToBottom, containerRef, nearBottomThreshold]);
+
+  return { scrollToBottom, showScrollButton };
+}

--- a/frontend/src/features/chatbot/hooks/useChatbot.ts
+++ b/frontend/src/features/chatbot/hooks/useChatbot.ts
@@ -12,6 +12,7 @@ import type {
   VerificationReport,
 } from "@/core/types/chatbot.types";
 import { chatbotRepository } from "@/infrastructure/api/repositories";
+import { useChatSessionContext } from "../contexts/ChatSessionContext";
 
 interface UseChatbotReturn {
   sessions: ChatSession[];
@@ -48,6 +49,12 @@ interface UseChatbotOptions {
   context?: ChatContext | null;
   /** Agent commit 成功後觸發（通知父頁面重新載入資料） */
   onProblemUpdated?: () => void;
+  /** 從 URL 傳入的 session ID，useChatbot 會在初始化後切換到此 session */
+  externalSessionId?: string;
+  /** 當 session 被建立/切換時的回調（用於 URL navigation） */
+  onSessionChange?: (newId: string) => void;
+  /** 當 session 被刪除時的回調（用於 URL navigation） */
+  onSessionDeleted?: (fallbackId: string | null) => void;
 }
 
 /**
@@ -247,7 +254,13 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
     backgroundInfo = null,
     context = null,
     onProblemUpdated: _onProblemUpdated,
+    externalSessionId,
+    onSessionChange,
+    onSessionDeleted,
   } = options;
+
+  // Notify shared ChatSessionContext to refresh when session list changes
+  const chatSessionCtx = useChatSessionContext();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [currentSessionId, _setCurrentSessionId] = useState<string | null>(null);
   const currentSessionIdRef = useRef<string | null>(null);
@@ -451,6 +464,14 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
     init();
   }, [applyActiveRunsToSessions, enabled, setCurrentSessionId]);
 
+  // Sync to URL-provided session ID after initialization completes
+  useEffect(() => {
+    if (!externalSessionId || isInitializing) return;
+    if (currentSessionId !== externalSessionId) {
+      void switchSession(externalSessionId);
+    }
+  }, [externalSessionId, isInitializing, currentSessionId, switchSession]);
+
   /**
    * 創建新 session
    */
@@ -466,6 +487,8 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         next.delete(newSession.id);
         return next;
       });
+      void chatSessionCtx.refreshSessions();
+      onSessionChange?.(newSession.id);
       return newSession.id;
     } catch (err) {
       console.error("Failed to create session:", err);
@@ -486,16 +509,22 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         setSessions((prev) => {
           const filtered = prev.filter((session) => session.id !== sessionId);
 
-          // 如果刪除的是當前 session，切換到第一個
-          if (sessionId === currentSessionId && filtered.length > 0) {
-            setCurrentSessionId(filtered[0].id);
+          if (sessionId === currentSessionId) {
+            const fallback = filtered[0]?.id ?? null;
+            if (filtered.length > 0) {
+              setCurrentSessionId(filtered[0].id);
+            } else {
+              void createSession();
+            }
+            onSessionDeleted?.(fallback);
           } else if (filtered.length === 0) {
-            // 如果刪除後沒有 session，創建一個新的
-            createSession();
+            void createSession();
+            onSessionDeleted?.(null);
           }
 
           return filtered;
         });
+        void chatSessionCtx.refreshSessions();
       } catch (err) {
         console.error("Failed to delete session:", err);
         setError(i18n.t("chatbot:errors.deleteSessionFailed"));
@@ -548,6 +577,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
               : session,
           ),
         );
+        void chatSessionCtx.refreshSessions();
       } catch (err) {
         console.error("Failed to rename session:", err);
         setError(i18n.t("chatbot:errors.renameSessionFailed"));

--- a/frontend/src/features/chatbot/hooks/useChatbot.ts
+++ b/frontend/src/features/chatbot/hooks/useChatbot.ts
@@ -260,7 +260,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
   } = options;
 
   // Notify shared ChatSessionContext to refresh when session list changes
-  const chatSessionCtx = useChatSessionContext();
+  const { refreshSessions: refreshSharedSessions } = useChatSessionContext();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [currentSessionId, _setCurrentSessionId] = useState<string | null>(null);
   const currentSessionIdRef = useRef<string | null>(null);
@@ -487,7 +487,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         next.delete(newSession.id);
         return next;
       });
-      void chatSessionCtx.refreshSessions();
+      void refreshSharedSessions();
       onSessionChange?.(newSession.id);
       return newSession.id;
     } catch (err) {
@@ -495,7 +495,7 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
       setError(i18n.t("chatbot:errors.createSessionFailed"));
       return null;
     }
-  }, [setCurrentSessionId]);
+  }, [setCurrentSessionId, refreshSharedSessions, onSessionChange]);
 
   /**
    * 刪除 session
@@ -506,31 +506,36 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
         setError(null);
         await chatbotRepository.deleteSession(sessionId);
 
+        let fallback: string | null = null;
+        let shouldCreate = false;
+        let shouldCallDeleted = false;
+
         setSessions((prev) => {
           const filtered = prev.filter((session) => session.id !== sessionId);
-
           if (sessionId === currentSessionId) {
-            const fallback = filtered[0]?.id ?? null;
+            fallback = filtered[0]?.id ?? null;
             if (filtered.length > 0) {
               setCurrentSessionId(filtered[0].id);
             } else {
-              void createSession();
+              shouldCreate = true;
             }
-            onSessionDeleted?.(fallback);
+            shouldCallDeleted = true;
           } else if (filtered.length === 0) {
-            void createSession();
-            onSessionDeleted?.(null);
+            shouldCreate = true;
+            shouldCallDeleted = true;
           }
-
           return filtered;
         });
-        void chatSessionCtx.refreshSessions();
+
+        if (shouldCreate) void createSession();
+        if (shouldCallDeleted) onSessionDeleted?.(fallback);
+        void refreshSharedSessions();
       } catch (err) {
         console.error("Failed to delete session:", err);
         setError(i18n.t("chatbot:errors.deleteSessionFailed"));
       }
     },
-    [currentSessionId, createSession, setCurrentSessionId],
+    [currentSessionId, createSession, setCurrentSessionId, refreshSharedSessions, onSessionDeleted],
   );
 
   /**
@@ -577,13 +582,13 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
               : session,
           ),
         );
-        void chatSessionCtx.refreshSessions();
+        void refreshSharedSessions();
       } catch (err) {
         console.error("Failed to rename session:", err);
         setError(i18n.t("chatbot:errors.renameSessionFailed"));
       }
     },
-    [],
+    [refreshSharedSessions],
   );
 
   // Derive the active run for the current session once so the subscription

--- a/frontend/src/features/chatbot/hooks/useChatbot.ts
+++ b/frontend/src/features/chatbot/hooks/useChatbot.ts
@@ -464,14 +464,6 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
     init();
   }, [applyActiveRunsToSessions, enabled, setCurrentSessionId]);
 
-  // Sync to URL-provided session ID after initialization completes
-  useEffect(() => {
-    if (!externalSessionId || isInitializing) return;
-    if (currentSessionId !== externalSessionId) {
-      void switchSession(externalSessionId);
-    }
-  }, [externalSessionId, isInitializing, currentSessionId, switchSession]);
-
   /**
    * 創建新 session
    */
@@ -565,6 +557,14 @@ export function useChatbot(options: UseChatbotOptions = {}): UseChatbotReturn {
       }
     }
   }, [sessions, setCurrentSessionId]);
+
+  // Sync to URL-provided session ID after initialization completes
+  useEffect(() => {
+    if (!externalSessionId || isInitializing) return;
+    if (currentSessionId !== externalSessionId) {
+      void switchSession(externalSessionId);
+    }
+  }, [externalSessionId, isInitializing, currentSessionId, switchSession]);
 
   /**
    * 重新命名 session

--- a/frontend/src/features/chatbot/index.ts
+++ b/frontend/src/features/chatbot/index.ts
@@ -2,3 +2,4 @@ export { AIWorkspaceProvider } from "./components/workspace/AIWorkspaceProvider"
 export { WorkspaceShell } from "./components/workspace/WorkspaceShell";
 export { ChatContainer } from "./components/chat-ui/ChatContainer";
 export { useWorkspace } from "./hooks/useWorkspace";
+export { ChatSessionProvider, useChatSessionContext } from "./contexts/ChatSessionContext";

--- a/frontend/src/features/contest/components/admin/examEditor/CodingTestEditorLayout.tsx
+++ b/frontend/src/features/contest/components/admin/examEditor/CodingTestEditorLayout.tsx
@@ -29,6 +29,7 @@ import type { QuestionSourceDragItem } from "./questionSource.types";
 import useToolbarSaveStatus from "./hooks/useToolbarSaveStatus";
 import { useEditorPaneScrollSelection } from "./hooks/useEditorPaneScrollSelection";
 import { labelForContestProblemOrder } from "@/features/contest/domain/contestProblemOrderLabel";
+import { useWorkspace } from "@/features/chatbot";
 import styles from "./ExamEditorLayout.module.scss";
 
 interface CodingTestEditorLayoutProps {
@@ -93,16 +94,19 @@ const CodingTestEditorLayout: React.FC<CodingTestEditorLayoutProps> = ({
   const { refreshContest, loading: contestLoading } = useContest();
   const listSave = useToolbarSaveStatus();
   const effectiveClassroomId = classroomId || contest.boundClassroomId || undefined;
+  const { isOpen: workspaceChatOpen } = useWorkspace();
+  /** When AI chat sidebar is open, default both side panels collapsed to save horizontal space. */
+  const defaultSidePanelsExpanded = !workspaceChatOpen;
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [orderedProblems, setOrderedProblems] = useState<ContestProblemSummary[]>(() =>
     sortProblems(contest.problems ?? [])
   );
-  const [sidebarExpanded, setSidebarExpanded] = useState(true);
+  const [sidebarExpanded, setSidebarExpanded] = useState(defaultSidePanelsExpanded);
 
   const [sourceDragItem, setSourceDragItem] = useState<QuestionSourceDragItem | null>(null);
   const [sourceHoverIndex, setSourceHoverIndex] = useState<number | null>(null);
-  const [sourcePanelExpanded, setSourcePanelExpanded] = useState(true);
+  const [sourcePanelExpanded, setSourcePanelExpanded] = useState(defaultSidePanelsExpanded);
   const [sourceModalOpen, setSourceModalOpen] = useState(false);
   const [viewReorderPointerDepth, setViewReorderPointerDepth] = useState(0);
 

--- a/frontend/src/features/contest/components/admin/examEditor/ExamEditorLayout.tsx
+++ b/frontend/src/features/contest/components/admin/examEditor/ExamEditorLayout.tsx
@@ -39,6 +39,7 @@ import QuestionSourcePanel from "./QuestionSourcePanel";
 import type { QuestionSourceDragItem } from "./questionSource.types";
 import useToolbarSaveStatus from "./hooks/useToolbarSaveStatus";
 import { useEditorPaneScrollSelection } from "./hooks/useEditorPaneScrollSelection";
+import { useWorkspace } from "@/features/chatbot";
 import styles from "./ExamEditorLayout.module.scss";
 
 const QUESTION_TYPE_ORDER: ExamQuestionType[] = [
@@ -106,14 +107,17 @@ const ExamEditorLayout: React.FC<ExamEditorLayoutProps> = ({
   const { t } = useTranslation("contest");
   const { confirm, modalProps } = useConfirmModal();
   const toolbarSave = useToolbarSaveStatus();
+  const { isOpen: workspaceChatOpen } = useWorkspace();
+  /** When AI chat sidebar is open, default both side panels collapsed to save horizontal space. */
+  const defaultSidePanelsExpanded = !workspaceChatOpen;
 
   const [questions, setQuestions] = useState<ExamQuestion[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [sidebarExpanded, setSidebarExpanded] = useState(true);
+  const [sidebarExpanded, setSidebarExpanded] = useState(defaultSidePanelsExpanded);
   const [sourceDragItem, setSourceDragItem] = useState<QuestionSourceDragItem | null>(null);
   const [sourceHoverIndex, setSourceHoverIndex] = useState<number | null>(null);
-  const [sourcePanelExpanded, setSourcePanelExpanded] = useState(true);
+  const [sourcePanelExpanded, setSourcePanelExpanded] = useState(defaultSidePanelsExpanded);
   const [sourceModalOpen, setSourceModalOpen] = useState(false);
 
   const reorderTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -335,6 +335,7 @@
     "back": "Back",
     "backToProblemList": "Back to Problems",
     "changelog": "Changelog",
+    "chat": "Chat",
     "classrooms": "Classrooms",
     "contests": "Contests",
     "dashboard": "Dashboard",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -297,6 +297,7 @@
   "nav": {
     "back": "戻る",
     "backToProblemList": "問題リストへ",
+    "chat": "Chat",
     "classrooms": "クラスルーム",
     "contests": "コンテスト",
     "dashboard": "ダッシュボード",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -297,6 +297,7 @@
   "nav": {
     "back": "뒤로",
     "backToProblemList": "문제 목록으로",
+    "chat": "Chat",
     "classrooms": "교실",
     "contests": "대회",
     "dashboard": "대시보드",
@@ -304,7 +305,6 @@
     "marketplace": "문제 마켓플레이스",
     "problemList": "문제 목록",
     "problems": "문제",
-
     "ranking": "랭킹",
     "submissions": "제출 기록"
   },

--- a/frontend/src/i18n/locales/zh-TW/common.json
+++ b/frontend/src/i18n/locales/zh-TW/common.json
@@ -334,10 +334,11 @@
   "nav": {
     "back": "返回",
     "backToProblemList": "題目列表",
+    "changelog": "更新紀錄",
+    "chat": "Chat",
     "classrooms": "教室",
     "contests": "競賽",
     "dashboard": "儀表板",
-    "changelog": "更新紀錄",
     "documentation": "文件",
     "marketplace": "題庫市集",
     "problemList": "題目列表",

--- a/frontend/src/shared/utils/relativeTime.ts
+++ b/frontend/src/shared/utils/relativeTime.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns a compact relative time string for display in chat session lists.
+ * Compact format: "Just now", "3h", "1d", "4d", "2w", or localized date for older.
+ */
+export function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    return diffHours === 0 ? "Just now" : `${diffHours}h`;
+  }
+  if (diffDays === 1) return "1d";
+  if (diffDays < 7) return `${diffDays}d`;
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 5) return `${diffWeeks}w`;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -521,6 +521,8 @@ async def qjudge_browse(
     Do NOT use this tool for any write operations — use qjudge_contest_manager (get_detail, list_problems, reorder), qjudge_exam, or qjudge_coding_problems for contest questions.
 
     Actions:
+      search_all             — Search across classrooms, contests, and question banks by keyword (required: search).
+                               Returns {classrooms: [...], contests: [...], banks: [...]}.
       list_classrooms        — List classrooms you manage (optional: search)
       list_contests          — List contests you manage (optional: search, status)
       get_contest            — Get contest detail (required: contest_id)
@@ -531,6 +533,24 @@ async def qjudge_browse(
     """
     if action == "get_help":
         return _TOOL_HELP
+
+    if action == "search_all":
+        if not search:
+            return _error("search is required for search_all")
+        classrooms_q = {"scope": "manage", "search": search}
+        contests_q = {"scope": "manage", "search": search}
+        banks_q = {"search": search}
+        import asyncio
+        classrooms_res, contests_res, banks_res = await asyncio.gather(
+            django_api("GET", f"/api/v1/classrooms/?{urlencode(classrooms_q)}", ctx),
+            django_api("GET", f"/api/v1/contests/?{urlencode(contests_q)}", ctx),
+            django_api("GET", f"/api/v1/question-banks/?{urlencode(banks_q)}", ctx),
+        )
+        return {
+            "classrooms": classrooms_res.get("results", classrooms_res) if isinstance(classrooms_res, dict) else classrooms_res,
+            "contests": contests_res.get("results", contests_res) if isinstance(contests_res, dict) else contests_res,
+            "banks": banks_res if isinstance(banks_res, list) else banks_res.get("results", banks_res),
+        }
 
     if action == "list_classrooms":
         query = {"scope": "manage"}


### PR DESCRIPTION
## Summary

- **SideMenu 三 tab 導航**：教室 / 題庫 / Chat，依路由自動切換；Chat tab 顯示 Notion 風格 session 歷史清單（chat icon + 標題 + 相對時間）
- **Chat Session URL Routing**：新增 `/chat/:sessionId` route，session 切換反映在 URL，支援書籤與分享
- **統一 ChatTopBar**：full-page 與 sidebar 皆使用 title dropdown 快速切換 session，移除獨立 history panel
- **ChatSessionContext**：共享 session 清單，SideMenu 與 ChatContainer 同步更新
- **ChatHistoryPanel 重設計**：移除搜尋欄，Notion 風格（Carbon tokens），hover 顯示 overflow menu，可選底部「新增對話」按鈕

## Test Plan

- [ ] `/chat` → 自動跳至最後一個 session URL（`/chat/:id`）
- [ ] 切換 session → URL 更新、重新整理後恢復同一 session
- [ ] SideMenu 點 Chat tab → 顯示 session 清單；點 session → navigate + close menu
- [ ] SideMenu「新增對話」→ 建立新 session，URL 更新
- [ ] ChatTopBar title dropdown → 展開清單，點選切換
- [ ] `+` 新增 / `...` rename / delete 當前 session
- [ ] Sidebar mode（WorkspaceShell）→ 同樣使用 title dropdown，close 按鈕正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)