### PR TITLE
fix(infra): harden production release readiness

### DIFF
--- a/.codex/skills/qjudge-carbon-overflow-ux-fix/SKILL.md
+++ b/.codex/skills/qjudge-carbon-overflow-ux-fix/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: qjudge-carbon-overflow-ux-fix
+description: Use when QJudge Carbon React pages show double scrollbars, clipped content, broken split-pane height chains, mobile viewport jumps, or header/sidenav layout collisions.
+metadata:
+  version: "2026.08.12"
+  carbon_mcp_verified: "2026-08-12"
+  carbon_framework: "v11"
+  carbon_reference_tag: "v11.113.0"
+---
+
+# QJudge Carbon Overflow UX Fix
+
+## Quick start
+- 先讀 `references/overflow-layout-playbook.md`。
+- 目標是「每個視圖只保留一個主垂直捲動容器」。
+- 在 full-bleed 管理頁，優先用固定殼層（`position: fixed; inset: 0`）而不是讓 `body` 捲動。
+- Mobile/full-height shell 優先以 `min-height: 100dvh` 表達動態 viewport；只有明確 fallback 需求才同時保留 `100vh`。
+
+## 必守規則
+- 同一視圖不要同時讓「外層 page」與「內層 panel」都 `overflow-y: auto`。
+- 所有 flex/grid 高度鏈節點都要補 `min-height: 0`（必要時 `min-width: 0`）。
+- `height: 100%` 只能用在有明確高度參考的父層；否則改 `flex: 1` + `min-height: 0`。
+- header/sidenav 固定時，內容區需用明確幾何（`top/left/right/bottom`）或等價 grid，避免隱性超出。
+- Carbon 元件可覆寫容器 class，但不要直接覆蓋 `.cds--*` 內部行為來硬解。
+- Safe-area padding 由 shared shell/footer 統一處理，不在 feature panel 重複加入。
+
+## 標準流程
+1. 盤點 scroll owner
+- 搜尋：`rg -n "overflow-y|overflow|height:\s*100%|min-height:\s*0|100vh|100dvh|position:\s*fixed" frontend/src/features/...`
+- 找出哪個容器應是唯一 scroll owner（通常是 pane/list/content 之一）。
+
+2. 建立高度鏈
+- 從最外層到 scroll owner，逐層確保：
+  - `display: flex | grid`
+  - `min-height: 0`
+  - 非 scroll owner 一律 `overflow: hidden`
+
+3. 套用布局模式
+- Full-bleed admin：固定殼層 + 內容 viewport（見 reference Pattern A）
+- Split pane：左樹右內容或三欄時，只有指定 pane 可捲（見 Pattern B）
+
+4. 收斂 panel 契約
+- 每個 panel 僅二擇一：
+  - 自己 `overflow-y: auto`
+  - 交給下一層子容器捲
+- 不接受父子都可捲。
+
+5. 驗證
+- 桌機尺寸至少驗證 `1366x768` 與 `1920x1080`。
+- 手機至少驗證 `390x844`、`393x852` 與 landscape；檢查 dynamic viewport、virtual keyboard 與 `safe-area-inset-bottom`。
+- 檢查只有一條主捲軸、header/footer 固定可見、列表區單獨捲動。
+- Light/Dark 都要看對比與裁切。
+- 跑最小測試 + `npm run build`。
+- 跑 `bash .codex/skills/qjudge-quality-gates-owner/scripts/check-carbon-style.sh --staged`，確保沒有用 Carbon internal selector 隱藏 overflow 症狀。
+
+## 回歸檢查清單
+- 視圖沒有雙垂直捲軸。
+- 不會出現水平捲軸閃現。
+- 切換 panel 不會殘留上一個 panel 的滾動行為。
+- 手機尺寸下不破版（必要時改單欄）。
+
+## If blocked
+- 若第三方元件（圖表/編輯器）強制內部捲動，先鎖定外層不捲，僅保留其內層捲動，再依需求包一層 viewport 做裁切。
+- 若需求要求「header/footer 固定 + 中段捲動」，優先拆成 `header + body + footer` 三段式，不要用單一大容器混排。

--- a/.codex/skills/qjudge-carbon-overflow-ux-fix/references/overflow-layout-playbook.md
+++ b/.codex/skills/qjudge-carbon-overflow-ux-fix/references/overflow-layout-playbook.md
@@ -1,0 +1,125 @@
+# Overflow Layout Playbook (QJudge + Carbon)
+
+## Pattern A: Full-bleed Admin Shell（避免 page + panel 雙捲動）
+
+適用：
+- `/contests/:contestId/admin` 類型頁面
+- 有固定 header / rail sidenav
+
+```scss
+.layout {
+  position: fixed;
+  inset: 0;
+  min-height: 100dvh;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+}
+
+.content {
+  position: absolute;
+  top: 3rem;   // header
+  left: 3rem;  // rail
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+}
+
+.contentViewport {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+```
+
+要點：
+- `body` 不捲，panel 自己決定是否捲。
+- 內容區用幾何定位鎖住可視範圍。
+
+## Pattern B: Split Pane（左側清單 + 右側內容）
+
+```scss
+.root {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.leftPane {
+  width: 260px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.rightPane {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto; // 唯一 scroll owner
+}
+```
+
+要點：
+- 左右 pane 都先 `min-height: 0`。
+- 只有一邊 `overflow-y: auto`。
+
+## Pattern C: Header + Body + Footer（中段獨立捲動）
+
+```scss
+.panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.panelHeader,
+.panelFooter {
+  flex-shrink: 0;
+}
+
+.panelBody {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto; // 唯一 scroll owner
+}
+```
+
+## 常見反模式（避免）
+
+1. 父層 `overflow-y: auto` + 子層 `overflow-y: auto`
+2. 只寫 `height: 100%`，但祖先沒有明確高度
+3. flex 子元素漏掉 `min-height: 0`，導致內容把父層撐爆
+4. 用 `margin/padding` 模擬 header 高度，卻沒鎖定內容區邊界
+5. 在 `.cds--*` 內部 class 硬改 overflow，造成 Carbon 行為不可預期
+6. Mobile shell 只使用 `100vh`，造成瀏覽器 chrome 或虛擬鍵盤改變可視高度時跳動
+
+## DevTools 快速定位
+
+1. 先找哪個元素在滾：
+- Console:
+```js
+[...document.querySelectorAll('*')].filter((el) => {
+  const s = getComputedStyle(el);
+  return /(auto|scroll)/.test(s.overflowY) && el.scrollHeight > el.clientHeight;
+});
+```
+2. 看主視窗是否也在捲：
+- `document.documentElement.scrollHeight > window.innerHeight`
+3. 用 Elements 面板沿 DOM 往上檢查是否缺 `min-height: 0`。
+
+## 驗收標準
+- 僅保留預期的一條垂直捲軸。
+- 內容切換時，捲動行為穩定不跳動。
+- Light/Dark 下沒有層次錯位或裁切。
+- `390x844`、桌機 `1366x768` 與 200% zoom 下仍可抵達最後一個 focusable element。

--- a/.codex/skills/qjudge-quality-gates-owner/scripts/carbon-skills.test.js
+++ b/.codex/skills/qjudge-quality-gates-owner/scripts/carbon-skills.test.js
@@ -2,7 +2,6 @@
 
 const assert = require("node:assert/strict");
 const { readFileSync } = require("node:fs");
-const { homedir } = require("node:os");
 const { join, resolve } = require("node:path");
 const test = require("node:test");
 
