### PR TITLE
ci: migrate Docker actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -438,10 +438,10 @@ jobs:
         working-directory: backend
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -456,7 +456,7 @@ jobs:
 
       - name: Build and push Judge Image (when pull failed or Dockerfile changed)
         if: steps.pull-judge.outcome == 'failure'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: backend/judge
           file: backend/judge/Dockerfile.judge

--- a/.github/workflows/publish-judge-image.yml
+++ b/.github/workflows/publish-judge-image.yml
@@ -24,17 +24,17 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: backend/judge
           file: backend/judge/Dockerfile.judge

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -119,4 +119,7 @@ def test_workflows_use_node24_action_runtimes_without_force_flag() -> None:
     assert "actions/setup-node@v4" not in workflow_text
     assert "actions/setup-python@v5" not in workflow_text
     assert "actions/upload-artifact@v4" not in workflow_text
+    assert "docker/login-action@v3" not in workflow_text
+    assert "docker/setup-buildx-action@v3" not in workflow_text
+    assert "docker/build-push-action@v5" not in workflow_text
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" not in workflow_text


### PR DESCRIPTION
## Summary
- migrate `docker/login-action` to v4
- migrate `docker/setup-buildx-action` to v4
- migrate `docker/build-push-action` to v7
- expand the release workflow contract to reject all observed Node 20 action majors

## Verification
- official action metadata confirms all three versions use `node24`
- existing workflow inputs remain supported
- workflow YAML parsing and release contract tests pass
- local pre-push lint/typecheck/build/compose gate passes

## Context
Follow-up after main CI annotations exposed the remaining Docker action Node.js 20 deprecation warnings.