### PR TITLE
fix(security): close remaining CodeQL data flows

### DIFF
--- a/backend/apps/judge/io_judge.py
+++ b/backend/apps/judge/io_judge.py
@@ -10,6 +10,7 @@ For non-IO judging (special judge, checker, etc.) create a separate judge class.
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
@@ -20,6 +21,8 @@ from django.conf import settings
 from .base_judge import BaseJudge
 
 _CE_SENTINEL = "QJUDGE_CE_7f3a"
+_PUBLIC_SYSTEM_ERROR = "Judge system error"
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -131,12 +134,15 @@ class IOJudge(BaseJudge):
                 mem_limit=memory_limit,
             )
             return self._interpret(result, expected_output, time_limit)
-        except RuntimeError as exc:
-            return {"status": "SE", "output": "", "error": str(exc), "time": 0, "memory": 0}
-        except docker.errors.DockerException as exc:
-            return {"status": "SE", "output": "", "error": f"Docker error: {exc}", "time": 0, "memory": 0}
-        except Exception as exc:
-            return {"status": "SE", "output": "", "error": f"System Error: {exc}", "time": 0, "memory": 0}
+        except RuntimeError:
+            logger.exception("Judge runtime infrastructure failure")
+            return {"status": "SE", "output": "", "error": _PUBLIC_SYSTEM_ERROR, "time": 0, "memory": 0}
+        except docker.errors.DockerException:
+            logger.exception("Judge Docker infrastructure failure")
+            return {"status": "SE", "output": "", "error": _PUBLIC_SYSTEM_ERROR, "time": 0, "memory": 0}
+        except Exception:
+            logger.exception("Unexpected judge infrastructure failure")
+            return {"status": "SE", "output": "", "error": _PUBLIC_SYSTEM_ERROR, "time": 0, "memory": 0}
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -249,10 +255,12 @@ class IOJudge(BaseJudge):
                 "time": elapsed_ms,
                 "memory": 4096,
             }
-        except docker.errors.APIError as exc:
-            return {"exit_code": -1, "output": f"Docker API Error: {exc}", "time": 0, "memory": 0}
-        except Exception as exc:
-            return {"exit_code": -1, "output": f"System Error: {exc}", "time": 0, "memory": 0}
+        except docker.errors.APIError:
+            logger.exception("Judge container API failure")
+            return {"exit_code": -1, "output": _PUBLIC_SYSTEM_ERROR, "time": 0, "memory": 0}
+        except Exception:
+            logger.exception("Unexpected judge container failure")
+            return {"exit_code": -1, "output": _PUBLIC_SYSTEM_ERROR, "time": 0, "memory": 0}
         finally:
             if container:
                 try:

--- a/backend/apps/judge/tests.py
+++ b/backend/apps/judge/tests.py
@@ -11,6 +11,7 @@
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 import docker.errors
 from django.test import TestCase
@@ -272,10 +273,13 @@ class IOJudgeMockTests(TestCase):
 
     def test_se_on_docker_unavailable(self):
         judge = IOJudge("cpp")
-        judge._ensure_docker_client = lambda: (_ for _ in ()).throw(RuntimeError("Cannot connect"))
+        judge._ensure_docker_client = lambda: (_ for _ in ()).throw(
+            RuntimeError("docker-host-secret")
+        )
         r = judge.execute("", "", "", 1000, 128)
         self.assertEqual(r["status"], "SE")
-        self.assertIn("Cannot connect", r["error"])
+        self.assertEqual(r["error"], "Judge system error")
+        self.assertNotIn("secret", str(r))
 
     def test_se_on_docker_api_error(self):
         judge = self._mock_judge()
@@ -287,14 +291,48 @@ class IOJudgeMockTests(TestCase):
 
     def test_se_response_has_all_fields(self):
         judge = IOJudge("python")
-        judge._ensure_docker_client = lambda: (_ for _ in ()).throw(Exception("boom"))
+        judge._ensure_docker_client = lambda: (_ for _ in ()).throw(
+            Exception("judge-runtime-secret")
+        )
         r = judge.execute("", "", "", 1000, 128)
         for key in ("status", "output", "error", "time", "memory"):
             self.assertIn(key, r)
         self.assertEqual(r["status"], "SE")
         self.assertEqual(r["output"], "")
+        self.assertEqual(r["error"], "Judge system error")
+        self.assertNotIn("secret", str(r))
         self.assertEqual(r["time"], 0)
         self.assertEqual(r["memory"], 0)
+
+    def test_container_api_failure_does_not_expose_exception_details(self):
+        judge = IOJudge("cpp")
+        judge._client = SimpleNamespace(
+            containers=SimpleNamespace(
+                run=lambda **_kwargs: (_ for _ in ()).throw(
+                    docker.errors.APIError("docker-api-secret")
+                )
+            )
+        )
+
+        result = judge._run_in_container("true", timeout=1, mem_limit=64)
+
+        self.assertEqual(result["output"], "Judge system error")
+        self.assertNotIn("secret", str(result))
+
+    def test_container_runtime_failure_does_not_expose_exception_details(self):
+        judge = IOJudge("cpp")
+        judge._client = SimpleNamespace(
+            containers=SimpleNamespace(
+                run=lambda **_kwargs: (_ for _ in ()).throw(
+                    ValueError("container-runtime-secret")
+                )
+            )
+        )
+
+        result = judge._run_in_container("true", timeout=1, mem_limit=64)
+
+        self.assertEqual(result["output"], "Judge system error")
+        self.assertNotIn("secret", str(result))
 
     def test_python_no_compile_cmd(self):
         """Python 不應有 compile 步驟"""

