### PR TITLE
release: R2 artifacts fix + backend healthcheck curl

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/var/cache/apt/archives,sharing=locked \
     for i in 1 2 3 4 5; do \
       apt-get update && \
       apt-get install -y --no-install-recommends \
-        postgresql-client gcc ffmpeg \
+        postgresql-client gcc ffmpeg curl \
         libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
         libffi-dev libcairo2 shared-mime-info \
         fonts-noto-cjk fonts-noto-color-emoji && \

--- a/backend/apps/ai/services/artifact_storage.py
+++ b/backend/apps/ai/services/artifact_storage.py
@@ -81,12 +81,26 @@ def _ensure_bucket_exists(client) -> None:
         return
 
     bucket = settings.AI_ARTIFACT_S3_BUCKET
+    auto_create = getattr(settings, "OBJECT_STORAGE_AUTO_CREATE_BUCKETS", True)
     try:
         client.head_bucket(Bucket=bucket)
         _BUCKET_READY = True
         return
     except ClientError as exc:
         code = str(exc.response.get("Error", {}).get("Code", "")).strip()
+        if not auto_create:
+            # R2 / managed buckets: the token may not have account-wide
+            # HeadBucket permission. Trust the configured bucket and surface a
+            # clearer error if it really is missing on first put_object.
+            if code in {"403", "AccessDenied", "Forbidden"}:
+                _BUCKET_READY = True
+                return
+            if code in {"404", "NoSuchBucket", "NotFound"}:
+                raise AIArtifactStorageError(
+                    f"Artifact bucket '{bucket}' not found on object storage; "
+                    "create it in the provider dashboard before retrying."
+                ) from exc
+            raise AIArtifactStorageError("Failed to access artifact bucket") from exc
         if code not in {"404", "NoSuchBucket", "NotFound"}:
             raise AIArtifactStorageError("Failed to access artifact bucket") from exc
 

--- a/backend/apps/core/services/markdown_image_storage.py
+++ b/backend/apps/core/services/markdown_image_storage.py
@@ -81,12 +81,23 @@ def _ensure_bucket_exists(client) -> None:
         return
 
     bucket = settings.MARKDOWN_IMAGE_S3_BUCKET
+    auto_create = getattr(settings, "OBJECT_STORAGE_AUTO_CREATE_BUCKETS", True)
     try:
         client.head_bucket(Bucket=bucket)
         _BUCKET_READY = True
         return
     except ClientError as exc:
         code = str(exc.response.get("Error", {}).get("Code", "")).strip()
+        if not auto_create:
+            if code in {"403", "AccessDenied", "Forbidden"}:
+                _BUCKET_READY = True
+                return
+            if code in {"404", "NoSuchBucket", "NotFound"}:
+                raise MarkdownImageStorageError(
+                    f"Markdown image bucket '{bucket}' not found on object storage; "
+                    "create it in the provider dashboard before retrying."
+                ) from exc
+            raise MarkdownImageStorageError("Failed to access markdown image bucket") from exc
         if code not in {"404", "NoSuchBucket", "NotFound"}:
             raise MarkdownImageStorageError("Failed to access markdown image bucket") from exc
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -471,6 +471,13 @@ OBJECT_STORAGE_OBJECT_TAGGING_ENABLED = os.getenv(
     "OBJECT_STORAGE_OBJECT_TAGGING_ENABLED",
     "false" if ".r2.cloudflarestorage.com" in OBJECT_STORAGE_ENDPOINT_URL else "true",
 ).lower() == "true"
+# Cloudflare R2 does not allow bucket creation via the S3 API (buckets must be
+# pre-created in the dashboard or via the Cloudflare API). Disable auto-create
+# automatically when the configured endpoint points at R2.
+OBJECT_STORAGE_AUTO_CREATE_BUCKETS = os.getenv(
+    "OBJECT_STORAGE_AUTO_CREATE_BUCKETS",
+    "false" if ".r2.cloudflarestorage.com" in OBJECT_STORAGE_ENDPOINT_URL else "true",
+).lower() == "true"
 
 # Backwards-compatible aliases — existing modules read these.
 MINIO_ENDPOINT_URL = OBJECT_STORAGE_ENDPOINT_URL

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -6,6 +6,16 @@ Base settings shared across all environments.
 import os
 from pathlib import Path
 from datetime import timedelta
+from urllib.parse import urlparse
+
+
+def _endpoint_is_r2(url: str) -> bool:
+    """True iff the hostname is on cloudflarestorage.com (R2)."""
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    return host == "r2.cloudflarestorage.com" or host.endswith(".r2.cloudflarestorage.com")
 
 # Build paths inside the project
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -467,16 +477,17 @@ OBJECT_STORAGE_PRESIGNED_URL_TTL_SECONDS = int(
         os.getenv("MINIO_PRESIGNED_URL_TTL_SECONDS", "300"),
     )
 )
