### PR TITLE
fix(ai): restore production auth hops and update Actions runtime

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -13,9 +13,6 @@ concurrency:
   group: cd-prod
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     if: github.ref == 'refs/heads/main' && inputs.confirm_production
@@ -34,7 +31,7 @@ jobs:
           echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.sha.outputs.sha }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   # ============================================
   # Static Analysis & Build Check (Blocking)
@@ -53,15 +50,15 @@ jobs:
     name: Static Analysis & Build Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -106,9 +103,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"
@@ -151,7 +148,7 @@ jobs:
       DOCKER_IMAGE_JUDGE: ghcr.io/quan0715/qjudge/judge:latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -211,7 +208,7 @@ jobs:
       - name: Frontend API Integration Tests
         run: docker compose -f docker-compose.test.yml exec -T frontend-test npm run test:api
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -284,9 +281,9 @@ jobs:
       JUDGE_ENGINE_ENABLED: "false"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"
@@ -337,9 +334,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"
@@ -364,9 +361,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"
@@ -428,9 +425,9 @@ jobs:
       JUDGE_ENGINE_ENABLED: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,9 +28,6 @@ concurrency:
   group: deploy-docs
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     name: Build and Deploy Documentation
@@ -39,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -36,9 +36,6 @@ concurrency:
   group: deploy-landing
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     name: Build and Deploy Landing
@@ -47,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -28,9 +28,6 @@ concurrency:
   group: e2e-manual-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   e2e-auth:
     name: "E2E: Auth & Pending Actions"
@@ -38,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Start test stack
         run: |
           docker compose -f docker-compose.test.yml pull --ignore-pull-failures
@@ -75,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Start test stack
         run: |
           docker compose -f docker-compose.test.yml pull --ignore-pull-failures
@@ -112,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Start test stack
         run: |
           docker compose -f docker-compose.test.yml pull --ignore-pull-failures
@@ -149,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Start test stack
         run: |
           docker compose -f docker-compose.test.yml pull --ignore-pull-failures
@@ -186,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Start test stack
         run: |
           docker compose -f docker-compose.test.yml pull --ignore-pull-failures

--- a/.github/workflows/publish-judge-image.yml
+++ b/.github/workflows/publish-judge-image.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/ai-service/infrastructure/mcp/token_exchange.py
+++ b/ai-service/infrastructure/mcp/token_exchange.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from domain.ports import ExchangedToken, McpAuthFailed
+from infrastructure.oauth.backend_transport import backend_auth_headers
 
 
 class McpTokenExchangeClient:
@@ -44,8 +45,10 @@ class McpTokenExchangeClient:
         )
 
     async def _post(self, subject_token: str) -> httpx.Response:
+        headers = backend_auth_headers()
+        headers["Authorization"] = f"Bearer {subject_token}"
         kwargs = {
-            "headers": {"Authorization": f"Bearer {subject_token}"},
+            "headers": headers,
             "json": {"audience": "qjudge-mcp", "scope": "mcp"},
             "timeout": self._timeout_seconds,
         }

--- a/ai-service/infrastructure/oauth/backend_transport.py
+++ b/ai-service/infrastructure/oauth/backend_transport.py
@@ -1,0 +1,7 @@
+"""Headers for trusted authentication calls over the private Docker network."""
+
+
+def backend_auth_headers() -> dict[str, str]:
+    """Preserve the public HTTPS scheme across the private HTTP hop."""
+
+    return {"X-Forwarded-Proto": "https"}

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -40,6 +40,7 @@ from infrastructure.database.models import RunRow, SessionRow
 from infrastructure.database.uow import SqlAlchemyUnitOfWork
 from infrastructure.mcp.credential_lease import RedisCredentialLeaseStore
 from infrastructure.mcp.token_exchange import McpTokenExchangeClient
+from infrastructure.oauth.backend_transport import backend_auth_headers
 from infrastructure.oauth.jwt_verifier import AuthError, JwtVerifier
 from infrastructure.queue import CeleryRunDispatcher
 from worker.celery_app import celery_app
@@ -234,6 +235,10 @@ def _oauth_locations(settings: Settings) -> tuple[str, str]:
     return issuer, jwks_url
 
 
+def _jwks_client(jwks_url: str) -> PyJWKClient:
+    return PyJWKClient(jwks_url, headers=backend_auth_headers())
+
+
 def _artifact_store(settings: Settings) -> S3ArtifactStore:
     return S3ArtifactStore(
         bucket=settings.artifact_s3_bucket,
@@ -252,7 +257,7 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     issuer, jwks_url = _oauth_locations(settings)
     app.state.jwt_verifier = (
-        JwtVerifier(issuer, PyJWKClient(jwks_url))
+        JwtVerifier(issuer, _jwks_client(jwks_url))
         if issuer and jwks_url
         else _RejectingVerifier()
     )

--- a/ai-service/tests/unit/test_backend_auth_transport.py
+++ b/ai-service/tests/unit/test_backend_auth_transport.py
@@ -1,0 +1,9 @@
+"""Regression coverage for the trusted backend authentication hop."""
+
+from main import _jwks_client
+
+
+def test_jwks_client_marks_the_internal_backend_hop_as_https() -> None:
+    client = _jwks_client("http://backend:8000/.well-known/jwks.json")
+
+    assert client.headers == {"X-Forwarded-Proto": "https"}

--- a/ai-service/tests/unit/test_credential_service.py
+++ b/ai-service/tests/unit/test_credential_service.py
@@ -334,6 +334,7 @@ async def test_exchange_failure_is_mapped_and_never_preflighted(
 async def test_http_token_exchange_returns_bounded_mcp_token() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.headers["Authorization"] == "Bearer ai-token"
+        assert request.headers["X-Forwarded-Proto"] == "https"
         assert request.read() == b'{"audience":"qjudge-mcp","scope":"mcp"}'
         return httpx.Response(
             200,

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -107,3 +107,15 @@ def test_mcp_ci_jobs_respect_the_server_major_version_constraint() -> None:
     for step in install_steps:
         assert step["working-directory"] == "mcp-server"
         assert '"mcp[cli]>=1.9.0,<2.0"' in step["run"]
+
+
+def test_workflows_use_node24_action_runtimes_without_force_flag() -> None:
+    workflow_directory = REPOSITORY_ROOT / ".github" / "workflows"
+    workflow_text = "\n".join(
+        path.read_text() for path in sorted(workflow_directory.glob("*.yml"))
+    )
+
+    assert "actions/checkout@v4" not in workflow_text
+    assert "actions/setup-node@v4" not in workflow_text
+    assert "actions/setup-python@v5" not in workflow_text
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" not in workflow_text


### PR DESCRIPTION
## Summary
- preserve the public HTTPS scheme for AI Service JWKS and MCP token-exchange calls over the private Docker HTTP network
- upgrade official checkout, setup-node, and setup-python actions to v7 and remove the obsolete Node 24 force flag
- add regression contracts for both transport headers and workflow action versions

## Non-goals
- no browser-extension content script changes
- no provider integration or compatibility fallback

## Testing
- AI Service non-DB unit suite: 254 passed
- targeted transport regression: 2 passed
- release workflow contracts: 5 passed
- workflow YAML parse: 6 workflows
- Compose config gate passed
- frontend naming and architecture gates passed

## Risk and rollback
- medium production auth risk; rollback commit 698c0219 to restore prior AI transport behavior
- low CI risk; rollback commit aae79de0 to restore prior action majors