### PR TITLE
fix(security): resolve release CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,8 @@ jobs:
     needs: static-checks
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/backend/apps/contests/services/attendance.py
+++ b/backend/apps/contests/services/attendance.py
@@ -69,6 +69,14 @@ AttendanceErrorCode = Literal[
 ]
 ATTENDANCE_ERROR_CODES: tuple[AttendanceErrorCode, ...] = get_args(AttendanceErrorCode)
 
+
+class AttendanceValidationError(ValueError):
+    """Attendance validation failure with a safe public error code."""
+
+    def __init__(self, code: AttendanceErrorCode) -> None:
+        self.code = code
+        super().__init__(code)
+
 ATTENDANCE_ERROR_MESSAGES: dict[AttendanceErrorCode, str] = {
     "attendance_check_in_already_completed": "Attendance check-in has already been completed.",
     "attendance_check_in_required": (
@@ -119,17 +127,11 @@ def _credential_lock_cache_key(contest: Contest, purpose: str) -> str:
     return f"{ATTENDANCE_CREDENTIAL_LOCK_CACHE_PREFIX}:{contest.id}:{purpose}"
 
 
-def normalize_attendance_error_code(error: ValueError) -> str:
-    code = str(error)
-    return code if code in ATTENDANCE_ERROR_MESSAGES else "invalid_attendance_request"
-
-
-def build_attendance_error_payload(code: str) -> dict[str, Any]:
-    safe_code = code if code in ATTENDANCE_ERROR_MESSAGES else "invalid_attendance_request"
+def build_attendance_error_payload(code: AttendanceErrorCode) -> dict[str, Any]:
     return {
-        "code": safe_code,
+        "code": code,
         "error": {
-            "message": ATTENDANCE_ERROR_MESSAGES[safe_code],
+            "message": ATTENDANCE_ERROR_MESSAGES[code],
         },
     }
 
@@ -246,12 +248,12 @@ def _generate_new_attendance_credential(
                 timeout=cache_timeout,
             )
             return _public_attendance_credential(payload)
-    raise ValueError("attendance_manual_code_generation_failed")
+    raise AttendanceValidationError("attendance_manual_code_generation_failed")
 
 
 def create_attendance_credential(contest: Contest, purpose: str) -> dict[str, str]:
     if purpose not in ATTENDANCE_EVENT_TYPES:
-        raise ValueError("invalid_attendance_purpose")
+        raise AttendanceValidationError("invalid_attendance_purpose")
     active_key = _active_credential_cache_key(contest, purpose)
     active = cache.get(active_key)
     if _is_active_credential_fresh(active):
@@ -290,32 +292,32 @@ def create_attendance_token(contest: Contest, purpose: str) -> str:
 
 def validate_attendance_cache_payload(contest: Contest, purpose: str, value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
-        raise ValueError("invalid_attendance_token")
+        raise AttendanceValidationError("invalid_attendance_token")
     if str(value.get("contest_id")) != str(contest.id) or value.get("purpose") != purpose:
-        raise ValueError("invalid_attendance_token")
+        raise AttendanceValidationError("invalid_attendance_token")
     if not _is_credential_within_validation_window(value):
-        raise ValueError("invalid_attendance_token")
+        raise AttendanceValidationError("invalid_attendance_token")
     return value
 
 
 def validate_attendance_token(contest: Contest, purpose: str, token: str) -> dict[str, Any]:
     if purpose not in ATTENDANCE_EVENT_TYPES:
-        raise ValueError("invalid_attendance_purpose")
+        raise AttendanceValidationError("invalid_attendance_purpose")
     value = cache.get(_token_cache_key(token))
     return validate_attendance_cache_payload(contest, purpose, value)
 
 
 def validate_attendance_manual_code(contest: Contest, purpose: str, manual_code: str) -> dict[str, Any]:
     if purpose not in ATTENDANCE_EVENT_TYPES:
-        raise ValueError("invalid_attendance_purpose")
+        raise AttendanceValidationError("invalid_attendance_purpose")
     normalized = normalize_attendance_manual_code(manual_code)
     if len(normalized) != ATTENDANCE_MANUAL_CODE_LENGTH:
-        raise ValueError("invalid_attendance_manual_code")
+        raise AttendanceValidationError("invalid_attendance_manual_code")
     value = cache.get(_manual_code_cache_key(normalized))
     try:
         return validate_attendance_cache_payload(contest, purpose, value)
-    except ValueError:
-        raise ValueError("invalid_attendance_manual_code") from None
+    except AttendanceValidationError:
+        raise AttendanceValidationError("invalid_attendance_manual_code") from None
 
 
 def build_attendance_qr_value(purpose: str, token: str) -> str:
@@ -435,7 +437,7 @@ def build_attendance_status(contest: Contest, participant: ContestParticipant | 
 def assert_attendance_allows_start(contest: Contest, participant: ContestParticipant) -> None:
     status = build_attendance_status(contest, participant)
     if status["attendanceRequired"] and not status["canStartExam"]:
-        raise ValueError("attendance_check_in_required")
+        raise AttendanceValidationError("attendance_check_in_required")
 
 
 def validate_self_scan_credential(
@@ -443,9 +445,9 @@ def validate_self_scan_credential(
 ) -> str:
     """Validate the QR token or manual code and return the credential source label."""
     if token and manual_code:
-        raise ValueError("attendance_credential_conflict")
+        raise AttendanceValidationError("attendance_credential_conflict")
     if not token and not manual_code:
-        raise ValueError("attendance_token_required")
+        raise AttendanceValidationError("attendance_token_required")
     if manual_code:
         validate_attendance_manual_code(contest, purpose, manual_code)
         return "manual_code"
@@ -461,7 +463,7 @@ def _resolve_self_scan_event(
 ) -> dict[str, Any]:
     purpose = data["purpose"]
     if data.get("user_id"):
-        raise ValueError("user_id_forbidden_for_self_scan")
+        raise AttendanceValidationError("user_id_forbidden_for_self_scan")
     credential_source = validate_self_scan_credential(
         contest,
         purpose,
@@ -475,7 +477,7 @@ def _resolve_self_scan_event(
     if participant is None:
         participant = ContestParticipant.objects.filter(contest=contest, user=actor).first()
     if participant is None:
-        raise ValueError("not_registered")
+        raise AttendanceValidationError("not_registered")
 
     if purpose == "check_in" and participant.exam_status != ExamStatus.NOT_STARTED:
         return {"error_code": "check_in_only_before_personal_start"}
@@ -513,21 +515,21 @@ def _resolve_teacher_assisted_event(
 ) -> dict[str, Any]:
     purpose = data["purpose"]
     if not can_manage_contest(actor, contest):
-        raise ValueError("attendance_teacher_permission_required")
+        raise AttendanceValidationError("attendance_teacher_permission_required")
     if data.get("token"):
-        raise ValueError("token_forbidden_for_teacher_assisted")
+        raise AttendanceValidationError("token_forbidden_for_teacher_assisted")
     if not data.get("user_id"):
-        raise ValueError("user_id_required")
+        raise AttendanceValidationError("user_id_required")
     reason = str(data.get("reason") or "").strip()
     if not reason:
-        raise ValueError("reason_required")
+        raise AttendanceValidationError("reason_required")
     try:
         participant = ContestParticipant.objects.select_related("user").get(
             contest=contest,
             user_id=data["user_id"],
         )
     except ContestParticipant.DoesNotExist:
-        raise ValueError("participant_not_found") from None
+        raise AttendanceValidationError("participant_not_found") from None
 
     if _is_attendance_purpose_completed(contest, participant, purpose):
         return {"error_code": _attendance_completed_error_code(purpose)}
@@ -561,7 +563,7 @@ def create_attendance_event(
     elif mode == "teacher_assisted":
         resolved = _resolve_teacher_assisted_event(contest, actor, data)
     else:
-        raise ValueError("invalid_attendance_mode")
+        raise AttendanceValidationError("invalid_attendance_mode")
 
     if "error_response" in resolved or "error_code" in resolved:
         return resolved
@@ -604,7 +606,7 @@ def reset_participant_exam_records(
             user_id=user_id,
         )
     except ContestParticipant.DoesNotExist:
-        raise ValueError("participant_not_found") from None
+        raise AttendanceValidationError("participant_not_found") from None
 
     reset_summary = reset_participant_exam_record(
         participant,

--- a/backend/apps/contests/tests/integrity/test_run_views_security.py
+++ b/backend/apps/contests/tests/integrity/test_run_views_security.py
@@ -1,0 +1,16 @@
+from apps.contests.services.integrity_runs import InvalidRunTransition
+from apps.contests.views.integrity_runs import IntegrityRunViewSet
+
+
+def test_transition_response_does_not_expose_exception_details():
+    def fail_transition():
+        raise InvalidRunTransition("internal transition state: secret")
+
+    response = IntegrityRunViewSet._transition_response(fail_transition)
+
+    assert response.status_code == 409
+    assert response.data == {
+        "code": "invalid_integrity_run_transition",
+        "detail": "Integrity run cannot perform the requested transition.",
+    }
+    assert "secret" not in str(response.data)

--- a/backend/apps/contests/views/attendance.py
+++ b/backend/apps/contests/views/attendance.py
@@ -11,12 +11,12 @@ from ..permissions import can_manage_contest
 from ..services.attendance import (
     ATTENDANCE_EVENT_TYPES,
     ATTENDANCE_REFRESH_SECONDS,
+    AttendanceValidationError,
     validate_self_scan_credential,
     build_attendance_error_payload,
     build_attendance_qr_value,
     create_attendance_credential,
     create_attendance_event,
-    normalize_attendance_error_code,
     reset_participant_exam_records,
 )
 
@@ -84,9 +84,13 @@ def _attendance_disabled_response(contest: Contest) -> Response | None:
     )
 
 
-def _value_error_response(exc: ValueError, *, http_status: int = status.HTTP_400_BAD_REQUEST) -> Response:
+def _validation_error_response(
+    exc: AttendanceValidationError,
+    *,
+    http_status: int = status.HTTP_400_BAD_REQUEST,
+) -> Response:
     return Response(
-        build_attendance_error_payload(normalize_attendance_error_code(exc)),
+        build_attendance_error_payload(exc.code),
         status=http_status,
     )
 
@@ -153,8 +157,8 @@ class AttendanceMixin:
             credential_source = validate_self_scan_credential(
                 contest, purpose, token, manual_code
             )
-        except ValueError as exc:
-            return _value_error_response(exc)
+        except AttendanceValidationError as exc:
+            return _validation_error_response(exc)
 
         return Response({
             "valid": True,
@@ -183,14 +187,13 @@ class AttendanceMixin:
                 data=serializer.validated_data,
                 ensure_participant=self._ensure_classroom_bound_participant,
             )
-        except ValueError as exc:
-            code = normalize_attendance_error_code(exc)
+        except AttendanceValidationError as exc:
             http_status = (
                 status.HTTP_403_FORBIDDEN
-                if code == "attendance_teacher_permission_required"
+                if exc.code == "attendance_teacher_permission_required"
                 else status.HTTP_400_BAD_REQUEST
             )
-            return _value_error_response(exc, http_status=http_status)
+            return _validation_error_response(exc, http_status=http_status)
 
         error_response = result.get("error_response")
         if error_response is not None:
@@ -224,6 +227,6 @@ class AttendanceMixin:
                 serializer.validated_data["user_id"],
                 activity_user=request.user,
             )
-        except ValueError as exc:
-            return _value_error_response(exc)
+        except AttendanceValidationError as exc:
+            return _validation_error_response(exc)
         return Response(result)

--- a/backend/apps/contests/views/exam_lifecycle.py
+++ b/backend/apps/contests/views/exam_lifecycle.py
@@ -24,9 +24,9 @@ from ..services.anti_cheat_session import (
 from ..services.integrity_presence import clear_checkpoint
 from ..services.exam_submission import finalize_submission
 from ..services.attendance import (
+    AttendanceValidationError,
     assert_attendance_allows_start,
     build_attendance_error_payload,
-    normalize_attendance_error_code,
 )
 from ..services.activity_log import log_contest_activity
 from .exam_events import ExamEventsMixin
@@ -69,9 +69,9 @@ class ExamLifecycleMixin:
 
         try:
             assert_attendance_allows_start(contest, participant)
-        except ValueError as exc:
+        except AttendanceValidationError as exc:
             return Response(
-                build_attendance_error_payload(normalize_attendance_error_code(exc)),
+                build_attendance_error_payload(exc.code),
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/backend/apps/contests/views/integrity_runs.py
+++ b/backend/apps/contests/views/integrity_runs.py
@@ -39,11 +39,11 @@ class IntegrityRunViewSet(viewsets.ViewSet):
     def _transition_response(operation):
         try:
             run = operation()
-        except InvalidRunTransition as exc:
+        except InvalidRunTransition:
             return Response(
                 {
                     "code": "invalid_integrity_run_transition",
-                    "detail": str(exc),
+                    "detail": "Integrity run cannot perform the requested transition.",
                 },
                 status=status.HTTP_409_CONFLICT,
             )

--- a/backend/apps/oauth/tests/test_authorize.py
+++ b/backend/apps/oauth/tests/test_authorize.py
@@ -2,8 +2,10 @@ import json
 import hashlib
 import base64
 import secrets
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch
 
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.contrib.auth import get_user_model
 from oauth2_provider.models import Application, Grant
@@ -60,6 +62,28 @@ class AuthorizeRedirectTest(TestCase):
         self.assertIn("client_id=test-client-id", location)
         self.assertIn("client_name=Test", location)
 
+    @patch("apps.oauth.views._get_user_from_jwt_cookie")
+    def test_redirect_drops_unrecognized_query_fields(self, mock_get_user):
+        mock_get_user.return_value = self.user
+        _, challenge = _pkce_pair()
+
+        response = self.client.get(
+            "/o/authorize/",
+            {
+                "response_type": "code",
+                "client_id": "test-client-id",
+                "redirect_uri": "http://localhost:3000/callback",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "next": "https://evil.example/steal",
+            },
+        )
+
+        location = urlparse(response["Location"])
+        self.assertEqual(location.scheme, "https")
+        self.assertEqual(location.netloc, "qjudge.com")
+        self.assertNotIn("next", parse_qs(location.query))
+
     def test_redirects_to_login_when_not_authenticated(self):
         _, challenge = _pkce_pair()
         response = self.client.get(
@@ -78,6 +102,11 @@ class AuthorizeRedirectTest(TestCase):
         self.assertIn("next=", location)
         # next must be a relative path (not absolute) so the frontend accepts it
         self.assertNotIn("next=http", location)
+
+    @override_settings(FRONTEND_URL="javascript:alert(1)")
+    def test_rejects_unsafe_frontend_url_configuration(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get("/o/authorize/")
 
 
 @override_settings(

--- a/backend/apps/oauth/views.py
+++ b/backend/apps/oauth/views.py
@@ -2,14 +2,16 @@ import json
 import secrets
 import string
 from datetime import timedelta
-from urllib.parse import quote, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 import jwt
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 from drf_spectacular.utils import extend_schema, inline_serializer
@@ -30,6 +32,16 @@ from .resource_tokens import (
 )
 
 User = get_user_model()
+
+OAUTH_AUTHORIZATION_QUERY_FIELDS = (
+    "client_id",
+    "code_challenge",
+    "code_challenge_method",
+    "redirect_uri",
+    "response_type",
+    "scope",
+    "state",
+)
 
 
 def _supported_oauth_scopes() -> list[str]:
@@ -106,6 +118,46 @@ def _get_user_from_jwt_cookie(request):
         return User.objects.get(pk=user_id)
     except Exception:
         return None
+
+
+def _authorization_query(request) -> dict[str, str]:
+    """Copy only fields consumed by the QJudge OAuth consent screen."""
+    return {
+        field: request.GET[field]
+        for field in OAUTH_AUTHORIZATION_QUERY_FIELDS
+        if field in request.GET
+    }
+
+
+def _frontend_redirect(path: str, query: dict[str, str]):
+    """Build and validate a redirect constrained to the configured frontend origin."""
+    frontend_url = getattr(settings, "FRONTEND_URL", settings.OAUTH_ISSUER_URL)
+    parsed_frontend = urlparse(frontend_url)
+    if (
+        parsed_frontend.scheme not in {"http", "https"}
+        or not parsed_frontend.netloc
+        or parsed_frontend.username
+        or parsed_frontend.password
+        or parsed_frontend.query
+        or parsed_frontend.fragment
+    ):
+        raise ImproperlyConfigured("FRONTEND_URL must be an HTTP(S) origin or path prefix")
+
+    prefix = parsed_frontend.path.rstrip("/")
+    target_path = f"{prefix}/{path.lstrip('/')}"
+    target = parsed_frontend._replace(
+        path=target_path,
+        params="",
+        query=urlencode(query),
+        fragment="",
+    ).geturl()
+    if not url_has_allowed_host_and_scheme(
+        target,
+        allowed_hosts={parsed_frontend.netloc},
+        require_https=parsed_frontend.scheme == "https",
+    ):
+        raise ImproperlyConfigured("FRONTEND_URL produced an unsafe redirect target")
+    return redirect(target)
 
 
 @csrf_exempt
@@ -205,25 +257,24 @@ def dynamic_client_registration(request):
 @require_GET
 def authorize_redirect(request):
     """Redirect to frontend OAuth authorize page, using JWT cookie for auth."""
-    frontend_url = getattr(settings, "FRONTEND_URL", settings.OAUTH_ISSUER_URL)
     user = _get_user_from_jwt_cookie(request)
+    params = _authorization_query(request)
 
     if not user:
-        # Not logged in — redirect to frontend login with next= relative path
-        # Use relative path so the frontend open-redirect guard accepts it
-        full_url = request.get_full_path()
-        return redirect(f"{frontend_url}/login?next={quote(full_url, safe='')}")
+        next_path = request.path
+        if params:
+            next_path = f"{next_path}?{urlencode(params)}"
+        return _frontend_redirect("/login", {"next": next_path})
 
-    params = request.GET.urlencode()
     # Look up client name from Application for the consent page
-    client_id = request.GET.get("client_id")
+    client_id = params.get("client_id")
     if client_id:
         try:
             app = Application.objects.get(client_id=client_id)
-            params += f"&client_name={quote(app.name, safe='')}"
+            params["client_name"] = app.name
         except Application.DoesNotExist:
             pass
-    return redirect(f"{frontend_url}/oauth/authorize?{params}")
+    return _frontend_redirect("/oauth/authorize", params)
 
 
 class ApproveAuthorizationView(APIView):

--- a/backend/apps/problems/test_run_service.py
+++ b/backend/apps/problems/test_run_service.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Literal
+
 from apps.judge import judge_factory
 from apps.problems.models import CodingProblem, TestCase
 
 HARD_FAILURE_STATUSES = {"CE", "SE"}
+logger = logging.getLogger(__name__)
+
+TestRunSetupErrorCode = Literal["unsupported_language", "judge_unavailable"]
 
 
 class TestRunSetupError(Exception):
     """Raised when the test-run environment cannot be prepared."""
+
+    def __init__(self, code: TestRunSetupErrorCode) -> None:
+        self.code = code
+        super().__init__(code)
 
 
 class ProblemTestRunService:
@@ -49,9 +59,9 @@ class ProblemTestRunService:
         try:
             judge = judge_factory.get_judge(language)
         except ValueError as exc:
-            raise TestRunSetupError(str(exc)) from exc
+            raise TestRunSetupError("unsupported_language") from exc
         except Exception as exc:  # pragma: no cover - safety net
-            raise TestRunSetupError(f"Judge system error: {exc}") from exc
+            raise TestRunSetupError("judge_unavailable") from exc
 
         results = []
         max_exec_time = 0
@@ -67,13 +77,14 @@ class ProblemTestRunService:
                     time_limit=problem.time_limit,
                     memory_limit=problem.memory_limit,
                 )
-            except Exception as exc:  # pragma: no cover - safety net
+            except Exception:  # pragma: no cover - safety net
+                logger.exception("Unexpected judge execution failure")
                 exec_result = {
                     "status": "SE",
                     "time": 0,
                     "memory": 0,
                     "output": "",
-                    "error": str(exc),
+                    "error": "Judge execution failed.",
                 }
 
             case_result = cls._build_case_result(tc, exec_result)

--- a/backend/apps/problems/tests/test_test_run_service_security.py
+++ b/backend/apps/problems/tests/test_test_run_service_security.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apps.problems.test_run_service import (
+    ProblemTestRunService,
+    TestRunSetupError as RunSetupError,
+)
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    [
+        (ValueError("unsupported python-secret"), "unsupported_language"),
+        (RuntimeError("judge host secret"), "judge_unavailable"),
+    ],
+)
+def test_setup_error_exposes_only_typed_public_code(failure, expected_code):
+    with patch(
+        "apps.problems.test_run_service.judge_factory.get_judge",
+        side_effect=failure,
+    ):
+        with pytest.raises(RunSetupError) as caught:
+            ProblemTestRunService.run(
+                problem=SimpleNamespace(),
+                language="secret-language",
+                source_code="",
+            )
+
+    assert caught.value.code == expected_code
+    assert str(caught.value) == expected_code
+    assert "secret" not in str(caught.value)
+
+
+def test_unexpected_execution_failure_uses_fixed_public_message():
+    judge = SimpleNamespace(execute=lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("host secret")))
+    test_case = SimpleNamespace(
+        id=1,
+        input_data="",
+        output_data="",
+        is_hidden=False,
+    )
+    problem = SimpleNamespace(
+        test_cases=SimpleNamespace(all=lambda: [test_case]),
+        time_limit=1,
+        memory_limit=64,
+    )
+
+    with patch(
+        "apps.problems.test_run_service.judge_factory.get_judge",
+        return_value=judge,
+    ):
+        result = ProblemTestRunService.run(
+            problem=problem,
+            language="python",
+            source_code="print(1)",
+        )
+
+    assert result["results"][0]["error_message"] == "Judge execution failed."
+    assert "secret" not in str(result)

--- a/backend/apps/problems/views.py
+++ b/backend/apps/problems/views.py
@@ -276,14 +276,16 @@ class ProblemViewSet(viewsets.ModelViewSet):
                 source_code=serializer.validated_data["code"],
             )
         except TestRunSetupError as exc:
-            error_text = str(exc)
-            logger.warning("Test run setup error: %s", error_text)
-            if error_text.startswith("Judge system error:"):
+            logger.warning("Test run setup failed with code=%s", exc.code)
+            if exc.code == "judge_unavailable":
                 return Response(
                     {"error": "Judge system error"},
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
-            return Response({"error": error_text}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "Unsupported language"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         return Response(result)
     

--- a/frontend/src/features/auth/contexts/AuthContext.test.tsx
+++ b/frontend/src/features/auth/contexts/AuthContext.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { logout } from "@/infrastructure/api/repositories/auth.repository";
+import { getCurrentUser } from "@/infrastructure/api/repositories/user.repository";
+import { AuthProvider, useAuth } from "./AuthContext";
+
+vi.mock("@/infrastructure/api/repositories/auth.repository", () => ({
+  logout: vi.fn(),
+}));
+
+vi.mock("@/infrastructure/api/repositories/user.repository", () => ({
+  getCurrentUser: vi.fn(),
+}));
+
+const AuthProbe = () => {
+  const { loading, user, logout: signOut } = useAuth();
+  return (
+    <div>
+      <span data-testid="auth-state">
+        {loading ? "loading" : user?.username ?? "anonymous"}
+      </span>
+      <button type="button" onClick={() => void signOut()}>
+        Sign out
+      </button>
+    </div>
+  );
+};
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hydrates identity from the cookie-backed current-user endpoint", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      success: true,
+      data: { id: 7, username: "alice", role: "student" },
+    });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("alice");
+    });
+    expect(localStorage.getItem).not.toHaveBeenCalledWith("user");
+  });
+
+  it("settles as anonymous when no authenticated cookie session exists", async () => {
+    vi.mocked(getCurrentUser).mockRejectedValue(
+      Object.assign(new Error("Not authenticated"), { status: 401 }),
+    );
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("anonymous");
+    });
+    expect(localStorage.getItem).not.toHaveBeenCalledWith("user");
+  });
+
+  it("removes legacy identity data when signing out", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      success: true,
+      data: { id: 7, username: "alice", role: "student" },
+    });
+    vi.mocked(logout).mockResolvedValue(undefined);
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+    await screen.findByText("alice");
+    screen.getByRole("button", { name: "Sign out" }).click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("anonymous");
+    });
+    expect(localStorage.removeItem).toHaveBeenCalledWith("user");
+  });
+});

