### PR TITLE
release: make auth provider availability explicit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ OBJECT_STORAGE_SECRET_KEY=
 # TUNNEL_TOKEN=
 
 # Optional third-party login providers.
+# OAuth provider endpoints and credential variable names are configured here;
+# credentials themselves stay in the variables below.
+# QAUTH_PROVIDER_CONNECTIONS_JSON=[]
 # NYCU_OAUTH_CLIENT_ID=
 # NYCU_OAUTH_CLIENT_SECRET=
 # GITHUB_OAUTH_CLIENT_ID=

--- a/backend/apps/users/auth/provider_connections.py
+++ b/backend/apps/users/auth/provider_connections.py
@@ -28,13 +28,13 @@ def load_provider_connections(raw: str | None = None) -> dict[str, QAuthProvider
     return {
         item["key"]: QAuthProviderConnection(
             key=item["key"],
-            type=item.get("type", "oauth2"),
+            type=item.get("type", ""),
             issuer_url=item.get("issuer_url", ""),
             authorization_url=item.get("authorization_url", ""),
             token_url=item.get("token_url", ""),
             userinfo_url=item.get("userinfo_url", ""),
             jwks_url=item.get("jwks_url", ""),
-            scope=item.get("scope", "openid email profile"),
+            scope=item.get("scope", ""),
             client_id_env=item.get("client_id_env", ""),
             client_secret_env=item.get("client_secret_env", ""),
             claim_mapping=item.get("claim_mapping", {}),

--- a/backend/apps/users/auth/provider_registry.py
+++ b/backend/apps/users/auth/provider_registry.py
@@ -97,7 +97,11 @@ def get_oauth_service(provider: str) -> type[BaseOAuthService] | None:
 
 
 def get_oauth_provider_options() -> list[dict]:
-    return [registration.public_option() for registration in REGISTERED_OAUTH_PROVIDERS.values()]
+    return [
+        registration.public_option()
+        for registration in REGISTERED_OAUTH_PROVIDERS.values()
+        if registration.service.is_configured()
+    ]
 
 
 def is_registered_auth_provider(provider: str) -> bool:

--- a/backend/apps/users/auth/providers/base.py
+++ b/backend/apps/users/auth/providers/base.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlencode
 
 import requests
-from django.conf import settings
 
 from ..contracts import NormalizedQAuthIdentity, ProviderTokenSet
 from ..provider_connections import load_provider_connections, resolve_provider_credentials
@@ -13,16 +12,14 @@ from ..provider_connections import load_provider_connections, resolve_provider_c
 logger = logging.getLogger(__name__)
 
 
+class OAuthProviderConfigurationError(RuntimeError):
+    """Raised when a registered OAuth provider has no complete QAuth connection."""
+
+
 class BaseOAuthService(ABC):
     """Abstract base for OAuth provider services."""
 
     provider_key: str = ""
-    authorize_url_setting: str = ""
-    token_url_setting: str = ""
-    userinfo_url_setting: str = ""
-    client_id_setting: str = ""
-    client_secret_setting: str = ""
-    default_scope: str = ""
 
     @classmethod
     def get_authorization_url(cls, redirect_uri: str, state: str) -> str:
@@ -34,7 +31,7 @@ class BaseOAuthService(ABC):
             "state": state,
             "scope": cls._scope(),
         }
-        base = cls._provider_url("authorization_url", cls.authorize_url_setting)
+        base = cls._provider_url("authorization_url")
         return f"{base}?{urlencode(params)}"
 
     @classmethod
@@ -87,7 +84,7 @@ class BaseOAuthService(ABC):
         client_id, client_secret = cls._client_credentials()
         try:
             resp = requests.post(
-                cls._provider_url("token_url", cls.token_url_setting),
+                cls._provider_url("token_url"),
                 data={
                     "grant_type": "authorization_code",
                     "code": code,
@@ -113,7 +110,7 @@ class BaseOAuthService(ABC):
     def _fetch_user_info(cls, access_token: str) -> dict:
         try:
             resp = requests.get(
-                cls._provider_url("userinfo_url", cls.userinfo_url_setting),
+                cls._provider_url("userinfo_url"),
                 headers={"Authorization": f"Bearer {access_token}"},
                 timeout=(5, 15),
             )
@@ -133,35 +130,50 @@ class BaseOAuthService(ABC):
 
     @classmethod
     def _provider_connection(cls):
-        return load_provider_connections().get(cls.provider_key)
+        connection = load_provider_connections().get(cls.provider_key)
+        if connection is None:
+            raise OAuthProviderConfigurationError(
+                f"OAuth provider {cls.provider_key!r} is not configured",
+            )
+        return connection
 
     @classmethod
-    def _provider_url(cls, connection_attr: str, setting_name: str) -> str:
-        connection = cls._provider_connection()
-        if connection is not None:
-            value = getattr(connection, connection_attr, "")
-            if value:
-                return value
-        return getattr(settings, setting_name)
+    def _provider_url(cls, connection_attr: str) -> str:
+        value = getattr(cls._provider_connection(), connection_attr, "")
+        if not value:
+            raise OAuthProviderConfigurationError(
+                f"OAuth provider {cls.provider_key!r} requires {connection_attr}",
+            )
+        return value
 
     @classmethod
     def _client_credentials(cls) -> tuple[str, str]:
         connection = cls._provider_connection()
-        if connection is not None:
-            client_id, client_secret = resolve_provider_credentials(connection)
-            if client_id or client_secret:
-                return (
-                    client_id or getattr(settings, cls.client_id_setting),
-                    client_secret or getattr(settings, cls.client_secret_setting),
-                )
-        return (
-            getattr(settings, cls.client_id_setting),
-            getattr(settings, cls.client_secret_setting),
-        )
+        client_id, client_secret = resolve_provider_credentials(connection)
+        if not client_id or not client_secret:
+            raise OAuthProviderConfigurationError(
+                f"OAuth provider {cls.provider_key!r} requires client credentials",
+            )
+        return client_id, client_secret
 
     @classmethod
     def _scope(cls) -> str:
-        connection = cls._provider_connection()
-        if connection is not None and connection.scope:
-            return connection.scope
-        return cls.default_scope
+        scope = cls._provider_connection().scope
+        if not scope:
+            raise OAuthProviderConfigurationError(
+                f"OAuth provider {cls.provider_key!r} requires scope",
+            )
+        return scope
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        """Return whether this provider can complete a server-side OAuth flow."""
+        try:
+            cls._provider_url("authorization_url")
+            cls._provider_url("token_url")
+            cls._provider_url("userinfo_url")
+            cls._client_credentials()
+            cls._scope()
+        except OAuthProviderConfigurationError:
+            return False
+        return True

--- a/backend/apps/users/auth/providers/github.py
+++ b/backend/apps/users/auth/providers/github.py
@@ -3,22 +3,16 @@
 import logging
 
 import requests
-from django.conf import settings
 
 from .base import BaseOAuthService
 from .profile import extract_avatar_url
 
 logger = logging.getLogger(__name__)
+GITHUB_USER_EMAILS_URL = "https://api.github.com/user/emails"
 
 
 class GitHubOAuthService(BaseOAuthService):
     provider_key = "github"
-    authorize_url_setting = "GITHUB_OAUTH_AUTHORIZE_URL"
-    token_url_setting = "GITHUB_OAUTH_TOKEN_URL"
-    userinfo_url_setting = "GITHUB_OAUTH_USERINFO_URL"
-    client_id_setting = "GITHUB_OAUTH_CLIENT_ID"
-    client_secret_setting = "GITHUB_OAUTH_CLIENT_SECRET"
-    default_scope = "read:user user:email"
 
     @classmethod
     def _default_avatar_url(cls, user_info: dict) -> str:
@@ -43,11 +37,7 @@ class GitHubOAuthService(BaseOAuthService):
         if not info.get("email"):
             try:
                 resp = requests.get(
-                    getattr(
-                        settings,
-                        "GITHUB_OAUTH_USER_EMAILS_URL",
-                        "https://api.github.com/user/emails",
-                    ),
+                    GITHUB_USER_EMAILS_URL,
                     headers={
                         "Authorization": f"Bearer {access_token}",
                         "Accept": "application/json",

--- a/backend/apps/users/auth/providers/google.py
+++ b/backend/apps/users/auth/providers/google.py
@@ -16,12 +16,6 @@ logger = logging.getLogger(__name__)
 
 class GoogleOAuthService(BaseOAuthService):
     provider_key = "google"
-    authorize_url_setting = "GOOGLE_OAUTH_AUTHORIZE_URL"
-    token_url_setting = "GOOGLE_OAUTH_TOKEN_URL"
-    userinfo_url_setting = "GOOGLE_OAUTH_USERINFO_URL"
-    client_id_setting = "GOOGLE_OAUTH_CLIENT_ID"
-    client_secret_setting = "GOOGLE_OAUTH_CLIENT_SECRET"
-    default_scope = "openid email profile"
 
     @classmethod
     def exchange_code(cls, code: str, redirect_uri: str) -> dict:

--- a/backend/apps/users/auth/providers/nycu.py
+++ b/backend/apps/users/auth/providers/nycu.py
@@ -6,12 +6,6 @@ from .profile import extract_avatar_url
 
 class NYCUOAuthService(BaseOAuthService):
     provider_key = "nycu"
-    authorize_url_setting = "NYCU_OAUTH_AUTHORIZE_URL"
-    token_url_setting = "NYCU_OAUTH_TOKEN_URL"
-    userinfo_url_setting = "NYCU_OAUTH_USERINFO_URL"
-    client_id_setting = "NYCU_OAUTH_CLIENT_ID"
-    client_secret_setting = "NYCU_OAUTH_CLIENT_SECRET"
-    default_scope = "profile"
 
     @classmethod
     def _parse_user_info(cls, raw: dict) -> dict:

--- a/backend/apps/users/tests/test_auth_enhanced.py
+++ b/backend/apps/users/tests/test_auth_enhanced.py
@@ -79,33 +79,18 @@ class EnhancedAuthTests(APITestCase):
             response.data["data"],
             {
                 "password_enabled": False,
-                "providers": [
-                    {
-                        "key": "nycu",
-                        "type": "oidc",
-                        "category": "campus",
-                        "display_name": "NYCU 國立陽明交通大學",
-                        "display_name_i18n_key": "auth.providers.nycu",
-                        "logo_url": "/illustrations/nycu-logo.png",
-                    },
-                    {
-                        "key": "github",
-                        "type": "oauth2",
-                        "category": "social",
-                        "display_name": "GitHub",
-                        "display_name_i18n_key": "auth.providers.github",
-                    },
-                    {
-                        "key": "google",
-                        "type": "oidc",
-                        "category": "social",
-                        "display_name": "Google",
-                        "display_name_i18n_key": "auth.providers.google",
-                        "logo_url": "/illustrations/google-icon.svg",
-                    },
-                ],
+                "providers": [],
             },
         )
+
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON="[]")
+    def test_oauth_login_rejects_a_registered_provider_without_a_connection(self):
+        url = reverse("auth:provider-login", kwargs={"provider": "nycu"})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(response.data["error"]["code"], "OAUTH_PROVIDER_NOT_CONFIGURED")
 
     @override_settings(AUTH_EMAIL_PASSWORD_ENABLED=False)
     def test_password_register_is_rejected_when_disabled(self):

--- a/backend/apps/users/tests/test_auth_provider_options.py
+++ b/backend/apps/users/tests/test_auth_provider_options.py
@@ -2,24 +2,32 @@ import json
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
 from apps.users.auth.options import get_auth_options
 from apps.users.auth.provider_connections import load_provider_connections, resolve_provider_credentials
+from apps.users.auth.providers.base import OAuthProviderConfigurationError
 from apps.users.auth.providers.nycu import NYCUOAuthService
 
 
-def test_get_auth_options_returns_registered_provider_metadata(settings):
+def test_get_auth_options_returns_only_configured_registered_provider_metadata(settings, monkeypatch):
     settings.AUTH_EMAIL_PASSWORD_ENABLED = False
-    settings.AUTH_PROVIDER_OPTIONS = [
-        {
-            "key": "nycu",
-            "type": "oidc",
-            "category": "campus",
-            "display_name": "Should not be used",
-            "logo_url": "/wrong.svg",
-            "token_url": "https://id.nycu.edu.tw/o/token/",
-            "client_secret_env": "NYCU_OAUTH_CLIENT_SECRET",
-        }
-    ]
+    settings.QAUTH_PROVIDER_CONNECTIONS_JSON = json.dumps(
+        [
+            {
+                "key": "nycu",
+                "type": "oidc",
+                "authorization_url": "https://id.nycu.edu.tw/o/authorize/",
+                "token_url": "https://id.nycu.edu.tw/o/token/",
+                "userinfo_url": "https://id.nycu.edu.tw/api/profile/",
+                "scope": "profile",
+                "client_id_env": "NYCU_OAUTH_CLIENT_ID",
+                "client_secret_env": "NYCU_OAUTH_CLIENT_SECRET",
+            }
+        ]
+    )
+    monkeypatch.setenv("NYCU_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("NYCU_OAUTH_CLIENT_SECRET", "client-secret")
 
     options = get_auth_options()
 
@@ -34,22 +42,17 @@ def test_get_auth_options_returns_registered_provider_metadata(settings):
                 "display_name_i18n_key": "auth.providers.nycu",
                 "logo_url": "/illustrations/nycu-logo.png",
             },
-            {
-                "key": "github",
-                "type": "oauth2",
-                "category": "social",
-                "display_name": "GitHub",
-                "display_name_i18n_key": "auth.providers.github",
-            },
-            {
-                "key": "google",
-                "type": "oidc",
-                "category": "social",
-                "display_name": "Google",
-                "display_name_i18n_key": "auth.providers.google",
-                "logo_url": "/illustrations/google-icon.svg",
-            },
         ],
+    }
+
+
+def test_get_auth_options_hides_registered_providers_without_a_connection(settings):
+    settings.AUTH_EMAIL_PASSWORD_ENABLED = False
+    settings.QAUTH_PROVIDER_CONNECTIONS_JSON = "[]"
+
+    assert get_auth_options() == {
+        "password_enabled": False,
+        "providers": [],
     }
 
 
@@ -113,6 +116,7 @@ def test_base_oauth_service_uses_provider_connection_for_authorization_url(setti
         ]
     )
     monkeypatch.setenv("NYCU_OAUTH_CLIENT_ID", "connection-client-id")
+    monkeypatch.setenv("NYCU_OAUTH_CLIENT_SECRET", "connection-client-secret")
 
     url = NYCUOAuthService.get_authorization_url("https://app.example.edu/callback", "state-123")
     parsed = urlparse(url)
@@ -125,18 +129,13 @@ def test_base_oauth_service_uses_provider_connection_for_authorization_url(setti
     assert query["scope"] == ["openid email profile"]
 
 
-def test_base_oauth_service_falls_back_to_legacy_provider_settings(settings):
+def test_base_oauth_service_rejects_credentials_without_a_connection(settings, monkeypatch):
     settings.QAUTH_PROVIDER_CONNECTIONS_JSON = "[]"
-    settings.NYCU_OAUTH_CLIENT_ID = "legacy-client-id"
-    settings.NYCU_OAUTH_AUTHORIZE_URL = "https://legacy.example.edu/o/authorize/"
+    monkeypatch.setenv("NYCU_OAUTH_CLIENT_ID", "legacy-client-id")
+    monkeypatch.setenv("NYCU_OAUTH_CLIENT_SECRET", "legacy-client-secret")
 
-    url = NYCUOAuthService.get_authorization_url("https://app.example.edu/callback", "state-123")
-    parsed = urlparse(url)
-    query = parse_qs(parsed.query)
-
-    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://legacy.example.edu/o/authorize/"
-    assert query["client_id"] == ["legacy-client-id"]
-    assert query["scope"] == ["profile"]
+    with pytest.raises(OAuthProviderConfigurationError, match="not configured"):
+        NYCUOAuthService.get_authorization_url("https://app.example.edu/callback", "state-123")
 
 
 def test_base_oauth_service_uses_provider_connection_for_token_exchange(settings, monkeypatch):

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -17,6 +17,49 @@ from apps.users.models import User, UserProfile
 from apps.users.services import EmailAuthService, JWTService
 
 
+NYCU_CONNECTION = json.dumps(
+    [{
+        "key": "nycu",
+        "type": "oidc",
+        "authorization_url": "https://oauth.example.com/authorize",
+        "token_url": "https://oauth.example.com/token",
+        "userinfo_url": "https://oauth.example.com/userinfo",
+        "scope": "profile",
+        "client_id_env": "NYCU_OAUTH_CLIENT_ID",
+        "client_secret_env": "NYCU_OAUTH_CLIENT_SECRET",
+    }],
+)
+GITHUB_CONNECTION = json.dumps(
+    [{
+        "key": "github",
+        "type": "oauth2",
+        "authorization_url": "https://github.com/login/oauth/authorize",
+        "token_url": "https://github.com/login/oauth/access_token",
+        "userinfo_url": "https://api.github.com/user",
+        "scope": "read:user user:email",
+        "client_id_env": "GITHUB_OAUTH_CLIENT_ID",
+        "client_secret_env": "GITHUB_OAUTH_CLIENT_SECRET",
+    }],
+)
+GOOGLE_CONNECTION = json.dumps(
+    [{
+        "key": "google",
+        "type": "oidc",
+        "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "userinfo_url": "https://www.googleapis.com/oauth2/v3/userinfo",
+        "scope": "openid email profile",
+        "client_id_env": "GOOGLE_OAUTH_CLIENT_ID",
+        "client_secret_env": "GOOGLE_OAUTH_CLIENT_SECRET",
+    }],
+)
+ALL_PROVIDER_CONNECTIONS = json.dumps([
+    *json.loads(NYCU_CONNECTION),
+    *json.loads(GITHUB_CONNECTION),
+    *json.loads(GOOGLE_CONNECTION),
+])
+
+
 def link_oauth_user(service, user_info, access_token=""):
     oauth_data = {"access_token": access_token, "user_info": user_info}
     return link_qauth_identity(
@@ -106,24 +149,18 @@ class AuthOptionsTests(SimpleTestCase):
 
     @override_settings(
         AUTH_EMAIL_PASSWORD_ENABLED=False,
-        AUTH_PROVIDER_OPTIONS=[
-            {
-                "key": "nycu",
-                "type": "oidc",
-                "category": "campus",
-                "display_name": "NYCU 國立陽明交通大學",
-                "display_name_i18n_key": "auth.providers.nycu",
-                "logo_url": "/auth-providers/nycu.svg",
-                "issuer": "https://id.nycu.edu.tw",
-                "token_url": "https://id.nycu.edu.tw/o/token/",
-                "client_secret_env": "NYCU_OAUTH_CLIENT_SECRET",
-            },
-            {
-                "key": "missing",
-                "category": "campus",
-                "display_name": "Missing University",
-            },
-        ],
+        QAUTH_PROVIDER_CONNECTIONS_JSON=ALL_PROVIDER_CONNECTIONS,
+    )
+    @patch.dict(
+        os.environ,
+        {
+            "NYCU_OAUTH_CLIENT_ID": "nycu-client-id",
+            "NYCU_OAUTH_CLIENT_SECRET": "nycu-secret",
+            "GITHUB_OAUTH_CLIENT_ID": "github-client-id",
+            "GITHUB_OAUTH_CLIENT_SECRET": "github-secret",
+            "GOOGLE_OAUTH_CLIENT_ID": "google-client-id",
+            "GOOGLE_OAUTH_CLIENT_SECRET": "google-secret",
+        },
     )
     def test_get_auth_options_returns_public_known_providers(self):
         options = get_auth_options()
@@ -189,6 +226,14 @@ class AuthOptionsTests(SimpleTestCase):
         self.assertEqual(nycu.claim_mapping["email"], "email")
         self.assertEqual(resolve_provider_credentials(nycu), ("client-id", "client-secret"))
 
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=GITHUB_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "GITHUB_OAUTH_CLIENT_ID": "github-client-id",
+            "GITHUB_OAUTH_CLIENT_SECRET": "github-secret",
+        },
+    )
     def test_auth_options_never_exposes_provider_connection_details(self):
         options = get_auth_options()
         provider = next(item for item in options["providers"] if item["key"] == "github")
@@ -206,9 +251,13 @@ class AuthOptionsTests(SimpleTestCase):
 
 
 class NYCUOAuthServiceTests(TestCase):
-    @override_settings(
-        NYCU_OAUTH_CLIENT_ID="client-id",
-        NYCU_OAUTH_AUTHORIZE_URL="https://oauth.example.com/authorize",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=NYCU_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "NYCU_OAUTH_CLIENT_ID": "client-id",
+            "NYCU_OAUTH_CLIENT_SECRET": "client-secret",
+        },
     )
     def test_get_authorization_url(self):
         url = NYCUOAuthService.get_authorization_url(
@@ -219,11 +268,13 @@ class NYCUOAuthServiceTests(TestCase):
         self.assertIn("client_id=client-id", url)
         self.assertIn("state=state-123", url)
 
-    @override_settings(
-        NYCU_OAUTH_TOKEN_URL="https://oauth.example.com/token",
-        NYCU_OAUTH_CLIENT_ID="client-id",
-        NYCU_OAUTH_CLIENT_SECRET="client-secret",
-        NYCU_OAUTH_USERINFO_URL="https://oauth.example.com/userinfo",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=NYCU_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "NYCU_OAUTH_CLIENT_ID": "client-id",
+            "NYCU_OAUTH_CLIENT_SECRET": "client-secret",
+        },
     )
     @patch("apps.users.auth.providers.base.requests.get")
     @patch("apps.users.auth.providers.base.requests.post")
