### PR TITLE
fix(deploy): validate private integrity controller correctly

### DIFF
--- a/ai-service/tests/contract/test_compose_boundaries.py
+++ b/ai-service/tests/contract/test_compose_boundaries.py
@@ -592,3 +592,8 @@ def test_production_deploy_checks_each_critical_http_boundary(tmp_path: Path) ->
     assert "http://localhost:8000/api/health/" in commands
     assert "http://localhost:8001/health/ready" in commands
     assert "http://localhost:8010/health" in commands
+    assert "exec -T integrity-controller python -c" in commands
+    assert (
+        "curl --fail --silent --show-error --max-time 8 "
+        "http://localhost:8010/health"
+    ) not in commands

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -352,11 +352,31 @@ wait_for_http() {
   return 1
 }
 
+wait_for_compose_http() {
+  local label="$1"
+  local service="$2"
+  local url="$3"
+  local attempt=1
+  local max_attempts=30
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if docker compose "${COMPOSE_FILES[@]}" exec -T "$service" \
+      python -c 'import sys; from urllib.request import urlopen; urlopen(sys.argv[1], timeout=8).close()' \
+      "$url" >/dev/null 2>&1; then
+      echo "[deploy] smoke ok: ${label}"
+      return 0
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  echo "[deploy] smoke failed: ${label} did not respond within 60s" >&2
+  return 1
+}
+
 echo "[deploy] smoke check"
 if ! wait_for_http "frontend" "http://localhost:80" || \
    ! wait_for_http "backend" "http://localhost:8000/api/health/" || \
    ! wait_for_http "AI service" "http://localhost:8001/health/ready" || \
-   ! wait_for_http "Integrity controller" "http://localhost:8010/health"; then
+   ! wait_for_compose_http "Integrity controller" "integrity-controller" "http://localhost:8010/health"; then
   echo "Deployment health checks failed. Previous SHA: ${previous_git_ref}" >&2
   if [ -n "$backup_file" ]; then
     echo "Validated database backup: ${backup_file}" >&2


### PR DESCRIPTION
## Summary

- fix production CD to probe the private Integrity controller from inside its container
- preserve the controller's private-only port boundary
- add a deployment contract that rejects host-level curl for port 8010

## Production status

Release `d453871d` is already running in production. Frontend, backend, AI service, and Integrity controller are healthy; the controller returns HTTP 200 internally. The prior CD run failed only because its host-level smoke check could not reach an intentionally unpublished port.

## Validation

- PR #216 CI: all seven checks passed
- complete deployment contract file: 38 passed
- shell syntax validation passed
- production container probe returns HTTP 200 and Docker health is healthy

After merge, CD will be rerun with `confirm_production=true`; successful independent health verification will then be followed by removal of the temporary pre-release environment rollback copy.
