### PR TITLE
fix(deploy): restore production internal health checks

### DIFF
--- a/backend/apps/core/tests/test_public_origin_settings.py
+++ b/backend/apps/core/tests/test_public_origin_settings.py
@@ -79,3 +79,37 @@ print(json.dumps([
 
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == expected
+
+
+def test_production_allowed_hosts_include_required_internal_service_names() -> None:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "DJANGO_ENV": "production",
+            "QJUDGE_PUBLIC_ORIGIN": "https://judge.example.test",
+            "SECRET_KEY": "allowed-hosts-test-secret",
+        }
+    )
+    script = """
+import json
+from config.settings import prod
+
+print(json.dumps(prod.ALLOWED_HOSTS))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=BACKEND_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [
+        "judge.example.test",
+        "localhost",
+        "127.0.0.1",
+        "backend",
+    ]

--- a/backend/config/settings/prod.py
+++ b/backend/config/settings/prod.py
@@ -38,7 +38,12 @@ if GLITCHTIP_DSN:
 _PUBLIC_ORIGIN_VALUE = os.getenv("QJUDGE_PUBLIC_ORIGIN", "")
 if _PUBLIC_ORIGIN_VALUE:
     _PUBLIC_ORIGIN = parse_public_origin(_PUBLIC_ORIGIN_VALUE)
-    ALLOWED_HOSTS = [_PUBLIC_ORIGIN.hostname]
+    ALLOWED_HOSTS = [
+        _PUBLIC_ORIGIN.hostname,
+        "localhost",
+        "127.0.0.1",
+        "backend",
+    ]
 else:
     _PUBLIC_ORIGIN = None
     ALLOWED_HOSTS = [


### PR DESCRIPTION
## Summary

- allow the production backend to accept the internal Docker hostname used by AI service calls
- allow loopback hostnames used by backend container health checks and deployment smoke tests
- keep the configured public origin as the canonical external hostname
- add an exact production settings regression test

## Context

The previous production deployment completed migrations and started services, but the smoke check failed with HTTP 400 because production `ALLOWED_HOSTS` contained only the public hostname. Public health was already successful, while internal requests use `localhost` and `backend`.

## Validation

- PR #214 CI: all seven checks passed
- targeted production settings tests: 9 passed
- Django system check passed
- pre-push lint, typecheck, production build, and Docker Compose validation passed

After this release merges, production CD will be rerun with `confirm_production=true` and all service health checks will be verified before removing the temporary environment rollback copy.