@@ -247,11 +298,13 @@ class NYCUOAuthServiceTests(TestCase):
         self.assertEqual(data["user_info"]["oauth_id"], "oauth-sub-1")
         self.assertEqual(data["user_info"]["avatar_url"], "https://id.nycu.edu.tw/avatar.png")
 
-    @override_settings(
-        NYCU_OAUTH_TOKEN_URL="https://oauth.example.com/token",
-        NYCU_OAUTH_CLIENT_ID="client-id",
-        NYCU_OAUTH_CLIENT_SECRET="client-secret",
-        NYCU_OAUTH_USERINFO_URL="https://oauth.example.com/userinfo",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=NYCU_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "NYCU_OAUTH_CLIENT_ID": "client-id",
+            "NYCU_OAUTH_CLIENT_SECRET": "client-secret",
+        },
     )
     @patch("apps.users.auth.providers.base.requests.post")
     def test_exchange_code_raises_on_token_exchange_failure(self, mock_post):
@@ -495,9 +548,13 @@ class OAuthProviderRegistryTests(TestCase):
 
 
 class GitHubOAuthServiceTests(TestCase):
-    @override_settings(
-        GITHUB_OAUTH_CLIENT_ID="gh-client-id",
-        GITHUB_OAUTH_AUTHORIZE_URL="https://github.com/login/oauth/authorize",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=GITHUB_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "GITHUB_OAUTH_CLIENT_ID": "gh-client-id",
+            "GITHUB_OAUTH_CLIENT_SECRET": "gh-secret",
+        },
     )
     def test_get_authorization_url(self):
         url = GitHubOAuthService.get_authorization_url(
@@ -508,12 +565,13 @@ class GitHubOAuthServiceTests(TestCase):
         self.assertIn("state=state-gh", url)
         self.assertIn("scope=read", url)
 
-    @override_settings(
-        GITHUB_OAUTH_TOKEN_URL="https://github.com/login/oauth/access_token",
-        GITHUB_OAUTH_CLIENT_ID="gh-client-id",
-        GITHUB_OAUTH_CLIENT_SECRET="gh-secret",
-        GITHUB_OAUTH_USERINFO_URL="https://api.github.com/user",
-        GITHUB_OAUTH_USER_EMAILS_URL="https://api.github.com/user/emails",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=GITHUB_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "GITHUB_OAUTH_CLIENT_ID": "gh-client-id",
+            "GITHUB_OAUTH_CLIENT_SECRET": "gh-secret",
+        },
     )
     @patch("apps.users.auth.providers.base.requests.get")
     @patch("apps.users.auth.providers.base.requests.post")
