### PR TITLE
fix(deploy): allow required internal backend hosts

### DIFF
--- a/backend/apps/core/tests/test_public_origin_settings.py
+++ b/backend/apps/core/tests/test_public_origin_settings.py
@@ -79,3 +79,37 @@ print(json.dumps([
 
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == expected
+
+
+def test_production_allowed_hosts_include_required_internal_service_names() -> None:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "DJANGO_ENV": "production",
+            "QJUDGE_PUBLIC_ORIGIN": "https://judge.example.test",
+            "SECRET_KEY": "allowed-hosts-test-secret",
+        }
+    )
+    script = """
+import json
+from config.settings import prod
+
+print(json.dumps(prod.ALLOWED_HOSTS))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=BACKEND_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [
+        "judge.example.test",
+        "localhost",
+        "127.0.0.1",
+        "backend",
+    ]

--- a/backend/config/settings/prod.py
+++ b/backend/config/settings/prod.py
@@ -38,7 +38,12 @@ if GLITCHTIP_DSN:
 _PUBLIC_ORIGIN_VALUE = os.getenv("QJUDGE_PUBLIC_ORIGIN", "")
 if _PUBLIC_ORIGIN_VALUE:
     _PUBLIC_ORIGIN = parse_public_origin(_PUBLIC_ORIGIN_VALUE)
-    ALLOWED_HOSTS = [_PUBLIC_ORIGIN.hostname]
+    ALLOWED_HOSTS = [
+        _PUBLIC_ORIGIN.hostname,
+        "localhost",
+        "127.0.0.1",
+        "backend",
+    ]
 else:
     _PUBLIC_ORIGIN = None
     ALLOWED_HOSTS = [


### PR DESCRIPTION
## Summary

- keep the canonical public hostname in production `ALLOWED_HOSTS`
- explicitly allow the Docker service hostname and loopback hosts required by internal service calls and health checks
- add a production settings regression test for the exact host list

## Production incident

The release itself started successfully, but the deployment smoke check received HTTP 400 from `http://localhost:8000/api/health/`. Public health with the configured host succeeded, confirming the backend was live. Internal AI-service calls also address Django as `backend`, so both internal names must be accepted.

## Verification

- `pytest apps/core/tests/test_public_origin_settings.py -q` (9 passed)
- `python manage.py check` (passed; existing django-ratelimit warning only)
- `git diff --check`
- pre-push: ESLint 0 errors, TypeScript, frontend production build, Docker Compose config all passed

A wider local `apps/core/tests` run could not create its test database because the dev DB role intentionally lacks CREATE DATABASE; CI uses the proper test database setup.
