### PR TITLE
fix: make healthcheck R2 and celery queue aware

### DIFF
--- a/backend/apps/core/management/commands/healthcheck.py
+++ b/backend/apps/core/management/commands/healthcheck.py
@@ -77,24 +77,49 @@ class Command(BaseCommand):
     def _check_object_storage_connection(self):
         from apps.contests.services.anticheat_storage import get_s3_client
 
+        buckets = self._configured_object_storage_buckets()
+        if not buckets:
+            return False, "no object storage buckets configured"
+
         client = get_s3_client()
-        client.list_buckets()
+        label, bucket = buckets[0]
+        client.list_objects_v2(Bucket=bucket, MaxKeys=0)
         endpoint = settings.OBJECT_STORAGE_ENDPOINT_URL
-        return True, f"connected to {endpoint}"
+        return True, f"connected to {endpoint}; probed {label} bucket '{bucket}'"
 
     def _check_object_storage_buckets(self):
         from apps.contests.services.anticheat_storage import get_s3_client
 
         client = get_s3_client()
-        existing = {b["Name"] for b in client.list_buckets()["Buckets"]}
-        required = {settings.ANTICHEAT_RAW_BUCKET}
-        missing = required - existing
-        if missing:
-            return False, f"missing buckets: {', '.join(sorted(missing))}"
-        return True, f"buckets present: {', '.join(sorted(required))}"
+        required = self._configured_object_storage_buckets()
+        if not required:
+            return False, "no object storage buckets configured"
+
+        for _label, bucket in required:
+            client.head_bucket(Bucket=bucket)
+
+        bucket_names = ", ".join(bucket for _label, bucket in required)
+        return True, f"buckets reachable: {bucket_names}"
+
+    def _configured_object_storage_buckets(self):
+        raw_buckets = [
+            ("anticheat_raw", getattr(settings, "ANTICHEAT_RAW_BUCKET", "")),
+            ("markdown_images", getattr(settings, "MARKDOWN_IMAGE_S3_BUCKET", "")),
+            ("ai_artifacts", getattr(settings, "AI_ARTIFACT_S3_BUCKET", "")),
+        ]
+        buckets = []
+        seen = set()
+        for label, bucket in raw_buckets:
+            bucket_name = (bucket or "").strip()
+            if not bucket_name or bucket_name in seen:
+                continue
+            buckets.append((label, bucket_name))
+            seen.add(bucket_name)
+        return buckets
 
     def _check_celery_default(self):
-        return self._ping_celery_queue("celery")
+        queue_name = getattr(settings, "CELERY_TASK_DEFAULT_QUEUE", "celery")
+        return self._ping_celery_queue(queue_name)
 
     def _ping_celery_queue(self, queue_name):
         from config.celery import app as celery_app
@@ -107,7 +132,16 @@ class Command(BaseCommand):
                 if q.get("name") == queue_name:
                     return True, f"worker={worker_name}"
 
-        return False, f"no worker consuming '{queue_name}'"
+        active_queue_names = sorted(
+            {
+                q.get("name")
+                for queues in active_queues.values()
+                for q in queues
+                if q.get("name")
+            }
+        )
+        active_detail = ", ".join(active_queue_names) if active_queue_names else "none"
+        return False, f"no worker consuming '{queue_name}' (active: {active_detail})"
 
     def _check_celery_beat(self):
         """Check beat scheduler — best-effort, non-fatal if unreachable."""

