### PR TITLE
release: complete GitHub Actions Node 24 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -438,10 +438,10 @@ jobs:
         working-directory: backend
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -456,7 +456,7 @@ jobs:
 
       - name: Build and push Judge Image (when pull failed or Dockerfile changed)
         if: steps.pull-judge.outcome == 'failure'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: backend/judge
           file: backend/judge/Dockerfile.judge

--- a/.github/workflows/publish-judge-image.yml
+++ b/.github/workflows/publish-judge-image.yml
@@ -24,17 +24,17 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: backend/judge
           file: backend/judge/Dockerfile.judge

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -119,4 +119,7 @@ def test_workflows_use_node24_action_runtimes_without_force_flag() -> None:
     assert "actions/setup-node@v4" not in workflow_text
     assert "actions/setup-python@v5" not in workflow_text
     assert "actions/upload-artifact@v4" not in workflow_text
+    assert "docker/login-action@v3" not in workflow_text
+    assert "docker/setup-buildx-action@v3" not in workflow_text
+    assert "docker/build-push-action@v5" not in workflow_text
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" not in workflow_text


### PR DESCRIPTION
## Release scope
- preserve HTTPS scheme for AI Service JWKS and backend token-exchange calls, fixing production AI BFF 503 responses
- migrate GitHub official actions and Docker actions to native Node 24 runtimes
- stabilize the Copilot provider asynchronous bootstrap assertion found by duplicate release CI
- add workflow contracts preventing the retired Node 20 action majors from returning

## Evidence
- feature PRs #218, #220, and #221 passed their full CI matrices
- latest PR #221: all 7 jobs passed and all Node.js 20 annotation queries returned empty
- no compatibility aliases or fallbacks were introduced

## Deployment
After the release merge and main push CI pass, deploy with `confirm_production=true` and verify authenticated AI model/session/run paths.