### PR TITLE
fix(ci): complete Node 24 migration and stabilize Copilot test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         working-directory: frontend
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: frontend-coverage-report
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-artifacts
           path: integration.log
@@ -320,7 +320,7 @@ jobs:
         working-directory: backend
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: backend-coverage-report

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -54,7 +54,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml logs --no-color > e2e-auth.log
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-auth-artifacts
           path: |
@@ -91,7 +91,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml logs --no-color > e2e-exam.log
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-exam-artifacts
           path: |
@@ -128,7 +128,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml logs --no-color > e2e-contest.log
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-contest-artifacts
           path: |
@@ -165,7 +165,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml logs --no-color > e2e-coding.log
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-coding-artifacts
           path: |
@@ -202,7 +202,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml logs --no-color > e2e-settings.log
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-settings-artifacts
           path: |

--- a/frontend/src/features/chatbot/contexts/QJudgeCopilotProvider.test.tsx
+++ b/frontend/src/features/chatbot/contexts/QJudgeCopilotProvider.test.tsx
@@ -196,8 +196,10 @@ describe("QJudgeCopilotProvider", () => {
       act(() => result.current.workspace.right.open());
       await waitFor(() => expect(listModels).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(1));
-      expect(result.current.sessions.activeSession.status).toBe("empty");
-      expect(result.current.sessions.sessions).toHaveLength(0);
+      await waitFor(() => {
+        expect(result.current.sessions.activeSession.status).toBe("empty");
+        expect(result.current.sessions.sessions).toHaveLength(0);
+      });
     },
   );
 

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -118,4 +118,5 @@ def test_workflows_use_node24_action_runtimes_without_force_flag() -> None:
     assert "actions/checkout@v4" not in workflow_text
     assert "actions/setup-node@v4" not in workflow_text
     assert "actions/setup-python@v5" not in workflow_text
+    assert "actions/upload-artifact@v4" not in workflow_text
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" not in workflow_text


### PR DESCRIPTION
## Summary
- upgrade all remaining `actions/upload-artifact` usages to v7 (Node 24)
- strengthen the workflow contract so Node 20 artifact actions cannot return
- wait for the Copilot session bootstrap state to settle before asserting, removing the observed CI race

## Verification
- targeted Copilot provider tests: 10 passed
- release workflow contract: 5 passed
- all workflow YAML parsed
- pre-push lint/typecheck/build/compose gate passed

## Context
Follow-up for release PR #219 after one duplicate Frontend matrix exposed both the remaining Node 20 warning and a flaky asynchronous assertion.