--- a/backend/apps/core/tests/test_healthcheck.py
+++ b/backend/apps/core/tests/test_healthcheck.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock, call, patch
+
+from django.test import SimpleTestCase, override_settings
+
+from apps.core.management.commands.healthcheck import Command
+
+
+class HealthcheckCommandTests(SimpleTestCase):
+    @override_settings(
+        OBJECT_STORAGE_ENDPOINT_URL="https://example.r2.cloudflarestorage.com",
+        ANTICHEAT_RAW_BUCKET="qjudge-anticheat-raw",
+        MARKDOWN_IMAGE_S3_BUCKET="qjudge-markdown-images",
+        AI_ARTIFACT_S3_BUCKET="qjudge-ai-artifacts",
+    )
+    @patch("apps.contests.services.anticheat_storage.get_s3_client")
+    def test_object_storage_connection_uses_bucket_scoped_probe(self, mock_get_client):
+        client = MagicMock()
+        mock_get_client.return_value = client
+
+        ok, detail = Command()._check_object_storage_connection()
+
+        self.assertTrue(ok)
+        self.assertIn("qjudge-anticheat-raw", detail)
+        client.list_objects_v2.assert_called_once_with(
+            Bucket="qjudge-anticheat-raw",
+            MaxKeys=0,
+        )
+        client.list_buckets.assert_not_called()
+
+    @override_settings(
+        ANTICHEAT_RAW_BUCKET="qjudge-anticheat-raw",
+        MARKDOWN_IMAGE_S3_BUCKET="qjudge-markdown-images",
+        AI_ARTIFACT_S3_BUCKET="qjudge-ai-artifacts",
+    )
+    @patch("apps.contests.services.anticheat_storage.get_s3_client")
+    def test_object_storage_buckets_use_head_bucket(self, mock_get_client):
+        client = MagicMock()
+        mock_get_client.return_value = client
+
+        ok, detail = Command()._check_object_storage_buckets()
+
+        self.assertTrue(ok)
+        self.assertIn("qjudge-ai-artifacts", detail)
+        client.head_bucket.assert_has_calls(
+            [
+                call(Bucket="qjudge-anticheat-raw"),
+                call(Bucket="qjudge-markdown-images"),
+                call(Bucket="qjudge-ai-artifacts"),
+            ]
+        )
+        client.list_buckets.assert_not_called()
+
+    @override_settings(CELERY_TASK_DEFAULT_QUEUE="default")
+    @patch.object(Command, "_ping_celery_queue")
+    def test_celery_default_uses_configured_default_queue(self, mock_ping):
+        mock_ping.return_value = (True, "worker=celery@worker")
+
+        ok, detail = Command()._check_celery_default()
+
+        self.assertTrue(ok)
+        self.assertEqual(detail, "worker=celery@worker")
+        mock_ping.assert_called_once_with("default")
+
+    def test_celery_queue_failure_reports_active_queues(self):
+        command = Command()
+        active_queues = {
+            "celery@worker-1": [{"name": "default"}],
+            "celery@worker-2": [{"name": "high_priority"}],
+        }
+        inspector = MagicMock()
+        inspector.active_queues.return_value = active_queues
+        celery_app = MagicMock()
+        celery_app.control.inspect.return_value = inspector
+
+        with patch("config.celery.app", celery_app):
+            ok, detail = command._ping_celery_queue("celery")
+
+        self.assertFalse(ok)
+        self.assertEqual(
+            detail,
+            "no worker consuming 'celery' (active: default, high_priority)",
+        )


### PR DESCRIPTION
## Summary\n- replace account-wide S3 list_buckets healthcheck probes with bucket-scoped R2-compatible checks\n- check all configured object storage buckets used by anticheat, markdown images, and AI artifacts\n- use CELERY_TASK_DEFAULT_QUEUE for the default Celery healthcheck and report active queues on mismatch\n\n## Verification\n- python3 -m py_compile backend/apps/core/management/commands/healthcheck.py backend/apps/core/tests/test_healthcheck.py\n- git diff --check -- backend/apps/core/management/commands/healthcheck.py backend/apps/core/tests/test_healthcheck.py\n- pre-push hook: frontend ESLint, TypeScript compile, frontend build, Docker Compose config\n\nNote: local host Python does not have Django and local Docker daemon is not running, so backend test execution is left to GitHub CI.