### PR TITLE
fix(storage): cover ai-artifacts in R2 migration and skip create_bucket on R2

### DIFF
--- a/backend/apps/ai/services/artifact_storage.py
+++ b/backend/apps/ai/services/artifact_storage.py
@@ -81,12 +81,26 @@ def _ensure_bucket_exists(client) -> None:
         return
 
     bucket = settings.AI_ARTIFACT_S3_BUCKET
+    auto_create = getattr(settings, "OBJECT_STORAGE_AUTO_CREATE_BUCKETS", True)
     try:
         client.head_bucket(Bucket=bucket)
         _BUCKET_READY = True
         return
     except ClientError as exc:
         code = str(exc.response.get("Error", {}).get("Code", "")).strip()
+        if not auto_create:
+            # R2 / managed buckets: the token may not have account-wide
+            # HeadBucket permission. Trust the configured bucket and surface a
+            # clearer error if it really is missing on first put_object.
+            if code in {"403", "AccessDenied", "Forbidden"}:
+                _BUCKET_READY = True
+                return
+            if code in {"404", "NoSuchBucket", "NotFound"}:
+                raise AIArtifactStorageError(
+                    f"Artifact bucket '{bucket}' not found on object storage; "
+                    "create it in the provider dashboard before retrying."
+                ) from exc
+            raise AIArtifactStorageError("Failed to access artifact bucket") from exc
         if code not in {"404", "NoSuchBucket", "NotFound"}:
             raise AIArtifactStorageError("Failed to access artifact bucket") from exc
 

--- a/backend/apps/core/services/markdown_image_storage.py
+++ b/backend/apps/core/services/markdown_image_storage.py
@@ -81,12 +81,23 @@ def _ensure_bucket_exists(client) -> None:
         return
 
     bucket = settings.MARKDOWN_IMAGE_S3_BUCKET
+    auto_create = getattr(settings, "OBJECT_STORAGE_AUTO_CREATE_BUCKETS", True)
     try:
         client.head_bucket(Bucket=bucket)
         _BUCKET_READY = True
         return
     except ClientError as exc:
         code = str(exc.response.get("Error", {}).get("Code", "")).strip()
+        if not auto_create:
+            if code in {"403", "AccessDenied", "Forbidden"}:
+                _BUCKET_READY = True
+                return
+            if code in {"404", "NoSuchBucket", "NotFound"}:
+                raise MarkdownImageStorageError(
+                    f"Markdown image bucket '{bucket}' not found on object storage; "
+                    "create it in the provider dashboard before retrying."
+                ) from exc
+            raise MarkdownImageStorageError("Failed to access markdown image bucket") from exc
         if code not in {"404", "NoSuchBucket", "NotFound"}:
             raise MarkdownImageStorageError("Failed to access markdown image bucket") from exc
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -471,6 +471,13 @@ OBJECT_STORAGE_OBJECT_TAGGING_ENABLED = os.getenv(
     "OBJECT_STORAGE_OBJECT_TAGGING_ENABLED",
     "false" if ".r2.cloudflarestorage.com" in OBJECT_STORAGE_ENDPOINT_URL else "true",
 ).lower() == "true"
+# Cloudflare R2 does not allow bucket creation via the S3 API (buckets must be
+# pre-created in the dashboard or via the Cloudflare API). Disable auto-create
+# automatically when the configured endpoint points at R2.
+OBJECT_STORAGE_AUTO_CREATE_BUCKETS = os.getenv(
+    "OBJECT_STORAGE_AUTO_CREATE_BUCKETS",
+    "false" if ".r2.cloudflarestorage.com" in OBJECT_STORAGE_ENDPOINT_URL else "true",
+).lower() == "true"
 
 # Backwards-compatible aliases — existing modules read these.
 MINIO_ENDPOINT_URL = OBJECT_STORAGE_ENDPOINT_URL

