### PR TITLE
release: onboarding and classroom TA hotfix

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -1,7 +1,6 @@
 """
 Serializers for user authentication and profile management.
 """
-from datetime import timedelta
 from urllib.parse import urlparse
 
 from rest_framework import serializers
@@ -314,12 +313,6 @@ class UserPreferencesUpdateSerializer(serializers.Serializer):
         if not parsed.netloc:
             raise serializers.ValidationError("頭像連結格式無效")
         return value
-
-    def validate_onboarding_completed_at(self, value):
-        if value and value > timezone.now() + timedelta(seconds=60):
-            raise serializers.ValidationError("完成時間不能晚於現在")
-        return value
-
 
 class UserLoginRecordSerializer(serializers.ModelSerializer):
     """Read-only serializer for login history entries."""

--- a/backend/apps/users/tests/test_preferences.py
+++ b/backend/apps/users/tests/test_preferences.py
@@ -215,7 +215,7 @@ class UserPreferencesViewTestCase(TestCase):
         profile = UserProfile.objects.get(user=self.user)
         self.assertIsNotNone(profile.onboarding_completed_at)
 
-    def test_patch_onboarding_completed_at_rejects_future_time(self):
+    def test_patch_onboarding_completed_at_uses_server_time_when_client_clock_is_ahead(self):
         self.client.force_authenticate(user=self.user)
         future_time = (timezone.now() + timedelta(minutes=5)).isoformat()
 
