### PR TITLE
fix(deploy): probe private integrity health internally

### DIFF
--- a/ai-service/tests/contract/test_compose_boundaries.py
+++ b/ai-service/tests/contract/test_compose_boundaries.py
@@ -592,3 +592,8 @@ def test_production_deploy_checks_each_critical_http_boundary(tmp_path: Path) ->
     assert "http://localhost:8000/api/health/" in commands
     assert "http://localhost:8001/health/ready" in commands
     assert "http://localhost:8010/health" in commands
+    assert "exec -T integrity-controller python -c" in commands
+    assert (
+        "curl --fail --silent --show-error --max-time 8 "
+        "http://localhost:8010/health"
+    ) not in commands

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -352,11 +352,31 @@ wait_for_http() {
   return 1
 }
 
+wait_for_compose_http() {
+  local label="$1"
+  local service="$2"
+  local url="$3"
+  local attempt=1
+  local max_attempts=30
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if docker compose "${COMPOSE_FILES[@]}" exec -T "$service" \
+      python -c 'import sys; from urllib.request import urlopen; urlopen(sys.argv[1], timeout=8).close()' \
+      "$url" >/dev/null 2>&1; then
+      echo "[deploy] smoke ok: ${label}"
+      return 0
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  echo "[deploy] smoke failed: ${label} did not respond within 60s" >&2
+  return 1
+}
+
 echo "[deploy] smoke check"
 if ! wait_for_http "frontend" "http://localhost:80" || \
    ! wait_for_http "backend" "http://localhost:8000/api/health/" || \
    ! wait_for_http "AI service" "http://localhost:8001/health/ready" || \
-   ! wait_for_http "Integrity controller" "http://localhost:8010/health"; then
+   ! wait_for_compose_http "Integrity controller" "integrity-controller" "http://localhost:8010/health"; then
   echo "Deployment health checks failed. Previous SHA: ${previous_git_ref}" >&2
   if [ -n "$backup_file" ]; then
     echo "Validated database backup: ${backup_file}" >&2


### PR DESCRIPTION
## Summary

- probe the private Integrity controller from inside its container during production smoke checks
- keep port 8010 private instead of exposing a host port only for deployment validation
- add a deployment contract preventing host-level curl against the private controller

## Production evidence

Production is already running release `d453871d`; frontend, backend, AI service, and Integrity controller are healthy. The controller returns HTTP 200 from inside its container and Docker reports it healthy. CD failed only because the deployment script attempted `localhost:8010` on the host even though Compose intentionally exposes 8010 only inside the container network.

## Verification

- red/green regression test for the private controller probe
- complete compose deployment contract file: 38 passed
- shell syntax validation for `scripts/deploy-prod.sh`
- pre-push lint, typecheck, production build, and Compose validation passed