@@ -553,9 +611,13 @@ class GoogleOAuthServiceTests(TestCase):
         p = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
         return f"{h}.{p}."
 
-    @override_settings(
-        GOOGLE_OAUTH_CLIENT_ID="google-client-id",
-        GOOGLE_OAUTH_AUTHORIZE_URL="https://accounts.google.com/o/oauth2/v2/auth",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=GOOGLE_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "GOOGLE_OAUTH_CLIENT_ID": "google-client-id",
+            "GOOGLE_OAUTH_CLIENT_SECRET": "google-secret",
+        },
     )
     def test_get_authorization_url(self):
         url = GoogleOAuthService.get_authorization_url(
@@ -565,11 +627,13 @@ class GoogleOAuthServiceTests(TestCase):
         self.assertIn("client_id=google-client-id", url)
         self.assertIn("scope=openid", url)
 
-    @override_settings(
-        GOOGLE_OAUTH_TOKEN_URL="https://oauth2.googleapis.com/token",
-        GOOGLE_OAUTH_CLIENT_ID="google-client-id",
-        GOOGLE_OAUTH_CLIENT_SECRET="google-secret",
-        GOOGLE_OAUTH_USERINFO_URL="https://www.googleapis.com/oauth2/v3/userinfo",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=GOOGLE_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "GOOGLE_OAUTH_CLIENT_ID": "google-client-id",
+            "GOOGLE_OAUTH_CLIENT_SECRET": "google-secret",
+        },
     )
     @patch("apps.users.auth.providers.base.requests.get")
     @patch("apps.users.auth.providers.base.requests.post")
