### PR TITLE
release: promote MCP JWKS transport hotfix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -511,6 +511,7 @@ services:
       - DJANGO_BASE_URL=http://backend:8000
       - MCP_PUBLIC_URL=${MCP_PUBLIC_URL:-http://qjudge-mcp:9000}
       - OAUTH_ISSUER_URL=${QJUDGE_PUBLIC_ORIGIN:?QJUDGE_PUBLIC_ORIGIN is required}
+      - OAUTH_JWKS_URL=http://backend:8000/.well-known/jwks.json
     depends_on:
       - backend
     networks:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -62,7 +62,10 @@ class QJudgeTokenVerifier(TokenVerifier):
         opaque_fallback: TokenVerifier | None = None,
     ) -> None:
         self._issuer = issuer.rstrip("/")
-        self._jwks_client = jwks_client or PyJWKClient(OAUTH_JWKS_URL)
+        self._jwks_client = jwks_client or PyJWKClient(
+            OAUTH_JWKS_URL,
+            headers={"X-Forwarded-Proto": DJANGO_FORWARDED_PROTO},
+        )
         self._opaque_fallback = opaque_fallback or DjangoTokenVerifier()
 
     async def verify_token(self, token: str) -> AccessToken | None:

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -1383,6 +1383,24 @@ def test_auth_settings_configured():
     assert isinstance(server.mcp._token_verifier, server.QJudgeTokenVerifier)
 
 
+def test_qjudge_verifier_fetches_jwks_with_the_backend_transport_headers(monkeypatch):
+    created = {}
+
+    class RecordingJwksClient:
+        def __init__(self, url, *, headers=None):
+            created["url"] = url
+            created["headers"] = headers
+
+    monkeypatch.setattr(server, "PyJWKClient", RecordingJwksClient)
+
+    server.QJudgeTokenVerifier()
+
+    assert created == {
+        "url": server.OAUTH_JWKS_URL,
+        "headers": {"X-Forwarded-Proto": server.DJANGO_FORWARDED_PROTO},
+    }
+
+
 def test_qjudge_verifier_accepts_local_mcp_jwt_without_remote_call():
     private_key = Ed25519PrivateKey.generate()
     token = jwt.encode(


### PR DESCRIPTION
## Summary
- Promote the verified MCP JWKS transport hotfix from dev to main.

## Scope
- Route MCP JWKS retrieval through the trusted backend network path.
- Preserve HTTPS proxy semantics for that internal request.
- Include the regression test.

## Verification
- MCP server tests: 78 passed.
- Naming and architecture gates: passed.
- Prior PR #223 CI: all required checks passed.
- Production hotfix smoke: MCP initialize 200 and POST /runs 202.

## Risk and rollback
- Limited to MCP JWKS retrieval.
- Roll back by reverting this release and redeploying the prior MCP image.