### PR TITLE
fix(i18n): hydrate user preferences globally

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import {
   RequireCompletedOnboarding,
   SettingsDialogProvider,
   SettingsDialog,
+  UserPreferencesHydrator,
 } from "@/features/auth";
 import { problemDetailRoutes, problemSolveRoutes } from "@/features/problems";
 import { classroomContestDetailRoutes, classroomContestAdminRoute, classroomExamPreviewRoute, classroomExamPrecheckRoute, classroomPracticeRoute } from "@/features/contest";
@@ -94,6 +95,7 @@ function App() {
               <ThemeProvider>
                 <MarkdownImageUploadProvider uploadImage={markdownImageUploader}>
                   <AuthProvider>
+                    <UserPreferencesHydrator />
                     <SettingsDialogProvider>
                     <RecurProviderBridge>
                     <BrowserRouter>

--- a/frontend/src/features/auth/components/UserPreferencesHydrator.tsx
+++ b/frontend/src/features/auth/components/UserPreferencesHydrator.tsx
@@ -1,0 +1,8 @@
+import { useUserPreferences } from "@/features/auth/hooks/useUserPreferences";
+
+const UserPreferencesHydrator = () => {
+  useUserPreferences();
+  return null;
+};
+
+export default UserPreferencesHydrator;

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -14,6 +14,7 @@ export { default as TeacherActivationScreen } from "./screens/TeacherActivationS
 export { default as AuthLayout } from "./components/layout/AuthLayout";
 export { default as ChangePasswordModal } from "./components/ChangePasswordModal";
 export { default as UserSettingsModal } from "./components/UserSettingsModal";
+export { default as UserPreferencesHydrator } from "./components/UserPreferencesHydrator";
 export {
   RequireAuth,
   RequireGuest,


### PR DESCRIPTION
## Summary
- Add a global user preferences hydrator under AuthProvider so authenticated full-page routes load saved preferences.
- Ensure student contest dashboard and exam pre-check routes apply the user's preferred language even when shared app chrome is not rendered.
- Keep a single root i18n provider; no additional I18nextProvider is introduced.

## Verification
- npm test -- useUserPreferences.test.ts
- npm run check:i18n
- npm run build
- pre-push hook: ESLint, TypeScript, frontend build, Docker Compose config

## Notes
- Existing API Key i18n strings are unrelated to this bug and are not removed in this PR.
- E2E was skipped by the local pre-push hook and should be covered by CI/manual run if needed.