### PR TITLE
fix(auth): filter registration campus providers

### DIFF
--- a/frontend/src/features/auth/screens/AuthProviderOptionsScreen.test.tsx
+++ b/frontend/src/features/auth/screens/AuthProviderOptionsScreen.test.tsx
@@ -192,4 +192,31 @@ describe("auth provider options", () => {
     expect(await screen.findByText("Test University")).toBeInTheDocument();
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
+
+  it("filters registration campus providers by registration support", async () => {
+    mockGetAuthOptions.mockResolvedValue({
+      ...authOptions,
+      data: {
+        ...authOptions.data,
+        providers: [
+          ...authOptions.data.providers,
+          {
+            key: "school-login-only",
+            category: "campus",
+            display_name: "Login Only University",
+            supports_registration: false,
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/register/campus-sso"]}>
+        <CampusSsoScreen />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Test University")).toBeInTheDocument();
+    expect(screen.queryByText("Login Only University")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/auth/screens/CampusSsoScreen.tsx
+++ b/frontend/src/features/auth/screens/CampusSsoScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { InlineLoading } from "@carbon/react";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 import type { AuthProviderOption } from "@/core/entities/auth.entity";
 import { getOAuthUrl } from "@/infrastructure/api/repositories/auth.repository";
 import { useAuthOptions } from "@/features/auth/hooks";
@@ -23,12 +24,16 @@ const ProviderLogo = ({ provider, alt }: { provider: AuthProviderOption; alt: st
 
 const CampusSsoScreen = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const { options } = useAuthOptions();
   // Auto-syncs query params (e.g. teacher_activation_token) → sessionStorage
   usePendingActions();
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState("");
-  const campusProviders = options.providers.filter((provider) => provider.category === "campus");
+  const isRegistrationSso = location.pathname.startsWith("/register/campus-sso");
+  const campusProviders = options.providers.filter(
+    (provider) => provider.category === "campus" && (!isRegistrationSso || provider.supports_registration),
+  );
 
   const handleSsoLogin = async (providerId: string) => {
     try {


### PR DESCRIPTION
## 變更目標
- 修復 Codex P2 feedback：`/register/campus-sso` 只顯示 `supports_registration: true` 的 campus providers。
- 保持 `/login/campus-sso` 行為不變，仍顯示所有 campus providers。

## 影響範圍
- `frontend/src/features/auth/screens/CampusSsoScreen.tsx`
- `frontend/src/features/auth/screens/AuthProviderOptionsScreen.test.tsx`

## 驗證
- `npm test -- AuthProviderOptionsScreen.test.tsx`：通過，8 tests。
- `npm run check:i18n`：通過。
- `bash .codex/skills/qjudge-quality-gates-owner/scripts/check-carbon-style.sh`：通過。
- `npm run build`：通過；仍有既有 `_scrollbar.scss` slash-div deprecation 與 chunk size warning。
- `node .codex/skills/qjudge-quality-gates-owner/scripts/lint-architecture.js --root frontend/src`：通過。
- `node .codex/skills/qjudge-quality-gates-owner/scripts/lint-naming.js --root frontend/src`：仍失敗於 repo-wide 既有命名違規，本次修改檔案未新增違規。
- pre-push hook：ESLint / TypeScript / frontend build / Docker Compose config 通過；hook 內 E2E 依既有設定跳過。

## 風險與回滾
- 風險低，邏輯只依目前路徑區分登入/註冊 SSO provider 清單。
- 回滾方式：revert 此 PR。