### PR TITLE
fix(attendance): keep manualCode narrowing through async IIFE

### DIFF
--- a/frontend/src/features/contest/screens/attendance/StudentAttendanceScanScreen.tsx
+++ b/frontend/src/features/contest/screens/attendance/StudentAttendanceScanScreen.tsx
@@ -335,13 +335,14 @@ export default function StudentAttendanceScanScreen() {
 
     // Manual code: validate against the backend before proceeding
     if (!contestId) return undefined;
+    const manualCode = pendingScan.manualCode;
     let cancelled = false;
     (async () => {
       try {
         await validateAttendanceManualCode(
           contestId,
           pendingScan.purpose,
-          pendingScan.manualCode,
+          manualCode,
         );
         if (cancelled) return;
         setScan(pendingScan);


### PR DESCRIPTION
## Summary
- TypeScript build on main fails after PR #174 because `pendingScan.manualCode` (typed `string | undefined`) loses its narrowing inside the async IIFE that calls `validateAttendanceManualCode`.
- Capture `pendingScan.manualCode` into a local `const` immediately after the early-return guard so the narrowed value flows into the closure.

## Root cause
Object property narrowing does not propagate into async closures, so even with `if (!pendingScan.manualCode) return …` earlier in the effect, TS treats `pendingScan.manualCode` as `string | undefined` again inside `(async () => …)()`.

## Test plan
- [x] `cd frontend && npx tsc -b` passes locally
- [ ] CI: Frontend Build Check goes green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)