### PR TITLE
fix(deploy): bootstrap resident credentials without host sudo

### DIFF
--- a/ai-service/tests/contract/test_compose_boundaries.py
+++ b/ai-service/tests/contract/test_compose_boundaries.py
@@ -369,6 +369,20 @@ def test_default_production_compose_excludes_removed_integrations(tmp_path: Path
     assert "cloudflared" not in services
 
 
+def test_production_integrity_bootstrap_needs_no_host_sudo() -> None:
+    services = _compose("docker-compose.yml")["services"]
+    bootstrap = services["integrity-bootstrap"]
+    assert bootstrap["user"] == "0:0"
+    assert bootstrap["network_mode"] == "none"
+    assert bootstrap["restart"] == "no"
+    assert bootstrap["command"][-4:] == [
+        "--secrets-dir", "/bootstrap-secrets", "--resident-gid", "10001",
+    ]
+    assert services["integrity-resident"]["depends_on"]["integrity-bootstrap"] == {
+        "condition": "service_completed_successfully",
+    }
+
+
 def test_tunnel_profile_adds_cloudflared(tmp_path: Path) -> None:
     cloudflared = _compose("docker-compose.yml")["services"]["cloudflared"]
     assert "tunnel" in cloudflared["profiles"]
@@ -553,7 +567,7 @@ def test_production_deploy_prepares_integrity_runtime_before_start(
 
     assert result.returncode == 0, result.stderr
     integrity_bootstrap = commands.index(
-        "python3 scripts/bootstrap_integrity_secrets.py --resident-gid 10001"
+        "run --rm --no-deps --build integrity-bootstrap"
     )
     compose_start = commands.index("up -d --remove-orphans")
     assert integrity_bootstrap < compose_start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -501,6 +501,20 @@ services:
     networks:
       - oj_network
 
+  # Run credential ownership changes inside Docker so the deployment account
+  # does not need passwordless host sudo. The command only creates or validates
+  # the three files mounted from secrets/integrity.
+  integrity-bootstrap:
+    build: *backend_prod_build
+    image: oj-backend:prod
+    user: "0:0"
+    restart: "no"
+    command: ["python", "/bootstrap/bootstrap_integrity_secrets.py", "--secrets-dir", "/bootstrap-secrets", "--resident-gid", "10001"]
+    volumes:
+      - ./scripts/bootstrap_integrity_secrets.py:/bootstrap/bootstrap_integrity_secrets.py:ro
+      - ./secrets/integrity:/bootstrap-secrets
+    network_mode: none
+
   # Durable per-Run integrity storage. The resident owns every Run's journal in
   # one process, so exactly one writer holds this volume at a time.
   integrity-resident-data-init:
@@ -551,6 +565,8 @@ services:
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]
     depends_on:
+      integrity-bootstrap:
+        condition: service_completed_successfully
       integrity-resident-data-init:
         condition: service_completed_successfully
       backend:

--- a/frontend/public/docs/zh-TW/deployment-troubleshooting.md
+++ b/frontend/public/docs/zh-TW/deployment-troubleshooting.md
@@ -152,7 +152,7 @@ docker compose logs --tail=200 celery celery-high integrity-resident integrity-r
 docker compose exec -T integrity-resident python -c "from urllib.request import urlopen; assert urlopen('http://localhost:8011/ready').status == 200"
 ```
 
-如果 secret bind mount source 意外變成 directory，先停止使用該路徑的 container，確認是空目錄再移除，重新執行 `sudo python3 scripts/bootstrap_integrity_secrets.py --resident-gid 10001`。不要覆寫現有有效憑證。Resident 與 reconciler 常駐運作，老師不需手動啟動或重啟每場考試的 Worker。
+如果 secret bind mount source 意外變成 directory，先停止使用該路徑的 container，確認是空目錄再移除，重新執行 `docker compose run --rm --no-deps --build integrity-bootstrap`。不要覆寫現有有效憑證。Resident 與 reconciler 常駐運作，老師不需手動啟動或重啟每場考試的 Worker。
 
 ## 8. Tunnel 與 OAuth
 

--- a/integrity-service/tests/test_resident_deploy_contract.py
+++ b/integrity-service/tests/test_resident_deploy_contract.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 def test_deploy_uses_resident_credentials_and_readiness():
     script = (Path(__file__).resolve().parents[2] / "scripts/deploy-prod.sh").read_text()
-    assert "bootstrap_integrity_secrets.py --resident-gid 10001" in script
+    assert 'run --rm --no-deps --build integrity-bootstrap' in script
+    assert "sudo -n" not in script
     assert '"Integrity resident" "integrity-resident" "http://localhost:8011/ready"' in script
     assert "integrity-worker-image" not in script
     assert "integrity-controller" not in script

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -220,12 +220,9 @@ echo "[deploy] bootstrap AI OAuth signing key"
 python3 scripts/bootstrap_ai_oauth_keys.py
 
 echo "[deploy] bootstrap Integrity credentials"
-# Resident runs as 10001; only its public key and service token are group-readable.
-if [ "$(id -u)" -eq 0 ]; then
-  python3 scripts/bootstrap_integrity_secrets.py --resident-gid 10001
-else
-  sudo -n python3 scripts/bootstrap_integrity_secrets.py --resident-gid 10001
-fi
+# Resident runs as 10001. Apply group ownership from an isolated root container
+# instead of requiring passwordless sudo for the deployment account.
+docker compose "${COMPOSE_FILES[@]}" run --rm --no-deps --build integrity-bootstrap
 
 echo "[deploy] validate rendered Compose"
 docker compose "${COMPOSE_FILES[@]}" config --quiet


### PR DESCRIPTION
## 問題

Production CD run 34183199817 已通過 main SHA／CI／Tailscale 前置檢查，但在服務 build/start 前失敗：部署帳號執行 `sudo -n python3 scripts/bootstrap_integrity_secrets.py --resident-gid 10001` 時需要密碼。

## 修正

- Production Compose 新增一次性的 `integrity-bootstrap` service，以 container root 建立或驗證三個 Integrity credential，並只替 Resident 所需的 public key／service token 設定 GID 10001。
- deploy script 改呼叫 `docker compose run --rm --no-deps --build integrity-bootstrap`，不再要求 host passwordless sudo。
- Resident 明確等待 bootstrap 成功。
- 更新維運文件與部署 contract。

第一次失敗只將 production checkout 切到 main `83d5ea98`；失敗點早於 database backup、image build 與 `compose up`，未重建或移除既有服務。

## 驗證

- Production deploy contract：1 passed
- Production Compose/deploy contracts：39 passed
- `bash scripts/check-compose-config.sh`
- Naming / architecture checks
- Pre-push ESLint、TypeScript、frontend build、Compose gate

## Release

本 PR 合併 dev 且 exact-SHA CI 通過後，再開 dev → main PR。main CI 通過後重新觸發 CD，不跳過 gate。
