### PR TITLE
fix: build MCP widgets during Docker image build

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,3 +1,21 @@
+FROM node:22-slim AS widget-builder
+
+WORKDIR /src
+
+COPY frontend/package.json frontend/package-lock.json ./frontend/
+RUN npm --prefix frontend ci
+
+COPY frontend/index.html \
+     frontend/tsconfig.json \
+     frontend/tsconfig.app.json \
+     frontend/tsconfig.node.json \
+     frontend/vite.config.ts \
+     ./frontend/
+COPY frontend/public ./frontend/public
+COPY frontend/src ./frontend/src
+
+RUN npm --prefix frontend run build
+
 FROM python:3.11-slim
 
 WORKDIR /app
@@ -6,7 +24,7 @@ COPY mcp-server/pyproject.toml .
 RUN pip install --no-cache-dir "mcp[cli]>=1.9.0" "httpx>=0.27.0"
 
 COPY mcp-server/ .
-COPY frontend/dist/mcp-widgets/ ./mcp-widgets/
+COPY --from=widget-builder /src/frontend/dist/mcp-widgets/ ./mcp-widgets/
 
 EXPOSE 9000
 

--- a/mcp-server/Dockerfile.dockerignore
+++ b/mcp-server/Dockerfile.dockerignore
@@ -2,6 +2,14 @@
 !mcp-server
 !mcp-server/**
 !frontend
-!frontend/dist
-!frontend/dist/mcp-widgets
-!frontend/dist/mcp-widgets/**
+!frontend/index.html
+!frontend/package.json
+!frontend/package-lock.json
+!frontend/tsconfig.json
+!frontend/tsconfig.app.json
+!frontend/tsconfig.node.json
+!frontend/vite.config.ts
+!frontend/public
+!frontend/public/**
+!frontend/src
+!frontend/src/**


### PR DESCRIPTION
## Summary
- build MCP widget assets inside the qjudge-mcp Docker image with a Node builder stage
- update Dockerfile-specific ignore rules so remote CD has the frontend build inputs without relying on committed dist artifacts

## Verification
- docker compose -f docker-compose.yml config -q
- docker compose -f docker-compose.dev.yml config -q
- mcp-server/.venv/bin/python -m pytest mcp-server/tests/test_server.py
- npm --prefix frontend run build
- git push pre-push hook: ESLint, TypeScript, frontend build, compose config

## Note
- Local docker compose build reached npm ci and no longer failed on missing frontend/dist/mcp-widgets. The local run then hit Docker Desktop BuildKit metadata I/O with only about 1.1GiB free disk, so final image verification is delegated to CI/CD.