--- a/scripts/r2/migrate-dev-minio-to-r2.sh
+++ b/scripts/r2/migrate-dev-minio-to-r2.sh
@@ -7,7 +7,7 @@ QJUDGE_DC="$PROJECT_ROOT/.codex/skills/qjudge-env-compose-owner/scripts/qjudge-d
 usage() {
   cat <<'USAGE' >&2
 Usage:
-  scripts/r2/migrate-dev-minio-to-r2.sh [--dry-run|--apply] [--prefix PREFIX] [--only raw|videos|markdown]
+  scripts/r2/migrate-dev-minio-to-r2.sh [--dry-run|--apply] [--prefix PREFIX] [--only raw|videos|markdown|artifacts]
 
 Copies local dev MinIO objects into the currently configured dev R2 buckets.
 This script never deletes source or target objects.
@@ -15,7 +15,7 @@ This script never deletes source or target objects.
 Defaults:
   mode: dry-run
   source endpoint: http://minio:9000
-  source buckets: anticheat-raw, anticheat-videos, markdown-images
+  source buckets: anticheat-raw, anticheat-videos, markdown-images, ai-artifacts
   target buckets: current Django settings / .env values
 
 Examples:
@@ -50,9 +50,9 @@ while [[ $# -gt 0 ]]; do
     --only)
       ONLY="${2:-}"
       case "$ONLY" in
-        raw|videos|markdown) ;;
+        raw|videos|markdown|artifacts) ;;
         *)
-          echo "--only must be one of: raw, videos, markdown" >&2
+          echo "--only must be one of: raw, videos, markdown, artifacts" >&2
           exit 2
           ;;
       esac
@@ -117,6 +117,7 @@ SOURCE_REGION = os.environ.get("MINIO_MIGRATION_SOURCE_REGION", "us-east-1")
 SOURCE_RAW_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_RAW_BUCKET", "anticheat-raw")
 SOURCE_VIDEO_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_VIDEO_BUCKET", "anticheat-videos")
 SOURCE_MARKDOWN_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_MARKDOWN_BUCKET", "markdown-images")
+SOURCE_ARTIFACT_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_ARTIFACT_BUCKET", "ai-artifacts")
 
 if MODE not in {"dry-run", "apply"}:
     raise SystemExit(f"unsupported mode: {MODE}")
@@ -149,6 +150,7 @@ pairs = [
     BucketPair("raw", SOURCE_RAW_BUCKET, settings.ANTICHEAT_RAW_BUCKET),
     BucketPair("videos", SOURCE_VIDEO_BUCKET, settings.ANTICHEAT_VIDEO_BUCKET),
     BucketPair("markdown", SOURCE_MARKDOWN_BUCKET, settings.MARKDOWN_IMAGE_S3_BUCKET),
+    BucketPair("artifacts", SOURCE_ARTIFACT_BUCKET, settings.AI_ARTIFACT_S3_BUCKET),
 ]
 if ONLY:
     pairs = [pair for pair in pairs if pair.label == ONLY]


### PR DESCRIPTION
## Summary
- R2 deployments were failing on artifact / markdown image APIs because `_ensure_bucket_exists` still tried to `head_bucket` + `create_bucket`. R2 disallows S3-API bucket creation and bucket-scoped tokens lack account-wide HeadBucket, so requests bubbled up `Failed to access/create bucket`.
- Adds `OBJECT_STORAGE_AUTO_CREATE_BUCKETS` (auto-off on `*.r2.cloudflarestorage.com`). When disabled, `head_bucket` 403/AccessDenied is treated as "bucket exists, no scope" and 404 surfaces a clearer "create it in the dashboard" error.
- Adds the missing `ai-artifacts` pair to `scripts/r2/migrate-dev-minio-to-r2.sh` so dev artifact objects (rubric.md, grade.csv, user uploads) can be copied alongside raw / videos / markdown.

## Deploy notes
1. Pre-create the `qjudge-dev-ai-artifacts` bucket on Cloudflare R2 and add it to the R2 API token's bucket scope.
2. Set `AI_ARTIFACT_S3_BUCKET=qjudge-dev-ai-artifacts` in the dev `.env` (and the prod equivalent when promoted).
3. Run `scripts/r2/migrate-dev-minio-to-r2.sh --dry-run --only artifacts`, then `--apply --only artifacts`.

## Test plan
- [x] Dev migration: `--dry-run --only artifacts` reports seen=48 / would_copy=48 / errors=0.
- [x] Dev migration: `--apply --only artifacts` reports copied=48 / errors=0; R2 list confirms 48 objects on `qjudge-dev-ai-artifacts`.
- [x] Open an AI session with existing artifacts on `q-judge-dev.quan.wtf` and confirm the Artifact Panel can fetch rubric / grade.csv via R2 presigned URLs.
- [x] Verify markdown image upload still works on dev (regression check for the shared `_ensure_bucket_exists` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)