@@ -597,11 +661,13 @@ class GoogleOAuthServiceTests(TestCase):
             "https://lh3.googleusercontent.com/avatar",
         )
 
-    @override_settings(
-        GOOGLE_OAUTH_TOKEN_URL="https://oauth2.googleapis.com/token",
-        GOOGLE_OAUTH_CLIENT_ID="google-client-id",
-        GOOGLE_OAUTH_CLIENT_SECRET="google-secret",
-        GOOGLE_OAUTH_USERINFO_URL="https://www.googleapis.com/oauth2/v3/userinfo",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=GOOGLE_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "GOOGLE_OAUTH_CLIENT_ID": "google-client-id",
+            "GOOGLE_OAUTH_CLIENT_SECRET": "google-secret",
+        },
     )
     @patch("apps.users.auth.providers.base.requests.get")
     @patch("apps.users.auth.providers.base.requests.post")
@@ -639,11 +705,13 @@ class GoogleOAuthServiceTests(TestCase):
             "https://lh3.googleusercontent.com/fallback-avatar",
         )
 
-    @override_settings(
-        GOOGLE_OAUTH_TOKEN_URL="https://oauth2.googleapis.com/token",
-        GOOGLE_OAUTH_CLIENT_ID="google-client-id",
-        GOOGLE_OAUTH_CLIENT_SECRET="google-secret",
-        GOOGLE_OAUTH_USERINFO_URL="https://www.googleapis.com/oauth2/v3/userinfo",
+    @override_settings(QAUTH_PROVIDER_CONNECTIONS_JSON=GOOGLE_CONNECTION)
+    @patch.dict(
+        os.environ,
+        {
+            "GOOGLE_OAUTH_CLIENT_ID": "google-client-id",
+            "GOOGLE_OAUTH_CLIENT_SECRET": "google-secret",
+        },
     )
     @patch("apps.users.auth.providers.base.requests.get")
     @patch("apps.users.auth.providers.base.requests.post")

--- a/backend/apps/users/views/auth.py
+++ b/backend/apps/users/views/auth.py
@@ -18,6 +18,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 
 from ..auth.account_linking import link_qauth_identity
 from ..auth.options import get_auth_options, is_password_auth_enabled
+from ..auth.providers.base import OAuthProviderConfigurationError
 from ..auth.provider_registry import get_oauth_service
 from ..serializers import LoginSerializer, OAuthCallbackSerializer, RegisterSerializer
 from ..services import (
@@ -233,7 +234,20 @@ class ProviderLoginView(SchemaAPIView):
             )
         redirect_uri = f"{settings.FRONTEND_URL}/auth/{provider}/callback"
         state = secrets.token_urlsafe(16)
-        auth_url = service.get_authorization_url(redirect_uri, state)
+        try:
+            auth_url = service.get_authorization_url(redirect_uri, state)
+        except OAuthProviderConfigurationError:
+            logger.error("OAuth provider is not configured provider=%s", provider)
+            return Response(
+                {
+                    "success": False,
+                    "error": {
+                        "code": "OAUTH_PROVIDER_NOT_CONFIGURED",
+                        "message": f"OAuth provider is not configured: {provider}",
+                    },
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
         return Response({"success": True, "data": {"authorization_url": auth_url}})
 
     @extend_schema(request=LoginSerializer)
@@ -309,6 +323,18 @@ class OAuthCallbackView(SchemaAPIView):
             access_jti = str(AccessToken(tokens["access"]).get("jti", ""))
             record_login(user, request, login_method=provider, jti=access_jti)
             return token_cookie_response(user, tokens)
+        except OAuthProviderConfigurationError:
+            logger.error("OAuth provider is not configured provider=%s", provider)
+            return Response(
+                {
+                    "success": False,
+                    "error": {
+                        "code": "OAUTH_PROVIDER_NOT_CONFIGURED",
+                        "message": f"OAuth provider is not configured: {provider}",
+                    },
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
         except Exception as exc:
             logger.exception("%s OAuth callback failed: %s", provider, exc)
             return Response(

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -354,29 +354,7 @@ CELERY_TASK_DEFAULT_QUEUE = "default"
 # artifact maintenance run in the independent AI scheduler.
 CELERY_BEAT_SCHEDULE = {}
 
-# NYCU OAuth settings
-NYCU_OAUTH_CLIENT_ID = os.getenv("NYCU_OAUTH_CLIENT_ID", "")
-NYCU_OAUTH_CLIENT_SECRET = os.getenv("NYCU_OAUTH_CLIENT_SECRET", "")
-NYCU_OAUTH_AUTHORIZE_URL = "https://id.nycu.edu.tw/o/authorize/"
-NYCU_OAUTH_TOKEN_URL = "https://id.nycu.edu.tw/o/token/"
-NYCU_OAUTH_USERINFO_URL = "https://id.nycu.edu.tw/api/profile/"
-
-# GitHub OAuth settings
-GITHUB_OAUTH_CLIENT_ID = os.getenv("GITHUB_OAUTH_CLIENT_ID", "")
-GITHUB_OAUTH_CLIENT_SECRET = os.getenv("GITHUB_OAUTH_CLIENT_SECRET", "")
-GITHUB_OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
-GITHUB_OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token"
-GITHUB_OAUTH_USERINFO_URL = "https://api.github.com/user"
-GITHUB_OAUTH_USER_EMAILS_URL = "https://api.github.com/user/emails"
-
-# Google OAuth settings
-GOOGLE_OAUTH_CLIENT_ID = os.getenv("GOOGLE_OAUTH_CLIENT_ID", "")
-GOOGLE_OAUTH_CLIENT_SECRET = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "")
-GOOGLE_OAUTH_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
-GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
-GOOGLE_OAUTH_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
-
-# Public login method settings. Provider metadata is registered in apps.users.auth.provider_registry.
+# Public login method settings. OAuth connections are configured through QAuth.
 AUTH_EMAIL_PASSWORD_ENABLED = os.getenv("AUTH_EMAIL_PASSWORD_ENABLED", "True").lower() in {"1", "true", "yes", "on"}
 QAUTH_PROVIDER_CONNECTIONS_JSON = os.getenv("QAUTH_PROVIDER_CONNECTIONS_JSON", "[]")
 

--- a/frontend/public/docs/zh-TW/identity-auth-extension.md
+++ b/frontend/public/docs/zh-TW/identity-auth-extension.md
@@ -78,7 +78,7 @@ http://localhost:5173/auth/school/callback
 
 ### 2. 建立後端 provider service
 
-在 `backend/apps/users/auth/providers/` 新增 provider class，繼承 `BaseOAuthService`。至少要設定穩定的 `provider_key`、預設 scope 與 settings 名稱，並把 provider profile 轉成共同欄位：
+在 `backend/apps/users/auth/providers/` 新增 provider class，繼承 `BaseOAuthService`。至少要設定穩定的 `provider_key`，並把 provider profile 轉成共同欄位：
 
 - `oauth_id`：穩定且不可變的 subject
 - `username`
@@ -102,7 +102,7 @@ class 的 `provider_key` 必須和 registry key 完全相同。路由不必為�
 
 在部署環境的 `QAUTH_PROVIDER_CONNECTIONS_JSON` 加入同一個 key，並用 `client_id_env`、`client_secret_env` 指向另外兩個環境變數。credential 本身只放進 secret 管理或 `.env`，不要直接放進 JSON。
 
-若 endpoint 可以沿用 Django settings 的既有預設，connection 可只覆寫必要欄位。設定完成後先用 Compose config 檢查 JSON 與環境變數，再啟動服務。
+connection 必須明確提供 authorization、token、userinfo endpoint、scope 與兩個 credential env 名稱；未完整設定的 provider 不會出現在公開登入選項，也無法啟動 OAuth 流程。設定完成後先用 Compose config 檢查 JSON 與環境變數，再啟動服務。
 
 ### 5. 補上前端顯示文字
 

--- a/frontend/public/docs/zh-TW/nycu-login-showcase.md
+++ b/frontend/public/docs/zh-TW/nycu-login-showcase.md
@@ -65,12 +65,6 @@ NYCU 的 service class 在 `backend/apps/users/auth/providers/nycu.py`：
 ```python
 class NYCUOAuthService(BaseOAuthService):
     provider_key = "nycu"
-    authorize_url_setting = "NYCU_OAUTH_AUTHORIZE_URL"
-    token_url_setting = "NYCU_OAUTH_TOKEN_URL"
-    userinfo_url_setting = "NYCU_OAUTH_USERINFO_URL"
-    client_id_setting = "NYCU_OAUTH_CLIENT_ID"
-    client_secret_setting = "NYCU_OAUTH_CLIENT_SECRET"
-    default_scope = "profile"
 ```
 
 Provider service 的欄位意義：
@@ -78,12 +72,6 @@ Provider service 的欄位意義：
 | 欄位 | 核心功能 |
 | --- | --- |
 | `provider_key` | 對應 provider key；`BaseOAuthService` 用它讀取 `QAUTH_PROVIDER_CONNECTIONS_JSON`，並寫入 `ExternalIdentity.provider_key` |
-| `authorize_url_setting` | connection settings 沒提供 URL 時，回讀 Django settings 的欄位名 |
-| `token_url_setting` | token endpoint 的 settings fallback 欄位名 |
-| `userinfo_url_setting` | userinfo endpoint 的 settings fallback 欄位名 |
-| `client_id_setting` | client id 的 settings fallback 欄位名 |
-| `client_secret_setting` | client secret 的 settings fallback 欄位名 |
-| `default_scope` | connection settings 沒提供 scope 時使用的 scope |
 
 新增 provider 時，選定一個 `provider_key`，例如 `example-university`，並讓 metadata、registry、connection、API path 都使用同一個值。NYCU 舊資料中的 `nycu-oauth` 會由 migration 收斂成 `nycu`。
 
@@ -213,9 +201,9 @@ Connection 參數：
 | `load_provider_connections(raw=None)` | 解析 `QAUTH_PROVIDER_CONNECTIONS_JSON`，回傳以 `key` 索引的 connection map |
 | `resolve_provider_credentials(connection)` | 依 `client_id_env`、`client_secret_env` 從環境變數讀取 credential |
 | `BaseOAuthService._provider_connection()` | 依 provider service 的 `provider_key` 找 connection |
-| `BaseOAuthService._provider_url()` | 優先讀 connection URL，再回讀 Django settings |
-| `BaseOAuthService._client_credentials()` | 優先讀 connection credential env，再回讀 Django settings |
-| `BaseOAuthService._scope()` | 優先讀 connection scope，再使用 service `default_scope` |
+| `BaseOAuthService._provider_url()` | 讀取 connection URL，缺少時拒絕啟動登入流程 |
+| `BaseOAuthService._client_credentials()` | 讀取 connection 指定的 credential env，任一缺少時拒絕啟動登入流程 |
+| `BaseOAuthService._scope()` | 讀取 connection scope，缺少時拒絕啟動登入流程 |
 
 ### 步驟 5：前端載入 options 並渲染 NYCU 入口
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,4 @@
-import { BrowserRouter } from "react-router-dom";
-import { Routes, Route } from "react-router";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { lazy } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nextProvider } from "react-i18next";

--- a/frontend/src/docs-main.tsx
+++ b/frontend/src/docs-main.tsx
@@ -6,8 +6,7 @@
  */
 
 import { createRoot } from "react-dom/client";
-import { HashRouter, Navigate } from "react-router-dom";
-import { Routes, Route } from "react-router";
+import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
 import i18n from "@/i18n";
 import DocsLayout from "@/features/docs/components/DocsLayout";

--- a/frontend/src/features/admin/routes.tsx
+++ b/frontend/src/features/admin/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Route } from "react-router";
+import { Route } from "react-router-dom";
 import { RouteLoadingBoundary } from "@/shared/ui/RouteLoadingBoundary";
 
 const UserManagementScreen = lazy(() => import("./screens/UserManagementScreen"));

--- a/frontend/src/features/app/routes.tsx
+++ b/frontend/src/features/app/routes.tsx
@@ -1,4 +1,4 @@
-import { Route } from "react-router";
+import { Route } from "react-router-dom";
 import NotFoundScreen from "./screens/NotFoundScreen";
 import ServerErrorScreen from "./screens/ServerErrorScreen";
 

--- a/frontend/src/features/auth/components/layout/AuthLayout.tsx
+++ b/frontend/src/features/auth/components/layout/AuthLayout.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { useLocation, useOutlet, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Light, Asleep, ArrowLeft } from '@carbon/icons-react';
@@ -182,7 +182,7 @@ const AuthLayout = () => {
                     exit={{ opacity: 0, y: -10 }}
                     transition={{ duration: 0.15, ease: 'easeInOut' }}
                   >
-                    {outlet && cloneElement(outlet, { key: location.pathname })}
+                    {outlet}
                   </motion.div>
                 </AnimatePresence>
               </div>

--- a/frontend/src/features/auth/hooks/useAuthOptions.ts
+++ b/frontend/src/features/auth/hooks/useAuthOptions.ts
@@ -1,25 +1,40 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { AuthOptions } from "@/core/entities/auth.entity";
 import { getAuthOptions } from "@/infrastructure/api/repositories/auth.repository";
 
-const DEFAULT_AUTH_OPTIONS: AuthOptions = {
-  password_enabled: true,
+const UNRESOLVED_AUTH_OPTIONS: AuthOptions = {
+  password_enabled: false,
   providers: [],
 };
 
 export const useAuthOptions = () => {
-  const [options, setOptions] = useState<AuthOptions>(DEFAULT_AUTH_OPTIONS);
+  const [options, setOptions] = useState<AuthOptions>(UNRESOLVED_AUTH_OPTIONS);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  const retry = useCallback(() => {
+    setAttempt((currentAttempt) => currentAttempt + 1);
+  }, []);
 
   useEffect(() => {
     let active = true;
+    setLoading(true);
+    setError(null);
 
     getAuthOptions()
       .then((response) => {
         if (active) setOptions(response.data);
       })
-      .catch(() => {
-        if (active) setOptions(DEFAULT_AUTH_OPTIONS);
+      .catch((requestError: unknown) => {
+        if (active) {
+          setOptions(UNRESOLVED_AUTH_OPTIONS);
+          setError(
+            requestError instanceof Error
+              ? requestError
+              : new Error("Failed to load authentication options"),
+          );
+        }
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -28,7 +43,7 @@ export const useAuthOptions = () => {
     return () => {
       active = false;
     };
-  }, []);
+  }, [attempt]);
 
-  return { options, loading };
+  return { options, loading, error, retry };
 };

--- a/frontend/src/features/auth/routes.tsx
+++ b/frontend/src/features/auth/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Route } from "react-router";
+import { Route } from "react-router-dom";
 import { RouteLoadingBoundary } from "@/shared/ui/RouteLoadingBoundary";
 import OAuthCallbackScreen from "./screens/OAuthCallbackScreen";
 

--- a/frontend/src/features/auth/screens/AuthProviderOptionsScreen.test.tsx
+++ b/frontend/src/features/auth/screens/AuthProviderOptionsScreen.test.tsx
@@ -122,6 +122,21 @@ describe("auth provider options", () => {
     mockGetOAuthUrl.mockResolvedValue("#campus-sso");
   });
 
+  it("shows a recoverable error instead of presenting password-only login when auth options fail", async () => {
+    mockGetAuthOptions
+      .mockRejectedValueOnce(new Error("auth options unavailable"))
+      .mockResolvedValueOnce(authOptions);
+
+    renderWithRouter(<LoginScreen />);
+
+    expect(await screen.findByTestId("auth-options-load-error")).toBeInTheDocument();
+    expect(screen.getByTestId("auth-options-retry")).toBeEnabled();
+    expect(screen.queryByTestId("auth-login-form")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("auth-options-retry"));
+    expect(await screen.findByText("GitHub")).toBeInTheDocument();
+  });
+
   it("hides email/password login when disabled and renders dynamic social providers", async () => {
     const { container } = renderWithRouter(<LoginScreen />);
 

--- a/frontend/src/features/auth/screens/CampusSsoScreen.tsx
+++ b/frontend/src/features/auth/screens/CampusSsoScreen.tsx
@@ -28,7 +28,11 @@ const CampusSsoScreen = () => {
   const { t } = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
-  const { options } = useAuthOptions();
+  const {
+    options,
+    error: authOptionsError,
+    retry: retryAuthOptions,
+  } = useAuthOptions();
   // Auto-syncs query params (e.g. action_link_token) → sessionStorage
   const { buildAuthLink } = usePendingActions();
   const [loading, setLoading] = useState<string | null>(null);
@@ -64,6 +68,27 @@ const CampusSsoScreen = () => {
     if (!selectedProvider || isAuthenticating) return;
     void handleSsoLogin(selectedProvider.key);
   };
+
+  if (authOptionsError) {
+    return (
+      <div className="auth-form">
+        <PendingActionBanner />
+        <div className="auth-options-error" data-testid="auth-options-load-error">
+          <p className="auth-error" role="alert">
+            {t("auth.optionsUnavailable", "無法載入可用的登入方式，請重試。")}
+          </p>
+          <Button
+            kind="tertiary"
+            type="button"
+            onClick={retryAuthOptions}
+            data-testid="auth-options-retry"
+          >
+            {t("common.retry", "重試")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/features/auth/screens/LoginScreen.tsx
+++ b/frontend/src/features/auth/screens/LoginScreen.tsx
@@ -30,7 +30,12 @@ const LoginPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { buildAuthLink } = usePendingActions();
-  const { options, loading: authOptionsLoading } = useAuthOptions();
+  const {
+    options,
+    loading: authOptionsLoading,
+    error: authOptionsError,
+    retry: retryAuthOptions,
+  } = useAuthOptions();
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -77,6 +82,27 @@ const LoginPage = () => {
       setOauthLoadingProvider(null);
     }
   };
+
+  if (authOptionsError) {
+    return (
+      <div className="auth-form">
+        <PendingActionBanner />
+        <div className="auth-options-error" data-testid="auth-options-load-error">
+          <p className="auth-error" role="alert">
+            {t("auth.optionsUnavailable", "無法載入可用的登入方式，請重試。")}
+          </p>
+          <Button
+            kind="tertiary"
+            type="button"
+            onClick={retryAuthOptions}
+            data-testid="auth-options-retry"
+          >
+            {t("common.retry", "重試")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/features/auth/screens/RegisterScreen.tsx
+++ b/frontend/src/features/auth/screens/RegisterScreen.tsx
@@ -25,7 +25,11 @@ const RegisterPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { buildAuthLink } = usePendingActions();
-  const { options } = useAuthOptions();
+  const {
+    options,
+    error: authOptionsError,
+    retry: retryAuthOptions,
+  } = useAuthOptions();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -107,6 +111,27 @@ const RegisterPage = () => {
       setProviderLoading(null);
     }
   };
+
+  if (authOptionsError) {
+    return (
+      <div className="auth-form">
+        <PendingActionBanner />
+        <div className="auth-options-error" data-testid="auth-options-load-error">
+          <p className="auth-error" role="alert">
+            {t("auth.optionsUnavailable", "無法載入可用的登入方式，請重試。")}
+          </p>
+          <Button
+            kind="tertiary"
+            type="button"
+            onClick={retryAuthOptions}
+            data-testid="auth-options-retry"
+          >
+            {t("common.retry", "重試")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/features/contest/components/studentDashboard/StudentContestDashboardView.test.tsx
+++ b/frontend/src/features/contest/components/studentDashboard/StudentContestDashboardView.test.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useState,

--- a/frontend/src/features/contest/components/studentDashboard/StudentContestDashboardView.tsx
+++ b/frontend/src/features/contest/components/studentDashboard/StudentContestDashboardView.tsx
@@ -34,7 +34,7 @@ import {
   WarningAlt,
 } from "@carbon/icons-react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 
 import type {
   ContestAnnouncement,

--- a/frontend/src/features/contest/routes.tsx
+++ b/frontend/src/features/contest/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Route } from "react-router";
+import { Route } from "react-router-dom";
 import { RouteLoadingBoundary } from "@/shared/ui/RouteLoadingBoundary";
 import RuntimeRouteWrapper from "./components/layout/RuntimeRouteWrapper";
 import { ContestProvider } from "./contexts/ContestContext";

--- a/frontend/src/features/contest/screens/admin/attendance/AttendanceProjectionScreen.tsx
+++ b/frontend/src/features/contest/screens/admin/attendance/AttendanceProjectionScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from "@carbon/icons-react";
 import { QRCodeSVG } from "@rc-component/qrcode";
 import { Button, InlineNotification } from "@carbon/react";
-import { Link, useParams } from "react-router";
+import { Link, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import type { AttendancePurpose, ContestDetail } from "@/core/entities/contest.entity";

--- a/frontend/src/features/contest/screens/attendance/StudentAttendanceScanScreen.test.tsx
+++ b/frontend/src/features/contest/screens/attendance/StudentAttendanceScanScreen.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useEffect, useRef } from "react";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---- Module mocks --------------------------------------------------------

--- a/frontend/src/features/contest/screens/attendance/StudentAttendanceScanScreen.tsx
+++ b/frontend/src/features/contest/screens/attendance/StudentAttendanceScanScreen.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, InlineLoading } from "@carbon/react";
 import { ArrowRight } from "@carbon/icons-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useNavigate, useParams, useSearchParams } from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import type { AttendancePhotoPolicy, AttendancePurpose } from "@/core/entities/contest.entity";

--- a/frontend/src/features/dashboard/routes.tsx
+++ b/frontend/src/features/dashboard/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Route } from "react-router";
+import { Route } from "react-router-dom";
 import { RouteLoadingBoundary } from "@/shared/ui/RouteLoadingBoundary";
 
 const DashboardScreen = lazy(() => import("./screens/DashboardScreen"));

--- a/frontend/src/features/docs/routes.tsx
+++ b/frontend/src/features/docs/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Route } from "react-router";
+import { Route } from "react-router-dom";
 import { RouteLoadingBoundary } from "@/shared/ui/RouteLoadingBoundary";
 
 const DocumentationScreen = lazy(() => import("./screens/DocumentationScreen"));

--- a/frontend/src/features/landing/routes.tsx
+++ b/frontend/src/features/landing/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Route } from "react-router";
+import { Route } from "react-router-dom";
 import { RouteLoadingBoundary } from "@/shared/ui/RouteLoadingBoundary";
 
 const LandingScreen = lazy(() => import("./screens/LandingScreen"));


### PR DESCRIPTION
Promotes #226 to production.

- Login pages show a recoverable error when auth options cannot be fetched, rather than a misleading password-only fallback.
- OAuth login options are exposed only for complete QAuth provider connections with available credentials.
- Legacy OAuth settings fallbacks are removed; unavailable configured providers return an explicit 503.
- React Router imports are normalized to prevent auth routes rendering a blank outlet.

Validated locally and by all CI checks on PR #226.