--- a/frontend/src/shared/ui/image/ImageEditDialog.test.tsx
+++ b/frontend/src/shared/ui/image/ImageEditDialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ImageEditDialog } from "./ImageEditDialog";
@@ -27,5 +27,68 @@ describe("ImageEditDialog", () => {
 
     expect(screen.getByTestId("image-edit-dialog")).toBeInTheDocument();
     expect(screen.getByText("Edit image")).toBeInTheDocument();
+  });
+
+  it("rejects non-HTTP image URLs before applying them", () => {
+    const onApplyUrl = vi.fn();
+    render(
+      <ImageEditDialog
+        alt="Cover"
+        emptyLabel="No image"
+        modalHeading="Edit image"
+        urlPlaceholder="https://example.com/image.png"
+        uploadLabel="Upload"
+        removeLabel="Remove"
+        applyLabel="Apply"
+        dropzoneLabel="Choose image"
+        dropzoneHint="PNG or JPEG"
+        onUpload={vi.fn()}
+        onApplyUrl={onApplyUrl}
+        triggerDataTestId="image-trigger"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("image-trigger"));
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "javascript:alert(document.domain)" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(onApplyUrl).not.toHaveBeenCalled();
+    expect(screen.getByTestId("image-edit-dialog")).toBeInTheDocument();
+  });
+
+  it("normalizes an HTTP image URL before applying it", async () => {
+    const onApplyUrl = vi.fn();
+    render(
+      <ImageEditDialog
+        alt="Cover"
+        emptyLabel="No image"
+        modalHeading="Edit image"
+        urlPlaceholder="https://example.com/image.png"
+        uploadLabel="Upload"
+        removeLabel="Remove"
+        applyLabel="Apply"
+        dropzoneLabel="Choose image"
+        dropzoneHint="PNG or JPEG"
+        onUpload={vi.fn()}
+        onApplyUrl={onApplyUrl}
+        triggerDataTestId="image-trigger"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("image-trigger"));
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "https://example.com/cover image.png" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(onApplyUrl).toHaveBeenCalledOnce();
+    expect(onApplyUrl).toHaveBeenCalledWith(
+      "https://example.com/cover%20image.png",
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("URL")).toHaveValue("");
+    });
   });
 });

--- a/frontend/src/shared/ui/image/ImageEditDialog.tsx
+++ b/frontend/src/shared/ui/image/ImageEditDialog.tsx
@@ -11,6 +11,7 @@ import {
   Tile,
 } from "@carbon/react";
 import { CloudUpload, Edit, TrashCan, UserAvatar } from "@carbon/icons-react";
+import DOMPurify from "dompurify";
 import { useTranslation } from "react-i18next";
 import type { PresetCoverImage } from "./presetCoverImages";
 import "./ImageEditDialog.scss";
@@ -39,6 +40,22 @@ interface ImageEditDialogProps {
   triggerDataTestId?: string;
   fileInputDataTestId?: string;
 }
+
+const normalizeRemoteImageUrl = (value: string): string | null => {
+  try {
+    const sanitizedValue = DOMPurify.sanitize(value, {
+      ALLOWED_TAGS: [],
+      ALLOWED_ATTR: [],
+    });
+    const parsed = new URL(sanitizedValue.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.href;
+  } catch {
+    return null;
+  }
+};
 
 export const ImageEditDialog: React.FC<ImageEditDialogProps> = ({
   previewUrl,
@@ -69,6 +86,7 @@ export const ImageEditDialog: React.FC<ImageEditDialogProps> = ({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const hasGallery = Boolean(galleryImages && galleryImages.length > 0);
+  const normalizedUrlInput = normalizeRemoteImageUrl(urlInput);
 
   const closeModal = () => {
     setOpen(false);
@@ -82,9 +100,8 @@ export const ImageEditDialog: React.FC<ImageEditDialogProps> = ({
   };
 
   const handleApplyUrl = () => {
-    const nextUrl = urlInput.trim();
-    if (!nextUrl) return;
-    void Promise.resolve(onApplyUrl(nextUrl)).finally(closeModal);
+    if (!normalizedUrlInput) return;
+    void Promise.resolve(onApplyUrl(normalizedUrlInput)).finally(closeModal);
   };
 
   const handleGallerySelect = (image: PresetCoverImage) => {
@@ -157,7 +174,7 @@ export const ImageEditDialog: React.FC<ImageEditDialogProps> = ({
           if (e.key === "Enter") handleApplyUrl();
         }}
       />
-      <Button type="button" kind="primary" size="md" disabled={!urlInput.trim() || disabled} onClick={handleApplyUrl}>
+      <Button type="button" kind="primary" size="md" disabled={!normalizedUrlInput || disabled} onClick={handleApplyUrl}>
         {applyLabel}
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- replace all IOJudge infrastructure exception payloads with one fixed public error while retaining full server-side exception logging
- sanitize user-entered image URLs and accept only normalized HTTP or HTTPS URLs before they can become preview sources
- add regression coverage for Docker/runtime exception secrecy and malicious image URL rejection

No compatibility aliases or fallback paths were added.

## Verification
- frontend: 190 files passed, 1048 tests passed, 1 skipped
- Judge and test-run security regression: 16 passed
- TypeScript, production build, and Django system check passed
- ESLint: 0 errors
- naming, architecture, repository export, Carbon strict, and staged gates passed