--- a/frontend/src/features/auth/contexts/AuthContext.tsx
+++ b/frontend/src/features/auth/contexts/AuthContext.tsx
@@ -1,14 +1,25 @@
 
-import React, { createContext, useContext, useState, useEffect, useRef, type ReactNode } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
 import type { User } from "@/core/entities/auth.entity";
 import { logout as logoutApi } from "@/infrastructure/api/repositories/auth.repository";
-import { clearAuthStorage } from "@/infrastructure/api/http.client";
+import { getCurrentUser } from "@/infrastructure/api/repositories/user.repository";
+import {
+  clearAuthStorage,
+  isAuthSessionStorageEvent,
+} from "@/infrastructure/api/http.client";
 
 interface AuthContextType {
   user: User | null;
   loading: boolean;
   setUser: (user: User | null) => void;
-  checkUser: () => void;
+  checkUser: () => Promise<void>;
   logout: () => Promise<void>;
 }
 
@@ -17,30 +28,21 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const lastUserStrRef = useRef<string | null>(null);
 
-  const checkUser = () => {
-    const userStr = localStorage.getItem('user');
-    // Skip setUser if the serialized value hasn't changed — prevents
-    // unnecessary re-renders when useUserPreferences writes back
-    // the same data to localStorage.
-    if (userStr === lastUserStrRef.current) {
-      setLoading(false);
-      return;
-    }
-    lastUserStrRef.current = userStr;
-    if (userStr) {
-      try {
-        setUser(JSON.parse(userStr));
-      } catch (e) {
-        console.error("Failed to parse user data", e);
-        setUser(null);
-      }
-    } else {
+  const checkUser = useCallback(async () => {
+    try {
+      const response = await getCurrentUser();
+      setUser(response.data);
+    } catch (error) {
       setUser(null);
+      const status = (error as { status?: number }).status;
+      if (status !== 401) {
+        console.error("Failed to load current user", error);
+      }
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
-  };
+  }, []);
 
   const logout = async () => {
     try {
@@ -55,12 +57,15 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   };
 
   useEffect(() => {
-    checkUser();
-    // Listen for storage changes to sync across tabs/components if they update localStorage directly
-    const handleStorageChange = () => checkUser();
-    window.addEventListener('storage', handleStorageChange);
-    return () => window.removeEventListener('storage', handleStorageChange);
-  }, []);
+    void checkUser();
+    const handleStorageChange = (event: StorageEvent) => {
+      if (isAuthSessionStorageEvent(event)) {
+        void checkUser();
+      }
+    };
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, [checkUser]);
 
   return (
     <AuthContext.Provider value={{ user, loading, setUser, checkUser, logout }}>
@@ -72,7 +77,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 };

--- a/frontend/src/features/auth/hooks/useUserPreferences.ts
+++ b/frontend/src/features/auth/hooks/useUserPreferences.ts
@@ -18,6 +18,7 @@ import type {
   UpdatePreferencesRequest,
   UpdateAccountProfileRequest,
 } from "@/core/entities/auth.entity";
+import { notifyAuthSessionChanged } from "@/infrastructure/api/http.client";
 
 // Module-level state to prevent multiple instances from loading simultaneously
 let globalLoadedForUserId: number | null = null;
@@ -105,18 +106,26 @@ export const useUserPreferences = (): UseUserPreferencesReturn => {
   const syncAuthUserProfile = useCallback(
     (nextProfile: Partial<UserProfile>) => {
       if (!user) return;
+      const currentProfile: UserProfile = user.profile ?? {
+        solved_count: 0,
+        submission_count: 0,
+        accept_rate: 0,
+        preferred_language: contentLanguage,
+        preferred_theme: preference,
+        editor_font_size: preferences?.editor_font_size ?? 12,
+        editor_tab_size: preferences?.editor_tab_size ?? 4,
+      };
       const nextUser = {
         ...user,
         profile: {
-          ...(user.profile || {}),
+          ...currentProfile,
           ...nextProfile,
         },
       };
-      setUser(nextUser as any);
-      localStorage.setItem("user", JSON.stringify(nextUser));
-      window.dispatchEvent(new Event("storage"));
+      setUser(nextUser);
+      notifyAuthSessionChanged();
     },
-    [user, setUser]
+    [contentLanguage, preference, preferences, user, setUser]
   );
 
   // Load preferences from backend when user is logged in
@@ -399,8 +408,7 @@ export const useUserPreferences = (): UseUserPreferencesReturn => {
       const response = await updateCurrentUserProfile(data);
       const nextUser = response.data;
       setUser(nextUser);
-      localStorage.setItem("user", JSON.stringify(nextUser));
-      window.dispatchEvent(new Event("storage"));
+      notifyAuthSessionChanged();
     },
     [user, setUser]
   );

--- a/frontend/src/features/auth/screens/InviteLinkScreen.tsx
+++ b/frontend/src/features/auth/screens/InviteLinkScreen.tsx
@@ -6,6 +6,7 @@ import type { ClassroomDetailDto } from "@/infrastructure/api/dto/classroom.dto"
 import { useAuth } from "@/features/auth/contexts/AuthContext";
 import { useAuthLayoutMetadata } from "@/features/auth/contexts/AuthLayoutContext";
 import { inspectActionLink, redeemActionLink } from "@/infrastructure/api/repositories/auth.repository";
+import { notifyAuthSessionChanged } from "@/infrastructure/api/http.client";
 import { mapClassroomDetailDto } from "@/infrastructure/mappers/classroom.mapper";
 import { getAuthedLandingPath } from "@/features/auth/utils/onboarding";
 import { PENDING_ACTIONS, storePendingAction, clearPendingAction } from "@/features/auth/pending-actions";
@@ -133,8 +134,7 @@ const InviteLinkScreen = () => {
       if (isAuthRedeemResponse(response)) {
         const nextUser = response.data.user;
         setUser(nextUser);
-        localStorage.setItem("user", JSON.stringify(nextUser));
-        window.dispatchEvent(new Event("storage"));
+        notifyAuthSessionChanged();
         setSuccess(response.message || "邀請已完成");
         window.location.href = getAuthedLandingPath(nextUser);
         return;

--- a/frontend/src/features/auth/screens/LoginScreen.tsx
+++ b/frontend/src/features/auth/screens/LoginScreen.tsx
@@ -13,6 +13,7 @@ import {
   getOAuthUrl,
   login,
 } from "@/infrastructure/api/repositories/auth.repository";
+import { notifyAuthSessionChanged } from "@/infrastructure/api/http.client";
 import { useAuthOptions } from "@/features/auth/hooks";
 import { getAuthedLandingPath } from "@/features/auth/utils/onboarding";
 import { AuthProviderButton } from "@/features/auth/components/AuthProviderButton";
@@ -47,9 +48,8 @@ const LoginPage = () => {
     try {
       const response = await login({ identifier, password });
       if (response.success) {
-        const { access_token: _a, refresh_token: _r, ...safeData } = response.data;
-        localStorage.setItem("user", JSON.stringify(safeData.user));
-        window.location.href = getAuthedLandingPath(safeData.user);
+        notifyAuthSessionChanged();
+        window.location.href = getAuthedLandingPath(response.data.user);
       } else {
         setError(t("auth.login.failed"));
       }

--- a/frontend/src/features/auth/screens/OAuthCallbackScreen.tsx
+++ b/frontend/src/features/auth/screens/OAuthCallbackScreen.tsx
@@ -4,6 +4,7 @@ import { Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'motion/react';
 import { oauthCallback } from "@/infrastructure/api/repositories/auth.repository";
+import { notifyAuthSessionChanged } from "@/infrastructure/api/http.client";
 import { useAuthLayoutMetadata } from '../contexts/AuthLayoutContext';
 import { AuthLoadingSkeleton } from '../components/AuthLoadingSkeleton';
 import { getAuthedLandingPath } from "@/features/auth/utils/onboarding";
@@ -56,9 +57,8 @@ const OAuthCallbackPage = () => {
         const response = await oauthCallback(provider, code);
 
         if (response.success) {
-          const { access_token: _a, refresh_token: _r, ...safeData } = response.data;
-          localStorage.setItem('user', JSON.stringify(safeData.user));
-          const nextPath = getAuthedLandingPath(safeData.user);
+          notifyAuthSessionChanged();
+          const nextPath = getAuthedLandingPath(response.data.user);
 
           const elapsedTime = Date.now() - startTime;
           const remainingTime = Math.max(0, MIN_ANIMATION_TIME - elapsedTime);

--- a/frontend/src/features/auth/screens/OnboardingScreen.tsx
+++ b/frontend/src/features/auth/screens/OnboardingScreen.tsx
@@ -16,6 +16,7 @@ import { useContentLanguage } from "@/shared/contexts/ContentLanguageContext";
 import { LanguageSwitch, ThemeSwitch } from "@/shared/ui/config";
 import { updatePreferences } from "@/infrastructure/api/repositories/user.repository";
 import { getAuthedLandingPath } from "@/features/auth/utils/onboarding";
+import { notifyAuthSessionChanged } from "@/infrastructure/api/http.client";
 import type { SupportedLanguage } from "@/i18n";
 
 const OnboardingScreen = () => {
@@ -74,8 +75,7 @@ const OnboardingScreen = () => {
       setPreference(preferences.preferred_theme);
       setContentLanguage(preferences.preferred_language as SupportedLanguage);
       setUser(nextUser);
-      localStorage.setItem("user", JSON.stringify(nextUser));
-      window.dispatchEvent(new Event("storage"));
+      notifyAuthSessionChanged();
       navigate(getAuthedLandingPath(nextUser), { replace: true });
     } catch (err: any) {
       setError(

--- a/frontend/src/features/auth/screens/RegisterScreen.tsx
+++ b/frontend/src/features/auth/screens/RegisterScreen.tsx
@@ -11,6 +11,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import type { AuthProviderOption } from "@/core/entities/auth.entity";
 import { getOAuthUrl, register } from "@/infrastructure/api/repositories/auth.repository";
+import { notifyAuthSessionChanged } from "@/infrastructure/api/http.client";
 import { useAuthOptions } from "@/features/auth/hooks";
 import { getAuthedLandingPath } from "@/features/auth/utils/onboarding";
 import { AuthProviderButton } from "@/features/auth/components/AuthProviderButton";
@@ -75,9 +76,8 @@ const RegisterPage = () => {
         password_confirm: confirmPassword,
       });
       if (response.success) {
-        const { access_token: _a, refresh_token: _r, ...safeData } = response.data;
-        localStorage.setItem("user", JSON.stringify(safeData.user));
-        window.location.href = getAuthedLandingPath(safeData.user);
+        notifyAuthSessionChanged();
+        window.location.href = getAuthedLandingPath(response.data.user);
       } else {
         setError(t("auth.register.failed"));
       }

--- a/frontend/src/features/contest/components/solver/submissions/ContestProblemSubmissions.integration.test.tsx
+++ b/frontend/src/features/contest/components/solver/submissions/ContestProblemSubmissions.integration.test.tsx
@@ -32,6 +32,10 @@ vi.mock("@/infrastructure/api/repositories/submission.repository", () => ({
   getSubmissions: vi.fn().mockResolvedValue({ results: [], count: 0 }),
 }));
 
+vi.mock("@/features/auth/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { id: 42 } }),
+}));
+
 import { getSubmissions } from "@/infrastructure/api/repositories/submission.repository";
 
 const CONTEST_ID = "contest-uuid";
@@ -85,9 +89,6 @@ function renderWithProviders(node: React.ReactElement) {
 describe("ContestProblemSubmissions integration — coding-problem id wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Component reads currentUser from localStorage; provide one so userId filter
-    // also lands in the outgoing params (extra assertion value).
-    localStorage.setItem("user", JSON.stringify({ id: 42 }));
   });
 
   it("forwards CodingProblem.id (not ContestQuestionBinding.id) to the submissions repository", async () => {

--- a/frontend/src/features/contest/components/solver/submissions/ContestProblemSubmissions.tsx
+++ b/frontend/src/features/contest/components/solver/submissions/ContestProblemSubmissions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   Button,
@@ -7,7 +7,7 @@ import {
 } from "@carbon/react";
 import { Renew } from "@carbon/icons-react";
 import { useContestSubmissions } from "@/features/contest/hooks/useContestSubmissions";
-import type { User } from "@/core/entities/user.entity";
+import { useAuth } from "@/features/auth/contexts/AuthContext";
 import { SubmissionDetailModal, SubmissionTable, type SubmissionRow } from "@/features/submissions/components";
 // Styles loaded via globals.scss (Sass Partials)
 
@@ -27,23 +27,14 @@ const ContestProblemSubmissions: React.FC<ContestProblemSubmissionsProps> = ({
   codingProblemId,
 }) => {
   const skeletonWidths = [
-    "calc(var(--cds-spacing-07) + var(--cds-spacing-06) + var(--cds-spacing-02))",
-    "var(--cds-spacing-08)",
-    "calc(var(--cds-spacing-07) + var(--cds-spacing-05) + var(--cds-spacing-01))",
-    "calc(var(--cds-spacing-07) + var(--cds-spacing-06) + var(--cds-spacing-02))",
-    "calc(var(--cds-spacing-09) + var(--cds-spacing-07))",
+    "3.75rem",
+    "2.5rem",
+    "3.125rem",
+    "3.75rem",
+    "5rem",
   ];
   const [searchParams, setSearchParams] = useSearchParams();
-  const [currentUser] = useState<User | null>(() => {
-    const userStr = localStorage.getItem("user");
-    if (!userStr) return null;
-    try {
-      return JSON.parse(userStr);
-    } catch (e) {
-      console.error("Failed to parse user", e);
-      return null;
-    }
-  });
+  const { user: currentUser } = useAuth();
 
   // Fetch submissions for this problem, filtered by current user
   const { data, isLoading, isFetching, refetch } = useContestSubmissions({

--- a/frontend/src/features/problems/contexts/ProblemContext.test.tsx
+++ b/frontend/src/features/problems/contexts/ProblemContext.test.tsx
@@ -23,6 +23,10 @@ vi.mock("@/infrastructure/api/repositories/submission.repository", () => ({
   getSubmissions: vi.fn(),
 }));
 
+vi.mock("@/features/auth/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
 // Mock react-router-dom
 vi.mock("react-router-dom", () => ({
   useParams: vi.fn(() => ({})),
@@ -105,8 +109,6 @@ const createWrapper = (problemId?: string, contestId?: string) => {
 describe("useProblem", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    // Reset localStorage mock
-    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
   });
 
   describe("useProblem hook", () => {

--- a/frontend/src/features/problems/contexts/ProblemContext.tsx
+++ b/frontend/src/features/problems/contexts/ProblemContext.tsx
@@ -12,6 +12,7 @@ import { getProblem, getProblemStatistics } from "@/infrastructure/api/repositor
 import { getSubmissions } from "@/infrastructure/api/repositories/submission.repository";
 import type { CodingProblemDetail } from "@/core/entities/problem.entity";
 import type { Submission } from "@/core/entities/submission.entity";
+import { useAuth } from "@/features/auth/contexts/AuthContext";
 
 // ============================================================================
 // Types
@@ -108,19 +109,7 @@ export const ProblemProvider: React.FC<ProblemProviderProps> = ({
   const params = useParams<{ problemId: string }>();
   const problemId = propProblemId || params.problemId;
 
-  // Get current user for "only mine" filter
-  const currentUser = useMemo(() => {
-    if (typeof window === "undefined") return null;
-    const userStr = localStorage.getItem("user");
-    if (userStr) {
-      try {
-        return JSON.parse(userStr);
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }, []);
+  const { user: currentUser } = useAuth();
 
   // Submissions params state
   const [submissionsParams, setSubmissionsParamsState] =

--- a/frontend/src/infrastructure/api/http.client.test.ts
+++ b/frontend/src/infrastructure/api/http.client.test.ts
@@ -77,6 +77,31 @@ describe("httpClient auth refresh", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("/api/v1/auth/login/password");
   });
 
+  it("returns the final 401 for optional session bootstrap without redirecting", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: false }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: false }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const response = await httpClient.get("/api/v1/users/me", {
+      allowUnauthenticated: true,
+    });
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(window.location.pathname).toBe("/dashboard");
+    expect(fetchMock.mock.calls[0][1]).not.toHaveProperty("allowUnauthenticated");
+  });
+
   it("can suppress global server-error toasts for optional background reads", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ success: false }), {

--- a/frontend/src/infrastructure/api/http.client.ts
+++ b/frontend/src/infrastructure/api/http.client.ts
@@ -1,12 +1,19 @@
-/**
- * Clear auth storage (for logout or token expiry)
- * Note: JWT tokens are now stored in HttpOnly cookies (more secure),
- * but we keep localStorage for user info cache.
- */
-export const clearAuthStorage = () => {
-  localStorage.removeItem("user");
-  window.dispatchEvent(new Event("storage"));
+const AUTH_SESSION_EVENT_KEY = "qjudge.auth.session_changed_at";
+
+/** Notify other tabs that the cookie-backed session state changed. */
+export const notifyAuthSessionChanged = () => {
+  localStorage.setItem(AUTH_SESSION_EVENT_KEY, String(Date.now()));
 };
+
+/** Clear client-side authentication state after logout or token expiry. */
+export const clearAuthStorage = () => {
+  // Remove data written by older builds. Identity is never restored from it.
+  localStorage.removeItem("user");
+  notifyAuthSessionChanged();
+};
+
+export const isAuthSessionStorageEvent = (event: StorageEvent): boolean =>
+  event.key === AUTH_SESSION_EVENT_KEY;
 
 /**
  * Get CSRF token from cookie.
@@ -34,6 +41,8 @@ const AUTH_REFRESH_ENDPOINT = "/api/v1/auth/refresh";
 export interface HttpClientRequestInit extends RequestInit {
   /** Keep an error local to a feature that already renders its own fallback UI. */
   suppressGlobalError?: boolean;
+  /** Return the final 401 response without redirecting, after one refresh attempt. */
+  allowUnauthenticated?: boolean;
 }
 
 const ensureDeviceId = (): string => {
@@ -166,7 +175,11 @@ const buildHeaders = (init: RequestInit = {}): Headers => {
 };
 
 const performFetch = (endpoint: string, init: HttpClientRequestInit = {}) => {
-  const { suppressGlobalError: _suppressGlobalError, ...requestInit } = init;
+  const {
+    suppressGlobalError: _suppressGlobalError,
+    allowUnauthenticated: _allowUnauthenticated,
+    ...requestInit
+  } = init;
   return fetch(endpoint, {
     ...requestInit,
     headers: buildHeaders(requestInit),
@@ -267,7 +280,7 @@ const customFetch = async (endpoint: string, init: HttpClientRequestInit = {}) =
     }
   }
 
-  if (response.status === 401) {
+  if (response.status === 401 && !init.allowUnauthenticated) {
     handleUnauthorized();
     throw new Error("Unauthorized");
   }

--- a/frontend/src/infrastructure/api/repositories/user.repository.test.ts
+++ b/frontend/src/infrastructure/api/repositories/user.repository.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { searchUsers, updateUserRole, uploadAvatar } from "./user.repository";
+import {
+  getCurrentUser,
+  searchUsers,
+  updateUserRole,
+  uploadAvatar,
+} from "./user.repository";
 
 describe("user repository endpoints", () => {
   const fetchMock = vi.fn();
@@ -33,6 +38,26 @@ describe("user repository endpoints", () => {
     expect(url).toBe("/api/v1/users/?q=alice");
     expect(options.method).toBe("GET");
     expect(options.credentials).toBe("include");
+  });
+
+  it("loads the current user through the cookie-backed session endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ success: true, data: { id: 7, username: "alice" } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await getCurrentUser();
+
+    expect(response.data).toMatchObject({ id: 7, username: "alice" });
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/users/me");
+    expect(options.credentials).toBe("include");
+    expect(options).not.toHaveProperty("allowUnauthenticated");
   });
 
   it("updateUserRole calls the users role endpoint", async () => {

--- a/frontend/src/infrastructure/api/repositories/user.repository.ts
+++ b/frontend/src/infrastructure/api/repositories/user.repository.ts
@@ -7,6 +7,16 @@ import type {
   UserSearchResponseDto,
 } from "@/infrastructure/api/dto/auth.dto";
 
+export const getCurrentUser = async (): Promise<CurrentUserResponseDto> => {
+  return requestJson<CurrentUserResponseDto>(
+    httpClient.get("/api/v1/users/me", {
+      allowUnauthenticated: true,
+      suppressGlobalError: true,
+    }),
+    "Failed to fetch current user",
+  );
+};
+
 export const updateAccountProfile = async (
   data: { username?: string; email?: string },
 ): Promise<CurrentUserResponseDto> => {

--- a/frontend/src/shared/ui/image/ImageEditDialog.test.tsx
+++ b/frontend/src/shared/ui/image/ImageEditDialog.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ImageEditDialog } from "./ImageEditDialog";
+
+describe("ImageEditDialog", () => {
+  it("opens the Carbon modal without an application-managed portal", () => {
+    render(
+      <ImageEditDialog
+        alt="Avatar"
+        variant="avatar"
+        emptyLabel="No image"
+        modalHeading="Edit image"
+        urlPlaceholder="https://example.com/image.png"
+        uploadLabel="Upload"
+        removeLabel="Remove"
+        applyLabel="Apply"
+        dropzoneLabel="Choose image"
+        dropzoneHint="PNG or JPEG"
+        onUpload={vi.fn()}
+        onApplyUrl={vi.fn()}
+        triggerDataTestId="image-trigger"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("image-trigger"));
+
+    expect(screen.getByTestId("image-edit-dialog")).toBeInTheDocument();
+    expect(screen.getByText("Edit image")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/ui/image/ImageEditDialog.tsx
+++ b/frontend/src/shared/ui/image/ImageEditDialog.tsx
@@ -1,5 +1,4 @@
 import React, { useId, useRef, useState } from "react";
-import ReactDOM from "react-dom";
 import {
   Button,
   Modal,
@@ -13,7 +12,6 @@ import {
 } from "@carbon/react";
 import { CloudUpload, Edit, TrashCan, UserAvatar } from "@carbon/icons-react";
 import { useTranslation } from "react-i18next";
-import { getModalPortalRoot } from "@/shared/ui/theme/portalRoot";
 import type { PresetCoverImage } from "./presetCoverImages";
 import "./ImageEditDialog.scss";
 
@@ -200,44 +198,41 @@ export const ImageEditDialog: React.FC<ImageEditDialogProps> = ({
         </div>
       </button>
 
-      {ReactDOM.createPortal(
-        <Modal
-          open={open}
-          data-testid="image-edit-dialog"
-          size={hasGallery ? "md" : "sm"}
-          modalHeading={modalHeading}
-          passiveModal
-          onRequestClose={closeModal}
-        >
-          <div className="image-edit-dialog__modal-body">
-            {hasGallery ? (
-              <Tabs>
-                <TabList aria-label="image source tabs">
-                  <Tab data-testid="image-edit-tab-gallery">{t("image.galleryTab", "圖庫")}</Tab>
-                  <Tab data-testid="image-edit-tab-upload">{t("image.uploadTab", "上傳")}</Tab>
-                  <Tab data-testid="image-edit-tab-link">{t("image.linkTab", "連結")}</Tab>
-                </TabList>
-                <TabPanels>
-                  <TabPanel>{galleryPanel}</TabPanel>
-                  <TabPanel>{uploadPanel}</TabPanel>
-                  <TabPanel>{linkPanel}</TabPanel>
-                </TabPanels>
-              </Tabs>
-            ) : (
-              <>
-                {uploadPanel}
-                {linkPanel}
-              </>
-            )}
-            {previewUrl && onRemove ? (
-              <Button type="button" kind="danger--ghost" size="md" renderIcon={TrashCan} disabled={disabled} onClick={handleRemove}>
-                {removeLabel}
-              </Button>
-            ) : null}
-          </div>
-        </Modal>,
-        getModalPortalRoot(),
-      )}
+      <Modal
+        open={open}
+        data-testid="image-edit-dialog"
+        size={hasGallery ? "md" : "sm"}
+        modalHeading={modalHeading}
+        passiveModal
+        onRequestClose={closeModal}
+      >
+        <div className="image-edit-dialog__modal-body">
+          {hasGallery ? (
+            <Tabs>
+              <TabList aria-label="image source tabs">
+                <Tab data-testid="image-edit-tab-gallery">{t("image.galleryTab", "圖庫")}</Tab>
+                <Tab data-testid="image-edit-tab-upload">{t("image.uploadTab", "上傳")}</Tab>
+                <Tab data-testid="image-edit-tab-link">{t("image.linkTab", "連結")}</Tab>
+              </TabList>
+              <TabPanels>
+                <TabPanel>{galleryPanel}</TabPanel>
+                <TabPanel>{uploadPanel}</TabPanel>
+                <TabPanel>{linkPanel}</TabPanel>
+              </TabPanels>
+            </Tabs>
+          ) : (
+            <>
+              {uploadPanel}
+              {linkPanel}
+            </>
+          )}
+          {previewUrl && onRemove ? (
+            <Button type="button" kind="danger--ghost" size="md" renderIcon={TrashCan} disabled={disabled} onClick={handleRemove}>
+              {removeLabel}
+            </Button>
+          ) : null}
+        </div>
+      </Modal>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- remove persisted user identity from localStorage and hydrate auth through the cookie-backed current-user endpoint
- harden OAuth redirects and backend public error responses with explicit allowlists and typed errors
- let Carbon Modal own its portal behavior and add least-privilege workflow permissions
- add regression coverage for auth hydration, OAuth redirects, attendance, integrity transitions, test runs, and image editing

No compatibility aliases or fallback behavior were added.

## Verification
- frontend: 190 files passed, 1046 tests passed, 1 skipped
- focused backend security tests: 31 passed
- attendance regression tests: 19 passed
- TypeScript typecheck passed
- frontend production build passed
- ESLint: 0 errors
- Django system check passed
- naming, architecture, repository export, Carbon strict, and Carbon staged gates passed