### PR TITLE
refactor: share exam response adapters

### DIFF
--- a/backend/apps/contests/tests/test_backend_architecture_boundaries.py
+++ b/backend/apps/contests/tests/test_backend_architecture_boundaries.py
@@ -31,6 +31,21 @@ def test_question_bank_import_resolver_is_shared_by_contest_imports():
     assert "apps.question_bank.import_resolver" in contest_problem_source
 
 
+def test_device_conflict_response_adapter_is_shared_by_exam_views():
+    adapter_source = _read("apps/contests/views/exam_validation_response.py")
+    assert "def build_device_conflict_response_for_view" in adapter_source
+    assert "build_device_conflict_payload" in adapter_source
+
+    for path in [
+        "apps/contests/views/exam_answer.py",
+        "apps/contests/views/exam_anticheat.py",
+        "apps/contests/views/exam_question.py",
+    ]:
+        source = _read(path)
+        assert "build_device_conflict_response_for_view" in source
+        assert "Response(conflict_payload" not in source
+
+
 def test_contest_detail_cache_helper_has_been_removed():
     assert not (BACKEND_ROOT / "apps/contests/services/detail_cache.py").exists()
 

--- a/backend/apps/contests/tests/test_exam_service_boundaries.py
+++ b/backend/apps/contests/tests/test_exam_service_boundaries.py
@@ -11,6 +11,10 @@ from apps.contests.services.anti_cheat_session import (
     active_session_key,
 )
 from apps.contests.services.exam_validation import validate_exam_operation
+from apps.contests.views.exam_validation_response import (
+    build_device_conflict_response_for_view,
+    validate_exam_operation_for_view,
+)
 from apps.users.models import User
 
 
@@ -89,6 +93,41 @@ def test_validate_exam_operation_returns_participant_on_success_and_raises_valid
 
 
 @pytest.mark.django_db