@@ -225,7 +225,14 @@ class UserPreferencesViewTestCase(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        profile = UserProfile.objects.get(user=self.user)
+        self.assertIsNotNone(profile.onboarding_completed_at)
+        self.assertLess(
+            abs((profile.onboarding_completed_at - timezone.now()).total_seconds()),
+            5,
+        )
 
     # ── Incident 2026-04-07 regression tests ──────────────────────────
 
@@ -271,30 +278,6 @@ class UserPreferencesViewTestCase(TestCase):
         self.assertIsNotNone(profile.onboarding_completed_at)
         diff = abs((profile.onboarding_completed_at - timezone.now()).total_seconds())
         self.assertLess(diff, 5, "Server should set onboarding time to ~now()")
-
-    def test_onboarding_completed_at_future_within_buffer(self):
-        """A timestamp within 60s buffer should be accepted."""
-        self.client.force_authenticate(user=self.user)
-        near_future = (timezone.now() + timedelta(seconds=30)).isoformat()
-
-        response = self.client.patch(
-            self.url,
-            {"onboarding_completed_at": near_future},
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_onboarding_completed_at_future_beyond_buffer(self):
-        """A timestamp >60s in the future should be rejected."""
-        self.client.force_authenticate(user=self.user)
-        far_future = (timezone.now() + timedelta(minutes=2)).isoformat()
-
-        response = self.client.patch(
-            self.url,
-            {"onboarding_completed_at": far_future},
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_preferences_response_shape(self):
         """GET response must contain all expected fields with correct types."""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import {
   RequireAuth,
   RequireGuest,
   RequireAdmin,
+  RequireClassroomManager,
   RequireTeacherOrAdmin,
   RequirePendingOnboarding,
   RequireCompletedOnboarding,
@@ -145,6 +146,17 @@ function App() {
                             {/* Classroom Exam Precheck - Classroom-scoped */}
                             {classroomExamPrecheckRoute}
                             {classroomContestAttendanceScanRoute}
+
+                            {/* Classroom management follows classroom membership, not platform role. */}
+                            <Route element={<RequireClassroomManager />}>
+                              <Route element={<MainLayout />}>
+                                {classroomContestAdminRoute}
+                              </Route>
+                              {classroomContestAttendanceProjectionRoute}
+                              <Route element={<ExamPreviewLayout />}>
+                                {classroomExamPreviewRoute}
+                              </Route>
+                            </Route>
                           </Route>
 
                         </Route>
@@ -154,8 +166,6 @@ function App() {
                           <Route element={<RequireCompletedOnboarding />}>
                             <Route element={<MainLayout />}>
                               {questionBankDetailRoute}
-                              {/* Classroom Contest Admin - Classroom-scoped, inside shared workspace shell */}
-                              {classroomContestAdminRoute}
                               <Route
                                 path="/chat"
                                 element={
@@ -165,13 +175,6 @@ function App() {
                                 }
                               />
                             </Route>
-
-                            {/* Classroom Exam Preview - Classroom-scoped */}
-                            {classroomContestAttendanceProjectionRoute}
-                            <Route element={<ExamPreviewLayout />}>
-                              {classroomExamPreviewRoute}
-                            </Route>
-
                           </Route>
                         </Route>
 

--- a/frontend/src/features/auth/components/RouteGuards.test.tsx
+++ b/frontend/src/features/auth/components/RouteGuards.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getClassroom } from "@/infrastructure/api/repositories/classroom.repository";
+import { RequireClassroomManager } from "./RouteGuards";
+
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: 7, username: "ta", role: "student" },
+    loading: false,
+  }),
+}));
+
+vi.mock("@/infrastructure/api/repositories/classroom.repository", () => ({
+  getClassroom: vi.fn(),
+}));
+
+describe("RequireClassroomManager", () => {
+  beforeEach(() => {
+    vi.mocked(getClassroom).mockReset();
+  });
+
+  it("allows a classroom TA even when their platform role is student", async () => {
+    vi.mocked(getClassroom).mockResolvedValue({
+      currentUserRole: "manager",
+    } as Awaited<ReturnType<typeof getClassroom>>);
+
+    render(
+      <MemoryRouter initialEntries={["/classrooms/classroom-1/contest/contest-1/admin"]}>
+        <Routes>
+          <Route element={<RequireClassroomManager />}>
+            <Route
+              path="/classrooms/:classroomId/contest/:contestId/admin"
+              element={<div>contest admin</div>}
+            />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("contest admin")).toBeInTheDocument();
+    expect(getClassroom).toHaveBeenCalledWith("classroom-1");
+  });
+
+  it("redirects an ordinary classroom member to the contest", async () => {
+    vi.mocked(getClassroom).mockResolvedValue({
+      currentUserRole: "member",
+    } as Awaited<ReturnType<typeof getClassroom>>);
+
+    render(
+      <MemoryRouter initialEntries={["/classrooms/classroom-1/contest/contest-1/admin"]}>
+        <Routes>
+          <Route element={<RequireClassroomManager />}>
+            <Route
+              path="/classrooms/:classroomId/contest/:contestId/admin"
+              element={<div>contest admin</div>}
+            />
+          </Route>
+          <Route
+            path="/classrooms/:classroomId/contest/:contestId"
+            element={<div>contest dashboard</div>}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("contest dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("contest admin")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/auth/components/RouteGuards.tsx
+++ b/frontend/src/features/auth/components/RouteGuards.tsx
@@ -1,6 +1,8 @@
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Navigate, Outlet, useLocation, useParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import PageLoading from '@/shared/ui/PageLoading';
+import { getClassroom } from '@/infrastructure/api/repositories/classroom.repository';
 import { getAuthedLandingPath, hasCompletedOnboarding } from "../utils/onboarding";
 
 export const RequireAuth = () => {
@@ -96,4 +98,47 @@ export const RequireTeacherOrAdmin = () => {
   }
 
   return <Outlet />;
+};
+
+export const RequireClassroomManager = () => {
+  const { classroomId, contestId } = useParams<{
+    classroomId: string;
+    contestId?: string;
+  }>();
+  const [canManage, setCanManage] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setCanManage(null);
+
+    if (!classroomId) {
+      setCanManage(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    void getClassroom(classroomId).then((classroom) => {
+      if (!active) return;
+      setCanManage(
+        classroom?.currentUserRole === 'platform_admin' ||
+        classroom?.currentUserRole === 'owner' ||
+        classroom?.currentUserRole === 'manager',
+      );
+    }).catch(() => {
+      if (active) setCanManage(false);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [classroomId]);
+
+  if (canManage === null) return <PageLoading fullScreen />;
+  if (canManage) return <Outlet />;
+
+  const fallback = classroomId && contestId
+    ? `/classrooms/${classroomId}/contest/${contestId}`
+    : '/dashboard';
+  return <Navigate to={fallback} replace />;
 };


### PR DESCRIPTION
## Summary\n- fix onboarding failures caused by client clock skew\n- allow classroom TAs to access classroom-scoped contest administration\n- retain classroom-scope authorization for ordinary members\n\n## Validation\n- dev PR #232 passed all 7 CI jobs\n- backend users suite: 130 passed locally\n- frontend auth/admin tests: 36 passed locally\n- frontend typecheck, lint, and production build passed locally