### PR TITLE
fix(auth): add campus sso verification actions

### DIFF
--- a/frontend/src/features/auth/components/layout/AuthLayout.tsx
+++ b/frontend/src/features/auth/components/layout/AuthLayout.tsx
@@ -72,15 +72,9 @@ const AuthLayout = () => {
       };
     }
     if (path.startsWith('/login/campus-sso') || path.startsWith('/register/campus-sso')) {
-      const isRegistrationSso = path.startsWith('/register/campus-sso');
-
       return {
         title: t("auth.campusSso.title"),
         subtitle: t("auth.campusSso.subtitle"),
-        backTo: isRegistrationSso ? '/register' : '/login',
-        backLabel: isRegistrationSso
-          ? t("auth.campusSso.backToRegister", "返回建立帳號")
-          : t("auth.campusSso.backToLogin", "返回登入"),
       };
     }
     if (path.startsWith('/auth/')) {

--- a/frontend/src/features/auth/screens/AuthProviderOptionsScreen.test.tsx
+++ b/frontend/src/features/auth/screens/AuthProviderOptionsScreen.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -78,6 +78,35 @@ function renderLoginWithLayout() {
   );
 }
 
+function renderCampusSsoRoute(initialPath: "/login/campus-sso" | "/register/campus-sso") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/login/campus-sso"
+          element={
+            <>
+              <CampusSsoScreen />
+              <CurrentPath />
+            </>
+          }
+        />
+        <Route
+          path="/register/campus-sso"
+          element={
+            <>
+              <CampusSsoScreen />
+              <CurrentPath />
+            </>
+          }
+        />
+        <Route path="/login" element={<CurrentPath />} />
+        <Route path="/register" element={<CurrentPath />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 const CurrentPath = () => {
   const location = useLocation();
   return <div data-testid="current-path">{location.pathname}</div>;
@@ -87,6 +116,7 @@ describe("auth provider options", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAuthOptions.mockResolvedValue(authOptions);
+    mockGetOAuthUrl.mockResolvedValue("#campus-sso");
   });
 
   it("hides email/password login when disabled and renders dynamic social providers", async () => {
@@ -187,10 +217,39 @@ describe("auth provider options", () => {
   });
 
   it("renders only campus providers on the campus SSO screen", async () => {
-    renderWithRouter(<CampusSsoScreen />);
+    renderCampusSsoRoute("/login/campus-sso");
 
     expect(await screen.findByText("Test University")).toBeInTheDocument();
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+    expect(screen.getByTestId("auth-campus-sso-back")).toHaveTextContent("返回登入");
+    expect(screen.getByTestId("auth-campus-sso-submit")).toBeDisabled();
+    expect(screen.getByTestId("auth-campus-sso-mobile-submit")).toBeDisabled();
+  });
+
+  it("requires selecting a campus provider before verification", async () => {
+    renderCampusSsoRoute("/login/campus-sso");
+
+    const provider = await screen.findByRole("button", { name: /Test University/ });
+    const submit = screen.getByTestId("auth-campus-sso-submit");
+
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(provider);
+    expect(provider).toHaveAttribute("aria-pressed", "true");
+    expect(submit).toBeEnabled();
+
+    fireEvent.click(submit);
+    await waitFor(() => expect(mockGetOAuthUrl).toHaveBeenCalledWith("school-x"));
+  });
+
+  it("returns to the originating registration screen from campus SSO", async () => {
+    renderCampusSsoRoute("/register/campus-sso");
+
+    expect(await screen.findByText("Test University")).toBeInTheDocument();
+    expect(screen.getByTestId("auth-campus-sso-back")).toHaveTextContent("返回建立帳號");
+
+    fireEvent.click(screen.getByTestId("auth-campus-sso-back"));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/register");
   });
 
   it("filters registration campus providers by registration support", async () => {

--- a/frontend/src/features/auth/screens/AuthProviders.scss
+++ b/frontend/src/features/auth/screens/AuthProviders.scss
@@ -75,6 +75,11 @@
     background-color: $layer-selected-01;
   }
 
+  &[data-selected="true"] {
+    background-color: $layer-selected-01;
+    border-color: $focus;
+  }
+
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -88,6 +93,19 @@
 
 .auth-school-list-status {
   margin-top: $spacing-05;
+}
+
+.auth-campus-sso-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: $spacing-03;
+  margin-top: $spacing-05;
+}
+
+.auth-campus-sso-action-btn {
+  width: 100%;
+  max-width: none;
+  justify-content: space-between;
 }
 
 .auth-oauth-group {

--- a/frontend/src/features/auth/screens/CampusSsoScreen.tsx
+++ b/frontend/src/features/auth/screens/CampusSsoScreen.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
-import { InlineLoading } from "@carbon/react";
+import { Button, InlineLoading } from "@carbon/react";
+import { ArrowRight } from "@carbon/icons-react";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import type { AuthProviderOption } from "@/core/entities/auth.entity";
 import { getOAuthUrl } from "@/infrastructure/api/repositories/auth.repository";
 import { useAuthOptions } from "@/features/auth/hooks";
 import { usePendingActions, PendingActionBanner } from "@/features/auth/pending-actions";
 import { getProviderDescription, getProviderDisplayName } from "@/features/auth/utils/authProviderLabels";
+import { MobileActionFooter } from "@/shared/ui/MobileActionFooter";
 
 const ProviderLogo = ({ provider, alt }: { provider: AuthProviderOption; alt: string }) => {
   if (provider.logo_url) {
@@ -25,15 +27,24 @@ const ProviderLogo = ({ provider, alt }: { provider: AuthProviderOption; alt: st
 const CampusSsoScreen = () => {
   const { t } = useTranslation();
   const location = useLocation();
+  const navigate = useNavigate();
   const { options } = useAuthOptions();
   // Auto-syncs query params (e.g. teacher_activation_token) → sessionStorage
-  usePendingActions();
+  const { buildAuthLink } = usePendingActions();
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const [selectedProviderKey, setSelectedProviderKey] = useState<string | null>(null);
   const isRegistrationSso = location.pathname.startsWith("/register/campus-sso");
+  const backPath = isRegistrationSso ? "/register" : "/login";
+  const backLabel = isRegistrationSso
+    ? t("auth.campusSso.backToRegister", "返回建立帳號")
+    : t("auth.campusSso.backToLogin", "返回登入");
+  const verifyLabel = t("auth.campusSso.verify", "驗證");
   const campusProviders = options.providers.filter(
     (provider) => provider.category === "campus" && (!isRegistrationSso || provider.supports_registration),
   );
+  const selectedProvider = campusProviders.find((provider) => provider.key === selectedProviderKey);
+  const isAuthenticating = loading !== null;
 
   const handleSsoLogin = async (providerId: string) => {
     try {
@@ -47,6 +58,15 @@ const CampusSsoScreen = () => {
     }
   };
 
+  const handleBack = () => {
+    navigate(buildAuthLink(backPath));
+  };
+
+  const handleVerify = () => {
+    if (!selectedProvider || isAuthenticating) return;
+    void handleSsoLogin(selectedProvider.key);
+  };
+
   return (
     <>
       <div className="auth-form">
@@ -55,14 +75,17 @@ const CampusSsoScreen = () => {
           {campusProviders.map((provider) => {
             const displayName = getProviderDisplayName(t, provider);
             const description = getProviderDescription(t, provider);
+            const isSelected = selectedProviderKey === provider.key;
 
             return (
               <button
                 key={provider.key}
                 type="button"
                 className="auth-school-list-item"
-                onClick={() => handleSsoLogin(provider.key)}
-                disabled={loading !== null}
+                aria-pressed={isSelected}
+                data-selected={isSelected ? "true" : undefined}
+                onClick={() => setSelectedProviderKey(provider.key)}
+                disabled={isAuthenticating}
               >
                 <div className="auth-school-list-item__logo-container">
                   <ProviderLogo provider={provider} alt={displayName} />
@@ -83,7 +106,53 @@ const CampusSsoScreen = () => {
         )}
 
         {error && <p className="auth-error">{error}</p>}
+
+        <div className="auth-actions auth-actions--desktop-submit auth-campus-sso-actions">
+          <Button
+            kind="secondary"
+            type="button"
+            className="auth-campus-sso-action-btn"
+            onClick={handleBack}
+            data-testid="auth-campus-sso-back"
+          >
+            {backLabel}
+          </Button>
+          <Button
+            kind="primary"
+            type="button"
+            className="auth-campus-sso-action-btn"
+            disabled={!selectedProvider || isAuthenticating}
+            onClick={handleVerify}
+            renderIcon={ArrowRight}
+            data-testid="auth-campus-sso-submit"
+          >
+            {verifyLabel}
+          </Button>
+        </div>
       </div>
+
+      <MobileActionFooter>
+        <Button
+          kind="secondary"
+          size="2xl"
+          type="button"
+          onClick={handleBack}
+          data-testid="auth-campus-sso-mobile-back"
+        >
+          {backLabel}
+        </Button>
+        <Button
+          kind="primary"
+          size="2xl"
+          type="button"
+          disabled={!selectedProvider || isAuthenticating}
+          onClick={handleVerify}
+          renderIcon={ArrowRight}
+          data-testid="auth-campus-sso-mobile-submit"
+        >
+          {verifyLabel}
+        </Button>
+      </MobileActionFooter>
     </>
   );
 };

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -38,7 +38,8 @@
       "backToRegister": "Back to create account",
       "redirecting": "Redirecting to campus login...",
       "subtitle": "Select your university to login",
-      "title": "Campus Authentication"
+      "title": "Campus Authentication",
+      "verify": "Verify"
     },
     "providerActions": {
       "loginWith": "Login with {{provider}}",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -38,7 +38,8 @@
       "backToRegister": "アカウント作成に戻る",
       "redirecting": "ログインページにリダイレクト中...",
       "subtitle": "ログインする大学を選択してください",
-      "title": "キャンパス認証"
+      "title": "キャンパス認証",
+      "verify": "認証"
     },
     "providerActions": {
       "loginWith": "{{provider}} でログイン",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -38,7 +38,8 @@
       "backToRegister": "계정 만들기로 돌아가기",
       "redirecting": "캠퍼스 로그인 페이지로 이동 중...",
       "subtitle": "로그인할 대학교를 선택하세요",
-      "title": "캠퍼스 인증"
+      "title": "캠퍼스 인증",
+      "verify": "인증"
     },
     "providerActions": {
       "loginWith": "{{provider}} 로 로그인",

--- a/frontend/src/i18n/locales/zh-TW/common.json
+++ b/frontend/src/i18n/locales/zh-TW/common.json
@@ -38,7 +38,8 @@
       "backToRegister": "返回建立帳號",
       "redirecting": "正在導向校園驗證頁面...",
       "subtitle": "選擇您的學校進行身份驗證登入",
-      "title": "校園身份驗證"
+      "title": "校園身份驗證",
+      "verify": "驗證"
     },
     "providerActions": {
       "loginWith": "使用 {{provider}} 登入",


### PR DESCRIPTION
## Summary
- Change campus SSO from immediate provider redirect to explicit school selection plus Verify action.
- Add route-aware Back / Verify actions for both desktop and mobile footer layouts.
- Add synced campus SSO `verify` i18n text and focused tests for the new flow.

## Non-goals
- No backend auth provider changes.
- No unrelated auth layout refactor beyond moving campus return action into the button group.

## Testing
- `npm test -- AuthProviderOptionsScreen.test.tsx`
- `npm run check:i18n`
- `bash .codex/skills/qjudge-quality-gates-owner/scripts/check-carbon-style.sh`
- `npm run build`
- Playwright mobile geometry check for `/login/campus-sso` at 390x844
- `node .codex/skills/qjudge-quality-gates-owner/scripts/lint-architecture.js --root frontend/src`
- Pre-push hook: frontend ESLint, TypeScript, build, Docker Compose config

## Notes
- `node .codex/skills/qjudge-quality-gates-owner/scripts/lint-naming.js --root frontend/src` still reports pre-existing repo-wide naming violations; none are in the files changed by this PR.

## Risk / rollback
- Low risk, scoped to auth campus SSO UI. Roll back this commit to restore immediate provider redirect behavior.