+def test_validate_exam_operation_view_adapter_preserves_legacy_error_response(
+    teacher: User,
+    student: User,
+    published_contest: Contest,
+):
+    draft_contest = Contest.objects.create(
+        name="Draft View Adapter Contest",
+        owner=teacher,
+        status="draft",
+        visibility="private",
+        contest_type="paper_exam",
+    )
+
+    participant, response = validate_exam_operation_for_view(
+        draft_contest,
+        student,
+        allow_admin_bypass=False,
+    )
+
+    assert participant is None
+    assert response.status_code == 403
+    assert response.data == {"error": "Contest is not published."}
+
+    participant, response = validate_exam_operation_for_view(
+        published_contest,
+        student,
+        allow_admin_bypass=False,
+    )
+
+    assert participant is None
+    assert response.status_code == 400
+    assert response.data == {"error": "Not registered for this contest."}
+
+
+@pytest.mark.django_db
 def test_device_conflict_service_returns_payload_not_response(
     student: User,
     published_contest: Contest,
@@ -131,3 +170,28 @@ def test_device_conflict_service_returns_payload_not_response(
         metadata__existing_device_id="existing-device",
         metadata__incoming_device_id="incoming-device",
     ).exists()
+
+
+@pytest.mark.django_db
+def test_device_conflict_view_adapter_wraps_payload_as_legacy_response(
+    student: User,
+    published_contest: Contest,
+):
+    participant = ContestParticipant.objects.create(
+        contest=published_contest,
+        user=student,
+        exam_status=ExamStatus.IN_PROGRESS,
+        started_at=timezone.now(),
+    )
+    cache.set(
+        active_session_key(published_contest.id, student.id),
+        {"device_id": "existing-device"},
+        timeout=60,
+    )
+    request = APIRequestFactory().get("/", HTTP_X_DEVICE_ID="incoming-device")
+
+    response = build_device_conflict_response_for_view(published_contest, participant, request)
+
+    assert response.status_code == 409
+    assert response.data["code"] == "EXAM_ACTIVE_OTHER_DEVICE"
+    assert response.data["active_exam"]["contest_id"] == published_contest.id

--- a/backend/apps/contests/views/exam_answer.py
+++ b/backend/apps/contests/views/exam_answer.py
@@ -28,9 +28,11 @@ from ..serializers import (
 )
 from ..permissions import can_manage_contest
 from apps.core.api.envelope import envelope
-from ..services.anti_cheat_session import build_device_conflict_payload
 from ..services.question_edit_lock import maybe_lock_from_exam_answer
-from .exam_validation_response import validate_exam_operation_for_view
+from .exam_validation_response import (
+    build_device_conflict_response_for_view,
+    validate_exam_operation_for_view,
+)
 
 
 class ExamAnswerViewSet(viewsets.GenericViewSet):
@@ -184,9 +186,9 @@ class ExamAnswerViewSet(viewsets.GenericViewSet):
             return error_response
 
         # Device guard (hard block)
-        conflict_payload = build_device_conflict_payload(contest, participant, request)
-        if conflict_payload is not None:
-            return Response(conflict_payload, status=status.HTTP_409_CONFLICT)
+        conflict_response = build_device_conflict_response_for_view(contest, participant, request)
+        if conflict_response is not None:
+            return conflict_response
 
         serializer = ExamAnswerSubmitSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -238,9 +240,9 @@ class ExamAnswerViewSet(viewsets.GenericViewSet):
 
         # Device guard (hard block, skip if already submitted)
         if participant.exam_status != ExamStatus.SUBMITTED:
-            conflict_payload = build_device_conflict_payload(contest, participant, request)
-            if conflict_payload is not None:
-                return Response(conflict_payload, status=status.HTTP_409_CONFLICT)
+            conflict_response = build_device_conflict_response_for_view(contest, participant, request)
+            if conflict_response is not None:
+                return conflict_response
 
         answers = ExamAnswer.objects.filter(
             participant=participant

--- a/backend/apps/contests/views/exam_anticheat.py
+++ b/backend/apps/contests/views/exam_anticheat.py
@@ -19,7 +19,6 @@ from ..serializers import (
 )
 from ..permissions import can_manage_contest
 from ..services.anti_cheat_session import (
-    build_device_conflict_payload,
     clear_active_session,
     get_active_sessions,
     get_device_id,
@@ -33,7 +32,10 @@ from ..services.anticheat_storage import (
     get_s3_client,
 )
 from .activity import ContestActivityViewSet
-from .exam_validation_response import validate_exam_operation_for_view
+from .exam_validation_response import (
+    build_device_conflict_response_for_view,
+    validate_exam_operation_for_view,
+)
 from apps.core.throttles import ExamAnticheatUrlsThrottle
 from ..constants import WEBCAM_CAPTURE_INTERVAL_SECONDS
 
@@ -43,9 +45,9 @@ class ExamAnticheatMixin:
 
     def _ensure_active_device_session(self, contest, participant, request):
         """Delegate to the shared helper, then refresh the active session."""
-        conflict_payload = build_device_conflict_payload(contest, participant, request)
-        if conflict_payload is not None:
-            return Response(conflict_payload, status=status.HTTP_409_CONFLICT)
+        conflict_response = build_device_conflict_response_for_view(contest, participant, request)
+        if conflict_response is not None:
+            return conflict_response
         set_active_session(contest, participant, request, get_device_id(request))
         return None
 

--- a/backend/apps/contests/views/exam_question.py
+++ b/backend/apps/contests/views/exam_question.py
@@ -28,7 +28,6 @@ from ..serializers import (
     ExamQuestionStudentSerializer,
 )
 from ..permissions import can_manage_contest
-from ..services.anti_cheat_session import build_device_conflict_payload
 from ..services.export_service import (
     ExportValidationError,
     build_paper_exam_sheet_response,
@@ -36,6 +35,7 @@ from ..services.export_service import (
 )
 from ..services.question_edit_lock import ensure_contest_question_editable
 from .activity import ContestActivityViewSet
+from .exam_validation_response import build_device_conflict_response_for_view
 
 logger = logging.getLogger(__name__)
 
@@ -103,10 +103,7 @@ class ContestExamQuestionViewSet(viewsets.ModelViewSet):
         participant = contest.registrations.filter(user=self.request.user).first()
         if not participant or participant.exam_status == ExamStatus.SUBMITTED:
             return None
-        conflict_payload = build_device_conflict_payload(contest, participant, self.request)
-        if conflict_payload is None:
-            return None
-        return Response(conflict_payload, status=status.HTTP_409_CONFLICT)
+        return build_device_conflict_response_for_view(contest, participant, self.request)
 
     # Aliases consumed by the `?kind=` filter in addition to raw enum values.
     _KIND_ALIAS = {

--- a/backend/apps/contests/views/exam_validation_response.py
+++ b/backend/apps/contests/views/exam_validation_response.py
@@ -1,9 +1,10 @@
-"""View-layer adapters for exam validation errors."""
+"""View-layer adapters for legacy exam endpoint responses."""
 
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 
+from ..services.anti_cheat_session import build_device_conflict_payload
 from ..services.exam_validation import validate_exam_operation
 
 
@@ -31,3 +32,11 @@ def validate_exam_operation_for_view(*args, **kwargs):
             {"error": message},
             status=getattr(exc, "status_code", status.HTTP_400_BAD_REQUEST),
         )
+
+
+def build_device_conflict_response_for_view(contest, participant, request) -> Response | None:
+    """Return a legacy 409 response for active-device conflicts."""
+    conflict_payload = build_device_conflict_payload(contest, participant, request)
+    if conflict_payload is None:
+        return None
+    return Response(conflict_payload, status=status.HTTP_409_CONFLICT)


### PR DESCRIPTION
## Summary
- Add `build_device_conflict_response_for_view` so hard-blocking exam views share one 409 response adapter instead of repeating `Response(conflict_payload, status=409)`.
- Add direct adapter tests for `validate_exam_operation_for_view` legacy wire format and device-conflict response wrapping.
- Add an architecture guard that keeps exam hard-block views on the shared conflict response adapter.

## Context
- Follow-up to merged PR #164. That PR merged before the review follow-up commit landed, so this branch is rebased from latest `origin/main` and contains only the adapter follow-up.
- `submissions/views.py` intentionally keeps its existing generic `PermissionDenied` response and does not expose `active_exam` details in this PR.

## Testing
- `.codex/skills/qjudge-env-compose-owner/scripts/qjudge-dc.sh test exec -T backend pytest -q apps/contests/tests/test_exam_service_boundaries.py apps/contests/tests/test_backend_architecture_boundaries.py apps/contests/tests/test_exam_anticheat.py apps/contests/tests/exam/test_exam_answers.py apps/contests/tests/exam/test_exam_questions_api.py` -> 129 passed in 17.37s.
- Pre-push hook passed: frontend ESLint had 0 errors / 407 warnings, TypeScript compile passed, frontend build passed, Docker Compose config valid; E2E was skipped by the hook.