+_OBJECT_STORAGE_IS_R2 = _endpoint_is_r2(OBJECT_STORAGE_ENDPOINT_URL)
 OBJECT_STORAGE_OBJECT_TAGGING_ENABLED = os.getenv(
     "OBJECT_STORAGE_OBJECT_TAGGING_ENABLED",
-    "false" if ".r2.cloudflarestorage.com" in OBJECT_STORAGE_ENDPOINT_URL else "true",
+    "false" if _OBJECT_STORAGE_IS_R2 else "true",
 ).lower() == "true"
 # Cloudflare R2 does not allow bucket creation via the S3 API (buckets must be
 # pre-created in the dashboard or via the Cloudflare API). Disable auto-create
 # automatically when the configured endpoint points at R2.
 OBJECT_STORAGE_AUTO_CREATE_BUCKETS = os.getenv(
     "OBJECT_STORAGE_AUTO_CREATE_BUCKETS",
-    "false" if ".r2.cloudflarestorage.com" in OBJECT_STORAGE_ENDPOINT_URL else "true",
+    "false" if _OBJECT_STORAGE_IS_R2 else "true",
 ).lower() == "true"
 
 # Backwards-compatible aliases — existing modules read these.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       pgbouncer:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      test: ["CMD", "curl", "--fail", "--silent", "--max-time", "8", "http://localhost:8001/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -199,7 +199,7 @@ services:
     networks:
       - oj_network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health/"]
+      test: ["CMD", "curl", "--fail", "--silent", "--max-time", "4", "http://localhost:8000/api/health/"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/scripts/r2/migrate-dev-minio-to-r2.sh
+++ b/scripts/r2/migrate-dev-minio-to-r2.sh
@@ -7,7 +7,7 @@ QJUDGE_DC="$PROJECT_ROOT/.codex/skills/qjudge-env-compose-owner/scripts/qjudge-d
 usage() {
   cat <<'USAGE' >&2
 Usage:
-  scripts/r2/migrate-dev-minio-to-r2.sh [--dry-run|--apply] [--prefix PREFIX] [--only raw|videos|markdown]
+  scripts/r2/migrate-dev-minio-to-r2.sh [--dry-run|--apply] [--prefix PREFIX] [--only raw|videos|markdown|artifacts]
 
 Copies local dev MinIO objects into the currently configured dev R2 buckets.
 This script never deletes source or target objects.
@@ -15,7 +15,7 @@ This script never deletes source or target objects.
 Defaults:
   mode: dry-run
   source endpoint: http://minio:9000
-  source buckets: anticheat-raw, anticheat-videos, markdown-images
+  source buckets: anticheat-raw, anticheat-videos, markdown-images, ai-artifacts
   target buckets: current Django settings / .env values
 
 Examples:
@@ -50,9 +50,9 @@ while [[ $# -gt 0 ]]; do
     --only)
       ONLY="${2:-}"
       case "$ONLY" in
-        raw|videos|markdown) ;;
+        raw|videos|markdown|artifacts) ;;
         *)
-          echo "--only must be one of: raw, videos, markdown" >&2
+          echo "--only must be one of: raw, videos, markdown, artifacts" >&2
           exit 2
           ;;
       esac
@@ -117,6 +117,7 @@ SOURCE_REGION = os.environ.get("MINIO_MIGRATION_SOURCE_REGION", "us-east-1")
 SOURCE_RAW_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_RAW_BUCKET", "anticheat-raw")
 SOURCE_VIDEO_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_VIDEO_BUCKET", "anticheat-videos")
 SOURCE_MARKDOWN_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_MARKDOWN_BUCKET", "markdown-images")
+SOURCE_ARTIFACT_BUCKET = os.environ.get("MINIO_MIGRATION_SOURCE_ARTIFACT_BUCKET", "ai-artifacts")
 
 if MODE not in {"dry-run", "apply"}:
     raise SystemExit(f"unsupported mode: {MODE}")
@@ -149,6 +150,7 @@ pairs = [
     BucketPair("raw", SOURCE_RAW_BUCKET, settings.ANTICHEAT_RAW_BUCKET),
     BucketPair("videos", SOURCE_VIDEO_BUCKET, settings.ANTICHEAT_VIDEO_BUCKET),
     BucketPair("markdown", SOURCE_MARKDOWN_BUCKET, settings.MARKDOWN_IMAGE_S3_BUCKET),
+    BucketPair("artifacts", SOURCE_ARTIFACT_BUCKET, settings.AI_ARTIFACT_S3_BUCKET),
 ]
 if ONLY:
     pairs = [pair for pair in pairs if pair.label == ONLY]


### PR DESCRIPTION
## Summary
Promote `dev` → `main` to ship two prod-affecting fixes:

- **#148 fix(storage): cover ai-artifacts in R2 migration and skip create_bucket on R2** — `_ensure_bucket_exists` no longer tries to `create_bucket` on R2; bucket-scoped tokens that 403 on HeadBucket are now treated as benign. Adds `AI_ARTIFACT_S3_BUCKET` plumbing and the missing `ai-artifacts` pair in `scripts/r2/migrate-dev-minio-to-r2.sh`.
- **6ad91662 fix(prod): install curl in backend image so healthcheck stops failing** — restores backend container healthcheck.

## Prod deploy notes
The R2 fix needs the following on the prod environment **before** the new image starts handling traffic (already done on `quan338` host, listed for the record):

1. Cloudflare R2 bucket `qjudge-ai-artifacts` exists and is added to the R2 API token's bucket scope. ✅ verified via `head_bucket` from the prod backend container.
2. `/home/quan/deploy/QJudge/.env` contains `AI_ARTIFACT_S3_BUCKET=qjudge-ai-artifacts`. ✅ added (backup at `.env.bak.1777192559`).
3. After deploy, restart `oj_backend` so it picks up the new env value.

## Test plan
- [x] Dev R2 migration: dry-run + apply for `--only artifacts` (48/48 copied, 0 errors).
- [x] Prod R2 token / bucket access verified from `oj_backend` container.
- [ ] After prod deploy: open an AI session with existing artifacts and confirm Artifact Panel can fetch rubric / grade.csv.
- [ ] After prod deploy: confirm `oj_backend` healthcheck returns to healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)