@@ -12,7 +11,10 @@ const projectSkills = [
   join(repoRoot, ".codex/skills/qjudge-quality-gates-owner/SKILL.md"),
   join(repoRoot, ".codex/skills/qjudge-mobile-action-footer/SKILL.md"),
 ];
-const overflowSkill = join(homedir(), ".codex/skills/qjudge-carbon-overflow-ux-fix/SKILL.md");
+const overflowSkill = join(
+  repoRoot,
+  ".codex/skills/qjudge-carbon-overflow-ux-fix/SKILL.md",
+);
 
 test("Carbon skills record the current MCP verification snapshot", () => {
   for (const skillPath of [...projectSkills, overflowSkill]) {
@@ -43,7 +45,12 @@ test("UI owner covers current component, accessibility, and public API decisions
   ]) {
     assert.match(policy, new RegExp(topic), topic);
   }
-  assert.doesNotMatch(policy, /selectorsFloatingMenus=\{\['\.cds--modal'\]\}/);
+  const internalModalSelector = new RegExp(
+    String.raw`selectorsFloatingMenus=\{\['\.` +
+      "cds" +
+      String.raw`--modal'\]\}`,
+  );
+  assert.doesNotMatch(policy, internalModalSelector);
   assert.match(policy, /app-owned selector/);
 });
 

--- a/.codex/skills/qjudge-quality-gates-owner/scripts/check-carbon-style.sh
+++ b/.codex/skills/qjudge-quality-gates-owner/scripts/check-carbon-style.sh
@@ -63,19 +63,19 @@ fi
 
 FAILED=0
 for file in "${TARGET_FILES[@]}"; do
-  if MATCHES=$(git show ":${file}" | rg -n --no-heading '\b(cds|bx)--'); then
+  if MATCHES=$(git show ":${file}" | grep -En '(cds|bx)--'); then
     printf '%s\n' "$MATCHES" | sed "s#^#${file}:#"
     printf '%s\n' 'Blocked: direct Carbon internal selectors (.cds-- / .bx--) are not allowed.' >&2
     FAILED=1
   fi
 
-  if MATCHES=$(git show ":${file}" | rg -n --no-heading '!important'); then
+  if MATCHES=$(git show ":${file}" | grep -En '!important'); then
     printf '%s\n' "$MATCHES" | sed "s#^#${file}:#"
     printf '%s\n' 'Blocked: !important is not allowed; fix specificity or component composition.' >&2
     FAILED=1
   fi
 
-  if MATCHES=$(git show ":${file}" | rg -n --no-heading 'var\(\s*--cds-spacing-(0[1-9]|1[0-3])(\s*,[^)]*)?\s*\)'); then
+  if MATCHES=$(git show ":${file}" | grep -En 'var\([[:space:]]*--cds-spacing-(0[1-9]|1[0-3])([[:space:]]*,[^)]*)?[[:space:]]*\)'); then
     printf '%s\n' "$MATCHES" | sed "s#^#${file}:#"
     printf '%s\n' 'Blocked: Carbon React does not emit --cds-spacing-* runtime variables; use @carbon/layout Sass tokens.' >&2
     FAILED=1

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,40 +1,37 @@
 name: CD Prod
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
-
   workflow_dispatch:
+    inputs:
+      confirm_production:
+        description: Confirm deployment of the selected main commit to production
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: cd-prod
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   deploy:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    if: github.ref == 'refs/heads/main' && inputs.confirm_production
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
+    environment: production
     permissions:
       contents: read
       checks: read
+      actions: read
 
     steps:
       - name: Determine SHA
         id: sha
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,6 +61,23 @@ jobs:
           PROD_SSH_HOST: ${{ secrets.PROD_SSH_HOST }}
           PROD_SSH_USER: ${{ secrets.PROD_SSH_USER }}
           PROD_DEPLOY_PATH: ${{ secrets.PROD_DEPLOY_PATH }}
+
+      - name: Verify release CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          conclusion="$(gh run list \
+            --workflow CI \
+            --commit "$DEPLOY_SHA" \
+            --event push \
+            --limit 1 \
+            --json conclusion \
+            --jq '.[0].conclusion // ""')"
+          if [ "$conclusion" != "success" ]; then
+            echo "CI has not passed for production SHA $DEPLOY_SHA" >&2
+            exit 1
+          fi
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ on:
       - ".env.example"
       - ".github/workflows/**"
       - ".github/actions/**"
-      - "scripts/i18n/i18n_check.py"
-      - "scripts/deploy-prod.sh"
+      - "scripts/**"
   pull_request:
     branches: [main, dev]
     paths:
@@ -37,8 +36,7 @@ on:
       - ".env.example"
       - ".github/workflows/**"
       - ".github/actions/**"
-      - "scripts/i18n/i18n_check.py"
-      - "scripts/deploy-prod.sh"
+      - "scripts/**"
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -70,15 +68,8 @@ jobs:
       - name: Deployment Compose Config Check
         run: |
           set -euo pipefail
-          bash -n scripts/deploy-prod.sh
-          # Compose env_file entries require a physical .env file.
-          cp .env.example .env
-          docker compose --env-file .env.example -f docker-compose.yml config -q
-          docker compose --env-file .env.example -f docker-compose.dev.yml config -q
-          docker compose -f docker-compose.test.yml config -q
-          docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.monitoring.yml config -q
-          docker compose --env-file .env.example -f docker-compose.dev.yml -f docker-compose.monitoring.yml config -q
-          docker compose --env-file .env.example -f docker-compose.test.yml -f loadtest/docker-compose.loadtest.yml config -q
+          bash -n scripts/deploy-prod.sh scripts/check-compose-config.sh
+          bash scripts/check-compose-config.sh
 
       - name: Install Frontend Deps
         run: npm ci
@@ -225,7 +216,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install MCP Server dependencies
-        run: pip install "mcp[cli]>=1.9.0" "httpx>=0.27.0" pytest
+        run: pip install "mcp[cli]>=1.9.0,<2.0" "httpx>=0.27.0" "PyJWT[crypto]>=2.9,<3.0" pytest
         working-directory: mcp-server
 
       - name: MCP Server Integration Tests
@@ -355,7 +346,7 @@ jobs:
           cache-dependency-path: mcp-server/pyproject.toml
 
       - name: Install MCP Server dependencies
-        run: pip install "mcp[cli]>=1.9.0" "httpx>=0.27.0" pytest
+        run: pip install "mcp[cli]>=1.9.0,<2.0" "httpx>=0.27.0" "PyJWT[crypto]>=2.9,<3.0" pytest
         working-directory: mcp-server
 
       - name: Run MCP Server Unit Tests

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ coverage.xml
 # Docker
 *.env
 !.env.example
+.env.next
 
 # Celery
 celerybeat-schedule

--- a/ai-service/tests/contract/test_compose_boundaries.py
+++ b/ai-service/tests/contract/test_compose_boundaries.py
@@ -387,21 +387,36 @@ def _run_fake_production_deploy(
     fake_bin.mkdir()
     _write_executable(
         fake_bin / "git",
-        '#!/bin/sh\nprintf "git %s\\n" "$*" >> "$QJUDGE_TEST_COMMAND_LOG"\n',
+        """#!/bin/sh
+printf 'git %s\n' "$*" >> "$QJUDGE_TEST_COMMAND_LOG"
+case "$*" in
+  "rev-parse HEAD") printf 'previous-sha\n' ;;
+esac
+""",
     )
     _write_executable(
         fake_bin / "docker",
         """#!/bin/sh
-printf 'docker %s\n' "$*" >> "$QJUDGE_TEST_COMMAND_LOG"
+printf 'DOCKER_GID=%s docker %s\n' "${DOCKER_GID:-}" "$*" >> "$QJUDGE_TEST_COMMAND_LOG"
 case "$*" in
   "compose version") exit 0 ;;
+  *"ps --status running --services"*) printf 'postgres\n' ;;
+  *"pg_dump"*) printf 'fake-custom-dump\n' ;;
+  *"pg_restore --list"*) exit 0 ;;
   *"exec -T"*) printf '0\n' ;;
 esac
 exit 0
 """,
     )
-    _write_executable(fake_bin / "python3", "#!/bin/sh\nexit 0\n")
-    _write_executable(fake_bin / "curl", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        fake_bin / "python3",
+        '#!/bin/sh\nprintf "python3 %s\\n" "$*" >> "$QJUDGE_TEST_COMMAND_LOG"\nexit 0\n',
+    )
+    _write_executable(
+        fake_bin / "curl",
+        '#!/bin/sh\nprintf "curl %s\\n" "$*" >> "$QJUDGE_TEST_COMMAND_LOG"\nexit 0\n',
+    )
+    _write_executable(fake_bin / "stat", "#!/bin/sh\nprintf '138\\n'\n")
 
     environment = os.environ.copy()
     environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
@@ -445,7 +460,7 @@ def test_production_deploy_enables_tunnel_only_when_token_is_configured(
     compose_deployment_commands = [
         line
         for line in commands.splitlines()
-        if line.startswith("docker compose -f")
+        if "docker compose -f" in line
     ]
     assert compose_deployment_commands
     assert all("--profile tunnel" in line for line in compose_deployment_commands)
@@ -528,3 +543,52 @@ def test_production_deploy_validates_roles_and_bootstraps_oauth_before_render() 
         assert key not in required_block
     assert "AI_DATABASE_URL" not in source
     assert "rolsuper OR rolcreatedb OR rolcreaterole" in source
+
+
+def test_production_deploy_prepares_integrity_runtime_before_start(
+    tmp_path: Path,
+) -> None:
+    result, commands = _run_fake_production_deploy(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    integrity_bootstrap = commands.index(
+        "python3 scripts/bootstrap_integrity_secrets.py"
+    )
+    compose_start = commands.index("up -d --remove-orphans")
+    assert integrity_bootstrap < compose_start
+    assert "--profile build build integrity-worker-image" in commands
+    assert "DOCKER_GID=138 docker compose" in commands
+
+
+def test_production_deploy_backs_up_database_before_start(tmp_path: Path) -> None:
+    result, commands = _run_fake_production_deploy(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    database_backup = commands.index("pg_dump")
+    compose_start = commands.index("up -d --remove-orphans")
+    assert database_backup < compose_start
+    assert "pg_restore --list" in commands
+    assert "[deploy] backup ready:" in result.stdout
+
+
+def test_production_deploy_prepares_database_admin_before_start(
+    tmp_path: Path,
+) -> None:
+    result, commands = _run_fake_production_deploy(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    database_admin = commands.index(
+        "exec -T -e QJUDGE_BOOTSTRAP_ADMIN_PASSWORD postgres"
+    )
+    compose_start = commands.index("up -d --remove-orphans")
+    assert database_admin < compose_start
+
+
+def test_production_deploy_checks_each_critical_http_boundary(tmp_path: Path) -> None:
+    result, commands = _run_fake_production_deploy(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "http://localhost:80" in commands
+    assert "http://localhost:8000/api/health/" in commands
+    assert "http://localhost:8001/health/ready" in commands
+    assert "http://localhost:8010/health" in commands

--- a/frontend/public/docs/zh-TW/deployment.md
+++ b/frontend/public/docs/zh-TW/deployment.md
@@ -161,6 +161,17 @@ python3 scripts/bootstrap_integrity_secrets.py
 
 腳本會保留格式正確的既有檔案，不需要每次部署都重建。
 
+從舊版升級時，先產生一份不會自動生效的 release 環境候選檔：
+
+```bash
+python3 scripts/prepare-prod-release-env.py \
+  --input .env \
+  --output .env.next \
+  --origin https://your-qjudge-origin.example
+```
+
+候選檔會保留現行服務仍需的設定，另外建立彼此獨立的 database admin、Django、AI 與 credential lease secrets，並寫入主機實際的 Docker socket UID/GID。腳本不會修改 `.env`，也拒絕覆寫既有 `.env.next`。先完成備份與 review，只有在核准的維護窗口才把候選檔提升為 active `.env`。
+
 現在把這次要部署的 commit SHA 交給 production 部署腳本：
 
 ```bash
@@ -169,7 +180,7 @@ python3 scripts/bootstrap_integrity_secrets.py
 
 第二個參數的用途是固定這次部署的版本。腳本會先從 Git remote 更新資料，再以 `checkout --force` 切到指定 SHA；因此這個 commit 必須已經存在於 remote、release tag，或部署主機的 repository 中。不要在保存開發中修改的工作目錄執行這支腳本，否則未提交的修改可能被覆蓋。
 
-這一步會下載或建立 images、執行 database bootstrap 與 migrations、啟動服務，再檢查首頁。第一次 build 可能需要一段時間。正常結束會看到：
+這一步會先建立並驗證 `artifacts/db_backups/` 下的 PostgreSQL custom-format 備份，接著初始化 database boundary 與 Integrity credentials、建立 images、執行 migrations、啟動服務，再分別檢查 frontend、backend、AI service 與 Integrity controller。第一次 build 可能需要一段時間。正常結束會看到：
 
 ```text
 [deploy] success
@@ -255,6 +266,10 @@ git fetch --all --tags --prune
 ```bash
 ./scripts/deploy-prod.sh "$(pwd)" "RELEASE_TAG_OR_COMMIT_SHA"
 ```
+
+GitHub 的正式部署工作流只接受從 `main` 手動觸發，必須勾選 production confirmation，且該 SHA 的 CI push run 必須成功。部署進行中不會被另一個 workflow run 自動取消。
+
+若健康檢查失敗，部署腳本會輸出先前 SHA 與本次已驗證的 backup 路徑。不要直接重跑 migration 或刪除 volume；先保留現場 logs，再依該 SHA、backup 與維護窗口的資料取捨執行人工回復。
 
 更新後重新執行第 8 節的健康檢查與使用者流程。
 

--- a/frontend/src/features/auth/hooks/useUserPreferences.ts
+++ b/frontend/src/features/auth/hooks/useUserPreferences.ts
@@ -1,6 +1,9 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useTheme } from "@/shared/ui/theme/ThemeContext";
-import { useContentLanguage } from "@/shared/contexts/ContentLanguageContext";
+import {
+  useContentLanguage,
+  type ContentLanguage,
+} from "@/shared/contexts/ContentLanguageContext";
 import { useAuth } from "@/features/auth/contexts/AuthContext";
 import {
   getPreferences as getUserPreferences,
@@ -89,20 +92,14 @@ export const useUserPreferences = (): UseUserPreferencesReturn => {
   const effectiveTheme: "light" | "dark" =
     theme === "g100" || theme === "g90" ? "dark" : "light";
 
-  // Store setContentLanguage in a ref to avoid dependency issues
-  const setContentLanguageRef = useRef(setContentLanguage);
-  setContentLanguageRef.current = setContentLanguage;
-
   const applyPreferencesToState = useCallback(
     (nextPreferences: UserPreferences) => {
       setPreferences(nextPreferences);
       // Sync backend preference into ThemeContext (single source of truth)
       setPreference(nextPreferences.preferred_theme);
-      setContentLanguageRef.current(
-        nextPreferences.preferred_language as typeof contentLanguage
-      );
+      setContentLanguage(nextPreferences.preferred_language as ContentLanguage);
     },
-    [setPreference]
+    [setContentLanguage, setPreference]
   );
 
   const syncAuthUserProfile = useCallback(
@@ -240,7 +237,7 @@ export const useUserPreferences = (): UseUserPreferencesReturn => {
         }
         return next;
       });
-      setContentLanguage(lang as typeof contentLanguage);
+      setContentLanguage(lang as ContentLanguage);
 
       if (user) {
         try {

--- a/frontend/src/features/classroom/components/ClassroomSettingsGeneralPanel.tsx
+++ b/frontend/src/features/classroom/components/ClassroomSettingsGeneralPanel.tsx
@@ -41,7 +41,10 @@ export const ClassroomSettingsGeneralPanel: React.FC<ClassroomSettingsGeneralPan
 
   // Keep a ref of the latest values for auto-save to avoid stale closures
   const latestRef = useRef({ name: settingName, description: settingDescription, icon: settingIcon });
-  latestRef.current = { name: settingName, description: settingDescription, icon: settingIcon };
+
+  useEffect(() => {
+    latestRef.current = { name: settingName, description: settingDescription, icon: settingIcon };
+  }, [settingDescription, settingIcon, settingName]);
 
   const savingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/frontend/src/features/contest/components/admin/AdminOverviewCommandCenter.tsx
+++ b/frontend/src/features/contest/components/admin/AdminOverviewCommandCenter.tsx
@@ -461,7 +461,12 @@ export default function AdminOverviewCommandCenter({
     await Promise.all([refreshAllAdminData(), participantDashboard.refresh()]);
   }, [refreshAllAdminData, participantDashboard]);
 
-  const studentQrCamera = useCameraStream({
+  const {
+    videoRef: studentQrVideoRef,
+    setVideoElement: setStudentQrVideoElement,
+    cameraState: studentQrCameraState,
+    cameraError: studentQrCameraError,
+  } = useCameraStream({
     active: studentQrScannerOpen,
     facingMode: "environment",
     messages: {
@@ -529,8 +534,8 @@ export default function AdminOverviewCommandCenter({
     [contestId, participants, showToast, t],
   );
   const studentQrScannerMode = useQrScanner({
-    videoRef: studentQrCamera.videoRef,
-    active: studentQrScannerOpen && studentQrCamera.cameraState === "ready",
+    videoRef: studentQrVideoRef,
+    active: studentQrScannerOpen && studentQrCameraState === "ready",
     onDetected: handleStudentQrDetected,
   });
 
@@ -1394,11 +1399,11 @@ export default function AdminOverviewCommandCenter({
       >
         <div className={styles.studentQrScanner}>
           <div className={styles.studentQrScannerViewport}>
-            {studentQrCamera.cameraState === "unavailable" ? (
-              <p>{studentQrCamera.cameraError}</p>
+            {studentQrCameraState === "unavailable" ? (
+              <p>{studentQrCameraError}</p>
             ) : (
               <video
-                ref={studentQrCamera.setVideoElement}
+                ref={setStudentQrVideoElement}
                 className={styles.studentQrScannerVideo}
                 muted
                 playsInline
@@ -1407,7 +1412,7 @@ export default function AdminOverviewCommandCenter({
             )}
           </div>
           <p className={styles.studentQrScannerHint}>
-            {studentQrCamera.cameraState === "ready"
+            {studentQrCameraState === "ready"
               ? t(
                   "adminOverview.command.participants.studentQr.ready",
                   "請掃描學生競賽主頁上的考生 QR。",

--- a/frontend/src/features/contest/components/admin/examEditor/ExamQuestionEditCard.tsx
+++ b/frontend/src/features/contest/components/admin/examEditor/ExamQuestionEditCard.tsx
@@ -412,6 +412,9 @@ const ExamQuestionEditCard: React.FC<ExamQuestionEditCardProps> = ({
   const [form, setForm] = useState<QuestionFormState>(() =>
     toFormState(question),
   );
+  const [originalForm, setOriginalForm] = useState<QuestionFormState>(() =>
+    toFormState(question),
+  );
   const [saving, setSaving] = useState(false);
   const [lockedSaveImpact, setLockedSaveImpact] =
     useState<LockedSaveImpact | null>(null);
@@ -426,6 +429,7 @@ const ExamQuestionEditCard: React.FC<ExamQuestionEditCardProps> = ({
     if (!editing) {
       const next = toFormState(question);
       setForm(next);
+      setOriginalForm(next);
       originalFormRef.current = next;
     }
   }, [question, editing]);
@@ -488,6 +492,7 @@ const ExamQuestionEditCard: React.FC<ExamQuestionEditCardProps> = ({
         const payload = buildPayload(snapshot, showScoreField);
         await onAutoSave(payload, question.id, action);
         originalFormRef.current = { ...snapshot };
+        setOriginalForm({ ...snapshot });
         setForm({ ...snapshot });
         return true;
       } catch (error) {
@@ -595,7 +600,7 @@ const ExamQuestionEditCard: React.FC<ExamQuestionEditCardProps> = ({
     showScoreField,
   ]);
 
-  const dirty = isFormDirty(form, originalFormRef.current, showScoreField);
+  const dirty = isFormDirty(form, originalForm, showScoreField);
 
   const handleExplicitSave = () => {
     const validationError = getValidationError();

--- a/frontend/src/features/contest/components/exam/PaperExamCore.tsx
+++ b/frontend/src/features/contest/components/exam/PaperExamCore.tsx
@@ -85,7 +85,6 @@ export const PaperExamCore: React.FC<PaperExamCoreProps> = ({
 
   const questionAreaRef = useRef<HTMLDivElement>(null);
   const allContentRef = useRef<HTMLDivElement>(null);
-  const allItemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const prevIndexRef = useRef<number | null>(null);
   const maxIndex = items.length > 0 ? items.length - 1 : 0;
   const isSyncIndexActive = syncIndex != null && syncIndex >= 0 && syncIndex < items.length;
@@ -141,7 +140,9 @@ export const PaperExamCore: React.FC<PaperExamCoreProps> = ({
       let closestIdx = 0;
       let closestDist = Infinity;
 
-      allItemRefs.current.forEach((el, idx) => {
+      container.querySelectorAll<HTMLElement>("[data-index]").forEach((el) => {
+        const idx = Number(el.dataset.index);
+        if (!Number.isInteger(idx)) return;
         const rect = el.getBoundingClientRect();
         const dist = Math.abs(rect.top + rect.height / 2 - centerY);
         if (dist < closestDist) {
@@ -163,7 +164,9 @@ export const PaperExamCore: React.FC<PaperExamCoreProps> = ({
   const toolbarVisible = effectiveViewMode === "single" ? singleScrollVisible : allScrollVisible;
 
   const handleScrollToItem = useCallback((index: number) => {
-    const el = allItemRefs.current.get(index);
+    const el = allContentRef.current?.querySelector<HTMLElement>(
+      `[data-index="${index}"]`,
+    );
     if (el) {
       el.scrollIntoView({ behavior: "smooth", block: "center" });
     }
@@ -255,10 +258,6 @@ export const PaperExamCore: React.FC<PaperExamCoreProps> = ({
           <div
             key={item.data.id}
             data-index={index}
-            ref={(el) => {
-              if (el) allItemRefs.current.set(index, el);
-              else allItemRefs.current.delete(index);
-            }}
             className={`${styles.allItem} ${dimClass}`}
           >
             {renderItem(item, index, "all")}

--- a/frontend/src/features/contest/screens/admin/panels/AdminOverviewScreen.tsx
+++ b/frontend/src/features/contest/screens/admin/panels/AdminOverviewScreen.tsx
@@ -67,15 +67,23 @@ export default function AdminOverviewScreen({
   const [publishingResults, setPublishingResults] = useState(false);
   const [resultRefreshKey, setResultRefreshKey] = useState(0);
   const [addParticipantOpen, setAddParticipantOpen] = useState(false);
+  const [currentTimeMs, setCurrentTimeMs] = useState(0);
   const classroomBound = Boolean(contest?.isClassroomBound);
+
+  useEffect(() => {
+    const updateTime = () => setCurrentTimeMs(Date.now());
+    updateTime();
+    const intervalId = window.setInterval(updateTime, 30000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
   const contestInProgress = useMemo(() => {
     if (!contest || contest.status !== "published") return false;
     const startMs = new Date(contest.startTime).getTime();
     const endMs = new Date(contest.endTime).getTime();
     if (Number.isNaN(startMs) || Number.isNaN(endMs)) return false;
-    const now = Date.now();
-    return now >= startMs && now < endMs;
-  }, [contest]);
+    return currentTimeMs >= startMs && currentTimeMs < endMs;
+  }, [contest, currentTimeMs]);
   const handleAddParticipant = useCallback(
     async (username: string) => {
       if (!contest?.id) return;

--- a/frontend/src/features/contest/screens/settings/grading/components/ScorePolicyMenu.tsx
+++ b/frontend/src/features/contest/screens/settings/grading/components/ScorePolicyMenu.tsx
@@ -4,7 +4,7 @@
  *
  * A before/after score distribution preview is shown before committing any policy change.
  */
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback } from "react";
 import { OverflowMenu, OverflowMenuItem, Tag } from "@carbon/react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -51,7 +51,7 @@ export default function ScorePolicyMenu({
   // ── Redistribute target selection modal ────────────────────────────────
   const [redistributeModalOpen, setRedistributeModalOpen] = useState(false);
   const [redistributeModalKey, setRedistributeModalKey] = useState(0);
-  const pendingRedistributeTargetIds = useRef<string[]>([]);
+  const [pendingRedistributeTargetIds, setPendingRedistributeTargetIds] = useState<string[]>([]);
 
   // ── Impact preview dialog ──────────────────────────────────────────────
   const [impactOpen, setImpactOpen] = useState(false);
@@ -119,7 +119,7 @@ export default function ScorePolicyMenu({
 
       if (policy === "redistribute") {
         // Open target selection first; impact shown after targets chosen
-        pendingRedistributeTargetIds.current = [];
+        setPendingRedistributeTargetIds([]);
         setRedistributeModalKey((k) => k + 1);
         setRedistributeModalOpen(true);
         return;
@@ -134,7 +134,7 @@ export default function ScorePolicyMenu({
 
   const handleRedistributeTargetsChosen = useCallback(
     (targetIds: string[]) => {
-      pendingRedistributeTargetIds.current = targetIds;
+      setPendingRedistributeTargetIds(targetIds);
       setRedistributeModalOpen(false);
 
       openImpactDialog("redistribute", targetIds);
@@ -146,11 +146,11 @@ export default function ScorePolicyMenu({
 
   const handleImpactConfirm = useCallback(() => {
     if (impactPolicy === "redistribute") {
-      commitPolicy("redistribute", pendingRedistributeTargetIds.current);
+      commitPolicy("redistribute", pendingRedistributeTargetIds);
     } else {
       commitPolicy(impactPolicy);
     }
-  }, [impactPolicy, commitPolicy]);
+  }, [impactPolicy, commitPolicy, pendingRedistributeTargetIds]);
 
   const handleBackToTargetSelection = useCallback(() => {
     setImpactOpen(false);
@@ -210,7 +210,7 @@ export default function ScorePolicyMenu({
         open={redistributeModalOpen}
         questionIndex={questionIndex}
         availableTargets={availableTargets}
-        initialSelectedIds={pendingRedistributeTargetIds.current}
+        initialSelectedIds={pendingRedistributeTargetIds}
         onClose={() => setRedistributeModalOpen(false)}
         onConfirm={handleRedistributeTargetsChosen}
         submitting={submitting}

--- a/frontend/src/features/problems/screens/problemsId/section/ProblemDetailSection.tsx
+++ b/frontend/src/features/problems/screens/problemsId/section/ProblemDetailSection.tsx
@@ -184,13 +184,17 @@ const ProblemDetailSectionInner: React.FC<Omit<ProblemDetailSectionProps, "probl
 
   // -- Test Case Handlers --
   const handleAddTestCase = (input: string, output: string) => {
-    const newCase: TestCaseItem = {
-      id: `custom_${Date.now()}`,
-      input,
-      output,
-      source: "custom",
-    };
     setTestCases((prev) => {
+      let sequence = prev.length + 1;
+      while (prev.some((testCase) => testCase.id === `custom_${sequence}`)) {
+        sequence += 1;
+      }
+      const newCase: TestCaseItem = {
+        id: `custom_${sequence}`,
+        input,
+        output,
+        source: "custom",
+      };
       const next = [...prev, newCase];
       saveCustomCases(next);
       return next;

--- a/frontend/src/features/question-banks/components/QuestionBankSettingsGeneralPanel.tsx
+++ b/frontend/src/features/question-banks/components/QuestionBankSettingsGeneralPanel.tsx
@@ -33,11 +33,14 @@ export const QuestionBankSettingsGeneralPanel: React.FC<
     description: settingDescription,
     icon: settingIcon,
   });
-  latestRef.current = {
-    name: settingName,
-    description: settingDescription,
-    icon: settingIcon,
-  };
+
+  useEffect(() => {
+    latestRef.current = {
+      name: settingName,
+      description: settingDescription,
+      icon: settingIcon,
+    };
+  }, [settingDescription, settingIcon, settingName]);
 
   const savingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/scripts/check-compose-config.sh
+++ b/scripts/check-compose-config.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/qjudge-compose-check.XXXXXX")"
+CHECK_ENV="${TEMP_DIR}/compose.env"
+PROJECT_ENV="${PROJECT_ROOT}/.env"
+CREATED_PROJECT_ENV="false"
+
+cleanup() {
+  if [[ "$CREATED_PROJECT_ENV" == "true" && -f "$PROJECT_ENV" ]]; then
+    rm -f -- "$PROJECT_ENV"
+  fi
+  rm -rf -- "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+cd "$PROJECT_ROOT"
+
+cp .env.example "$CHECK_ENV"
+cat >> "$CHECK_ENV" <<'ENV'
+QJUDGE_PUBLIC_ORIGIN=https://qjudge-compose-check.invalid
+SECRET_KEY=compose-check-secret-key
+POSTGRES_ADMIN_PASSWORD=compose-check-admin-password
+DB_PASSWORD=compose-check-web-password
+AI_DB_PASSWORD=compose-check-ai-password
+CREDENTIAL_LEASE_SECRET=compose-check-credential-lease-secret
+DOCKER_GID=999
+DOCKER_SOCKET_UID=1000
+OBJECT_STORAGE_ENDPOINT_URL=https://storage-compose-check.invalid
+OBJECT_STORAGE_PUBLIC_ENDPOINT_URL=https://storage-compose-check.invalid
+OBJECT_STORAGE_ACCESS_KEY=compose-check-storage-access-key
+OBJECT_STORAGE_SECRET_KEY=compose-check-storage-secret-key
+LOADTEST_OBJECT_STORAGE_ENDPOINT_URL=https://loadtest-storage-compose-check.invalid
+LOADTEST_OBJECT_STORAGE_PUBLIC_ENDPOINT_URL=https://loadtest-storage-compose-check.invalid
+LOADTEST_OBJECT_STORAGE_ACCESS_KEY=compose-check-loadtest-storage-access-key
+LOADTEST_OBJECT_STORAGE_SECRET_KEY=compose-check-loadtest-storage-secret-key
+LOADTEST_ANTICHEAT_RAW_BUCKET=compose-check-anticheat-raw
+ENV
+
+# Compose service env_file entries require a physical project-root .env.
+# Preserve an existing developer/production file; create and remove one only when absent.
+if [[ ! -e "$PROJECT_ENV" ]]; then
+  cp "$CHECK_ENV" "$PROJECT_ENV"
+  CREATED_PROJECT_ENV="true"
+fi
+
+compose=(docker compose --env-file "$CHECK_ENV")
+"${compose[@]}" -f docker-compose.yml config --quiet
+"${compose[@]}" -f docker-compose.dev.yml config --quiet
+"${compose[@]}" -f docker-compose.test.yml config --quiet
+"${compose[@]}" -f docker-compose.yml -f docker-compose.monitoring.yml config --quiet
+"${compose[@]}" -f docker-compose.dev.yml -f docker-compose.monitoring.yml config --quiet
+"${compose[@]}" -f docker-compose.test.yml -f loadtest/docker-compose.loadtest.yml config --quiet

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -110,6 +110,20 @@ for key in "${required_env_keys[@]}"; do
   require_env_key "$key"
 done
 
+docker_socket_gid="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || true)"
+case "$docker_socket_gid" in
+  ''|*[!0-9]*)
+    echo "Cannot determine the Docker socket group id" >&2
+    exit 1
+    ;;
+esac
+configured_docker_gid="$(get_env_value DOCKER_GID)"
+if [ -n "$configured_docker_gid" ] && [ "$configured_docker_gid" != "$docker_socket_gid" ]; then
+  echo ".env DOCKER_GID does not match /var/run/docker.sock" >&2
+  exit 1
+fi
+export DOCKER_GID="$docker_socket_gid"
+
 reject_env_placeholder "SECRET_KEY"
 reject_env_placeholder "POSTGRES_ADMIN_PASSWORD"
 reject_env_placeholder "DB_PASSWORD"
@@ -196,6 +210,8 @@ fi
 
 # ── deploy ─────────────────────────────────────────────────────
 
+previous_git_ref="$(git rev-parse HEAD)"
+
 echo "[deploy] fetch and checkout ${GIT_REF}"
 git fetch --all --tags --prune
 git checkout --force "${GIT_REF}"
@@ -203,8 +219,68 @@ git checkout --force "${GIT_REF}"
 echo "[deploy] bootstrap AI OAuth signing key"
 python3 scripts/bootstrap_ai_oauth_keys.py
 
+echo "[deploy] bootstrap Integrity credentials"
+python3 scripts/bootstrap_integrity_secrets.py
+
 echo "[deploy] validate rendered Compose"
 docker compose "${COMPOSE_FILES[@]}" config --quiet
+
+backup_file=""
+running_services="$(docker compose "${COMPOSE_FILES[@]}" ps --status running --services)"
+if printf '%s\n' "$running_services" | grep -qx postgres; then
+  backup_dir="${DEPLOY_PATH}/artifacts/db_backups"
+  backup_timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  backup_file="${backup_dir}/production_${backup_timestamp}_${previous_git_ref:0:12}.dump"
+  backup_tmp="${backup_file}.tmp"
+  umask 077
+  mkdir -p "$backup_dir"
+  chmod 700 "$backup_dir"
+  echo "[deploy] create pre-deploy database backup"
+  if ! docker compose "${COMPOSE_FILES[@]}" exec -T postgres sh -lc \
+    'exec pg_dump --username "$POSTGRES_USER" --dbname online_judge --format=custom --no-owner --no-privileges --compress=6' \
+    > "$backup_tmp"; then
+    rm -f -- "$backup_tmp"
+    echo "Pre-deploy database backup failed" >&2
+    exit 1
+  fi
+  if [ ! -s "$backup_tmp" ]; then
+    rm -f -- "$backup_tmp"
+    echo "Pre-deploy database backup is empty" >&2
+    exit 1
+  fi
+  if ! docker compose "${COMPOSE_FILES[@]}" exec -T postgres \
+    pg_restore --list < "$backup_tmp" >/dev/null; then
+    rm -f -- "$backup_tmp"
+    echo "Pre-deploy database backup validation failed" >&2
+    exit 1
+  fi
+  mv -- "$backup_tmp" "$backup_file"
+  sha256sum "$backup_file" > "${backup_file}.sha256"
+  echo "[deploy] backup ready: ${backup_file}"
+
+  echo "[deploy] prepare production database administrator"
+  export QJUDGE_BOOTSTRAP_ADMIN_PASSWORD="$(get_env_value POSTGRES_ADMIN_PASSWORD)"
+  docker compose "${COMPOSE_FILES[@]}" exec -T \
+    -e QJUDGE_BOOTSTRAP_ADMIN_PASSWORD \
+    postgres \
+    sh -lc 'psql --username "$POSTGRES_USER" --dbname postgres --no-psqlrc --quiet --set ON_ERROR_STOP=1' <<'SQL'
+\getenv admin_password QJUDGE_BOOTSTRAP_ADMIN_PASSWORD
+SELECT format(
+  'CREATE ROLE qjudge_admin LOGIN SUPERUSER CREATEDB CREATEROLE PASSWORD %L',
+  :'admin_password'
+)
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'qjudge_admin')
+\gexec
+SELECT format(
+  'ALTER ROLE qjudge_admin LOGIN SUPERUSER CREATEDB CREATEROLE PASSWORD %L',
+  :'admin_password'
+)
+\gexec
+SQL
+  unset QJUDGE_BOOTSTRAP_ADMIN_PASSWORD
+else
+  echo "[deploy] backup skipped: postgres is not running (fresh installation)"
+fi
 
 echo "[deploy] pull judge image from GHCR"
 if docker pull ghcr.io/quan0715/qjudge/judge:latest; then
@@ -222,8 +298,17 @@ fi
 echo "[deploy] build images"
 docker compose "${COMPOSE_FILES[@]}" build
 
+echo "[deploy] build Integrity worker image"
+docker compose "${COMPOSE_FILES[@]}" --profile build build integrity-worker-image
+
 echo "[deploy] start services"
-docker compose "${COMPOSE_FILES[@]}" up -d --remove-orphans
+if ! docker compose "${COMPOSE_FILES[@]}" up -d --remove-orphans; then
+  echo "Deployment start failed. Previous SHA: ${previous_git_ref}" >&2
+  if [ -n "$backup_file" ]; then
+    echo "Validated database backup: ${backup_file}" >&2
+  fi
+  exit 1
+fi
 
 echo "[deploy] verify application database roles"
 export PGPASSWORD="$(get_env_value POSTGRES_ADMIN_PASSWORD)"
@@ -248,27 +333,38 @@ if [ "$unsafe_role_count" != "0" ]; then
   exit 1
 fi
 
-echo "[deploy] prune old images"
-docker image prune -f
-
 # ── smoke check ────────────────────────────────────────────────
 
+wait_for_http() {
+  local label="$1"
+  local url="$2"
+  local attempt=1
+  local max_attempts=30
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if curl --fail --silent --show-error --max-time 8 "$url" >/dev/null 2>&1; then
+      echo "[deploy] smoke ok: ${label}"
+      return 0
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  echo "[deploy] smoke failed: ${label} did not respond within 60s" >&2
+  return 1
+}
+
 echo "[deploy] smoke check"
-max_attempts=30
-attempt=1
-
-while [ "$attempt" -le "$max_attempts" ]; do
-  if curl -sf http://localhost:80 >/dev/null 2>&1; then
-    echo "[deploy] smoke ok: http://localhost:80"
-    break
+if ! wait_for_http "frontend" "http://localhost:80" || \
+   ! wait_for_http "backend" "http://localhost:8000/api/health/" || \
+   ! wait_for_http "AI service" "http://localhost:8001/health/ready" || \
+   ! wait_for_http "Integrity controller" "http://localhost:8010/health"; then
+  echo "Deployment health checks failed. Previous SHA: ${previous_git_ref}" >&2
+  if [ -n "$backup_file" ]; then
+    echo "Validated database backup: ${backup_file}" >&2
   fi
-  sleep 2
-  attempt=$((attempt + 1))
-done
-
-if [ "$attempt" -gt "$max_attempts" ]; then
-  echo "[deploy] smoke failed: http://localhost:80 did not respond within 60s" >&2
   exit 1
 fi
+
+echo "[deploy] prune old images"
+docker image prune -f
 
 echo "[deploy] success"

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -85,7 +85,7 @@ cd "$PROJECT_ROOT"
 # ==================== 4. Docker Compose 配置驗證 ====================
 print_step "驗證 Docker Compose 配置..."
 
-if docker compose config -q 2>/dev/null || docker-compose config -q 2>/dev/null; then
+if bash scripts/check-compose-config.sh; then
     print_success "Docker Compose 配置有效"
 else
     print_error "Docker Compose 配置無效"

--- a/scripts/prepare-prod-release-env.py
+++ b/scripts/prepare-prod-release-env.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Create a non-active production environment candidate for the next release."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import secrets
+import string
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+ROTATED_KEYS = {
+    "QJUDGE_PUBLIC_ORIGIN",
+    "POSTGRES_ADMIN_PASSWORD",
+    "DB_PASSWORD",
+    "AI_DB_PASSWORD",
+    "CREDENTIAL_LEASE_SECRET",
+    "DOCKER_GID",
+    "DOCKER_SOCKET_UID",
+}
+PRESERVED_REQUIRED_KEYS = {
+    "SECRET_KEY",
+    "DB_PASSWORD",
+    "OBJECT_STORAGE_ENDPOINT_URL",
+    "OBJECT_STORAGE_PUBLIC_ENDPOINT_URL",
+    "OBJECT_STORAGE_ACCESS_KEY",
+    "OBJECT_STORAGE_SECRET_KEY",
+}
+
+
+def parse_env(lines: list[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        normalized = value.strip()
+        if len(normalized) >= 2 and normalized[0] == normalized[-1] and normalized[0] in "\"'":
+            normalized = normalized[1:-1]
+        values[key.strip()] = normalized
+    return values
+
+
+def normalize_origin(value: str) -> str:
+    try:
+        parsed = urlsplit(value.strip())
+        parsed.port
+    except ValueError as error:
+        raise ValueError("origin is not a valid URL") from error
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("origin must use HTTP or HTTPS and include a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("origin must not contain user information")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise ValueError("origin must not include a path, query, or fragment")
+    return f"{parsed.scheme.lower()}://{parsed.netloc}"
+
+
+def random_password() -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(48))
+
+
+def render_candidate(
+    source_lines: list[str],
+    source_values: dict[str, str],
+    *,
+    origin: str,
+    docker_socket: Path,
+) -> str:
+    missing = sorted(
+        key for key in PRESERVED_REQUIRED_KEYS if not source_values.get(key, "").strip()
+    )
+    if missing:
+        raise ValueError("active env is missing required keys: " + ", ".join(missing))
+    socket_stat = docker_socket.stat()
+    generated = {
+        "QJUDGE_PUBLIC_ORIGIN": normalize_origin(origin),
+        "POSTGRES_ADMIN_PASSWORD": random_password(),
+        "DB_PASSWORD": random_password(),
+        "AI_DB_PASSWORD": random_password(),
+        "CREDENTIAL_LEASE_SECRET": secrets.token_urlsafe(48),
+        "DOCKER_GID": str(socket_stat.st_gid),
+        "DOCKER_SOCKET_UID": str(socket_stat.st_uid),
+    }
+    retained_lines: list[str] = []
+    for raw_line in source_lines:
+        stripped = raw_line.strip()
+        key = stripped.split("=", 1)[0].strip() if "=" in stripped else ""
+        if key not in ROTATED_KEYS:
+            retained_lines.append(raw_line.rstrip("\n"))
+    while retained_lines and not retained_lines[-1]:
+        retained_lines.pop()
+    retained_lines.extend(
+        [
+            "",
+            "# Prepared release boundary. This file is inactive until explicitly promoted.",
+            *(f"{key}={value}" for key, value in generated.items()),
+            "",
+        ]
+    )
+    return "\n".join(retained_lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, default=Path(".env"))
+    parser.add_argument("--output", type=Path, default=Path(".env.next"))
+    parser.add_argument("--origin")
+    parser.add_argument(
+        "--docker-socket", type=Path, default=Path("/var/run/docker.sock")
+    )
+    args = parser.parse_args()
+
+    if args.output.exists():
+        raise SystemExit(f"Refusing to overwrite existing candidate: {args.output}")
+    source_lines = args.input.read_text().splitlines(keepends=True)
+    source_values = parse_env(source_lines)
+    origin = args.origin or source_values.get("QJUDGE_PUBLIC_ORIGIN") or source_values.get(
+        "FRONTEND_URL", ""
+    )
+    if not origin:
+        raise SystemExit("--origin is required when the active env has no public origin")
+    try:
+        content = render_candidate(
+            source_lines,
+            source_values,
+            origin=origin,
+            docker_socket=args.docker_socket,
+        )
+    except (OSError, ValueError) as error:
+        raise SystemExit(str(error)) from error
+
+    descriptor = os.open(args.output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "w") as stream:
+            stream.write(content)
+        args.output.chmod(0o600)
+    except BaseException:
+        args.output.unlink(missing_ok=True)
+        raise
+    print(f"Release environment candidate ready: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_prepare_prod_release_env.py
+++ b/scripts/tests/test_prepare_prod_release_env.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPOSITORY_ROOT / "scripts" / "prepare-prod-release-env.py"
+
+
+def _legacy_env() -> str:
+    return """\
+FRONTEND_URL=https://q-judge.com
+SECRET_KEY=existing-production-secret
+DB_PASSWORD=legacy-superuser-password
+OBJECT_STORAGE_ENDPOINT_URL=https://storage.example.invalid
+OBJECT_STORAGE_PUBLIC_ENDPOINT_URL=https://storage.example.invalid
+OBJECT_STORAGE_ACCESS_KEY=existing-storage-access
+OBJECT_STORAGE_SECRET_KEY=existing-storage-secret
+TUNNEL_TOKEN=existing-tunnel-token
+"""
+
+
+def _parse_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def test_release_env_rotates_database_credentials_without_touching_active_env(
+    tmp_path: Path,
+) -> None:
+    active = tmp_path / ".env"
+    output = tmp_path / ".env.next"
+    docker_socket = tmp_path / "docker.sock"
+    active.write_text(_legacy_env())
+    docker_socket.touch()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--input",
+            str(active),
+            "--output",
+            str(output),
+            "--origin",
+            "https://q-judge.com/",
+            "--docker-socket",
+            str(docker_socket),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert active.read_text() == _legacy_env()
+    assert os.stat(output).st_mode & 0o777 == 0o600
+
+    values = _parse_env(output)
+    assert values["QJUDGE_PUBLIC_ORIGIN"] == "https://q-judge.com"
+    assert values["SECRET_KEY"] == "existing-production-secret"
+    assert values["TUNNEL_TOKEN"] == "existing-tunnel-token"
+    assert values["DB_PASSWORD"] != "legacy-superuser-password"
+    generated = {
+        values["POSTGRES_ADMIN_PASSWORD"],
+        values["DB_PASSWORD"],
+        values["AI_DB_PASSWORD"],
+        values["CREDENTIAL_LEASE_SECRET"],
+    }
+    assert len(generated) == 4
+    assert all(len(value) >= 40 for value in generated)
+    socket_stat = docker_socket.stat()
+    assert values["DOCKER_GID"] == str(socket_stat.st_gid)
+    assert values["DOCKER_SOCKET_UID"] == str(socket_stat.st_uid)
+
+
+def test_release_env_refuses_to_replace_an_existing_candidate(tmp_path: Path) -> None:
+    active = tmp_path / ".env"
+    output = tmp_path / ".env.next"
+    docker_socket = tmp_path / "docker.sock"
+    active.write_text(_legacy_env())
+    output.write_text("keep-me\n")
+    docker_socket.touch()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--input",
+            str(active),
+            "--output",
+            str(output),
+            "--docker-socket",
+            str(docker_socket),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert output.read_text() == "keep-me\n"

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(name: str) -> dict:
+    return yaml.load(
+        (REPOSITORY_ROOT / ".github" / "workflows" / name).read_text(),
+        Loader=yaml.BaseLoader,
+    )
+
+
+def test_production_deploy_requires_an_explicit_main_branch_confirmation() -> None:
+    workflow = _workflow("cd-prod.yml")
+
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+    confirmation = workflow["on"]["workflow_dispatch"]["inputs"][
+        "confirm_production"
+    ]
+    assert confirmation["type"] == "boolean"
+    assert confirmation["required"] == "true"
+    assert confirmation["default"] == "false"
+
+    deploy = workflow["jobs"]["deploy"]
+    assert deploy["environment"] == "production"
+    assert "github.ref == 'refs/heads/main'" in deploy["if"]
+    assert "inputs.confirm_production" in deploy["if"]
+    assert workflow["concurrency"]["cancel-in-progress"] == "false"
+
+    deploy_step = next(
+        step for step in deploy["steps"] if step.get("name") == "Deploy on server"
+    )
+    assert "if" not in deploy_step
+    verify_ci_step = next(
+        step
+        for step in deploy["steps"]
+        if step.get("name") == "Verify release CI"
+    )
+    assert "gh run list" in verify_ci_step["run"]
+    assert "conclusion" in verify_ci_step["run"]
+    assert deploy["permissions"]["actions"] == "read"
+
+
+def test_ci_compose_check_uses_a_populated_ci_environment() -> None:
+    workflow = _workflow("ci.yml")
+    static_steps = workflow["jobs"]["static-checks"]["steps"]
+    compose_step = next(
+        step
+        for step in static_steps
+        if step.get("name") == "Deployment Compose Config Check"
+    )
+    command = compose_step["run"]
+
+    assert "bash scripts/check-compose-config.sh" in command
+
+    compose_check = (
+        REPOSITORY_ROOT / "scripts" / "check-compose-config.sh"
+    ).read_text()
+
+    for key in (
+        "QJUDGE_PUBLIC_ORIGIN",
+        "SECRET_KEY",
+        "POSTGRES_ADMIN_PASSWORD",
+        "DB_PASSWORD",
+        "AI_DB_PASSWORD",
+        "CREDENTIAL_LEASE_SECRET",
+        "DOCKER_GID",
+        "DOCKER_SOCKET_UID",
+        "OBJECT_STORAGE_ENDPOINT_URL",
+        "OBJECT_STORAGE_PUBLIC_ENDPOINT_URL",
+        "OBJECT_STORAGE_ACCESS_KEY",
+        "OBJECT_STORAGE_SECRET_KEY",
+        "LOADTEST_OBJECT_STORAGE_ENDPOINT_URL",
+        "LOADTEST_OBJECT_STORAGE_PUBLIC_ENDPOINT_URL",
+        "LOADTEST_OBJECT_STORAGE_ACCESS_KEY",
+        "LOADTEST_OBJECT_STORAGE_SECRET_KEY",
+        "LOADTEST_ANTICHEAT_RAW_BUCKET",
+    ):
+        assert f"{key}=" in compose_check
+    assert "--env-file" in compose_check
+    assert ".env.example" in compose_check
+
+
+def test_local_pre_push_uses_the_same_compose_config_gate_as_ci() -> None:
+    pre_push = (REPOSITORY_ROOT / "scripts" / "pre-push-check.sh").read_text()
+
+    assert "bash scripts/check-compose-config.sh" in pre_push
+    assert "docker compose config -q" not in pre_push
+
+
+def test_mcp_ci_jobs_respect_the_server_major_version_constraint() -> None:
+    workflow = _workflow("ci.yml")
+
+    install_steps = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if step.get("name") == "Install MCP Server dependencies"
+    ]
+
+    assert len(install_steps) == 2
+    for step in install_steps:
+        assert step["working-directory"] == "mcp-server"
+        assert '"mcp[cli]>=1.9.0,<2.0"' in step["run"]


### PR DESCRIPTION
## Summary
- make production CD manual-only, main-only, confirmation-gated, and dependent on a successful CI push run for the selected SHA
- add a shared Compose config gate used by CI and the local pre-push hook
- add inactive production env candidate generation with independent database and lease credentials
- create and validate a PostgreSQL backup before deployment, bootstrap legacy database admin and Integrity credentials, build the Integrity worker, and check all critical HTTP boundaries
- resolve React compiler lint blockers uncovered by the repaired CI gate

## Production safety
- no production application deployment is included or triggered
- the current production `.env` remains active and unchanged
- the prepared `.env.next` remains inactive until an approved maintenance window
- deployment failure reports the previous SHA and validated backup path; recovery remains an explicit operator action

## Validation
- all 7 GitHub CI jobs passed for `457f5cae19e120840edc0d1f69b65bf6da2a53c5`
- frontend coverage: 188 test files passed in the pre-commit verification run
- frontend lint, typecheck, and production build passed
- local pre-push gate passed, including the shared Compose matrix
- MCP unit tests passed (77 tests), and the full integration job passed with the MCP `<2.0` compatibility constraint
- 38 Compose boundary contract tests passed
- 8 deployment documentation contract tests passed
- 42 quality-gate contract tests passed
- naming, architecture, repository exports, and Carbon strict gates passed

## Scope exception
- this PR exceeds the preferred 20-file / 400-line review size because the deployment workflow, deployment script, environment preparation, Compose validation, contract tests, operator documentation, and repository-local overflow skill form one release-safety boundary
- splitting those pieces would create intermediate commits where the runtime behavior and its safety contracts disagree
- the frontend edits are narrow React compiler corrections exposed by restoring the CI gate; they do not introduce a separate feature

## Risk and rollback
- risk: high because the deployment path and production credential boundaries change
- rollback: do not promote `.env.next` until maintenance approval; retain the previous SHA and validated PostgreSQL backup; application rollback and database restore are separate explicit operator decisions

## Merge checklist
- [x] target branch is `dev`
- [x] branch is mergeable and all required project CI jobs pass
- [x] local pre-push, naming, architecture, repository export, Carbon, typecheck, build, and Compose gates pass
- [x] production remains on the previous SHA; no deployment or service restart was performed
- [ ] human review of the deployment and rollback sections
